### PR TITLE
Don't fail if embedding model in response is unknown.

### DIFF
--- a/core/src/main/scala/sttp/openai/requests/embeddings/EmbeddingsRequestBody.scala
+++ b/core/src/main/scala/sttp/openai/requests/embeddings/EmbeddingsRequestBody.scala
@@ -30,7 +30,7 @@ object EmbeddingsRequestBody {
         jsonValue =>
           SnakePickle.read[ujson.Value](jsonValue) match {
             case Str(value) =>
-              byEmbeddingsModelValue.getOrElse(value, throw DeserializationOpenAIException(new Exception(s"Could not deserialize: $value")))
+              byEmbeddingsModelValue.getOrElse(value, CustomEmbeddingsModel(value))
             case e => throw DeserializationOpenAIException(new Exception(s"Could not deserialize: $e"))
           }
       )


### PR DESCRIPTION
Instead, parse into CustomEmbeddingsModel.

Fixes #99 