### PR TITLE
Update sttp to 4.0.0-M6

### DIFF
--- a/core/src/main/scala/sttp/openai/OpenAI.scala
+++ b/core/src/main/scala/sttp/openai/OpenAI.scala
@@ -3,7 +3,7 @@ package sttp.openai
 import sttp.client4._
 import sttp.model.Uri
 import sttp.openai.OpenAIExceptions.OpenAIException
-import sttp.openai.json.SttpUpickleApiExtension.{asJsonSnake, asStringEither, upickleBodySerializer}
+import sttp.openai.json.SttpOpenAIApi.{asJsonSnake, asStringEither, upickleBodySerializer}
 import sttp.openai.requests.completions.CompletionsRequestBody.CompletionsBody
 import sttp.openai.requests.completions.CompletionsResponseData.CompletionsResponse
 import sttp.openai.requests.completions.chat.ChatRequestBody.ChatBody

--- a/core/src/main/scala/sttp/openai/OpenAI.scala
+++ b/core/src/main/scala/sttp/openai/OpenAI.scala
@@ -3,7 +3,7 @@ package sttp.openai
 import sttp.client4._
 import sttp.model.Uri
 import sttp.openai.OpenAIExceptions.OpenAIException
-import sttp.openai.json.SttpUpickleApiExtension.{asJsonSnake, asStringEither, upickleBodySerializerSnake}
+import sttp.openai.json.SttpUpickleApiExtension.{asJsonSnake, asStringEither, upickleBodySerializer}
 import sttp.openai.requests.completions.CompletionsRequestBody.CompletionsBody
 import sttp.openai.requests.completions.CompletionsResponseData.CompletionsResponse
 import sttp.openai.requests.completions.chat.ChatRequestBody.ChatBody

--- a/core/src/main/scala/sttp/openai/json/SnakePickle.scala
+++ b/core/src/main/scala/sttp/openai/json/SnakePickle.scala
@@ -1,12 +1,5 @@
 package sttp.openai.json
 
-import sttp.client4.json._
-import sttp.client4.upicklejson.SttpUpickleApi
-import sttp.client4._
-import sttp.model.ResponseMetadata
-import sttp.openai.OpenAIExceptions.OpenAIException
-import sttp.openai.OpenAIExceptions.OpenAIException._
-
 /** An object that transforms all snake_case keys into camelCase [[https://com-lihaoyi.github.io/upickle/#CustomConfiguration]] */
 object SnakePickle extends upickle.AttributeTagged {
   private def camelToSnake(s: String): String =
@@ -40,63 +33,4 @@ object SnakePickle extends upickle.AttributeTagged {
     new Reader.Delegate[Any, Option[T]](implicitly[SnakePickle.Reader[T]].map(Some(_))) {
       override def visitNull(index: Int) = None
     }
-}
-
-/** An sttp upickle api extension that deserializes JSON with snake_case keys into case classes with fields corresponding to keys in
-  * camelCase and maps errors to OpenAIException subclasses.
-  */
-object SttpUpickleApiExtension extends SttpUpickleApi {
-  override val upickleApi: SnakePickle.type = SnakePickle
-
-  def asJsonSnake[B: upickleApi.Reader: IsOption]: ResponseAs[Either[OpenAIException, B]] =
-    asString.mapWithMetadata(deserializeRightWithMappedExceptions(deserializeJsonSnake)).showAsJson
-
-  private def deserializeRightWithMappedExceptions[T](
-      doDeserialize: String => Either[DeserializationOpenAIException, T]
-  ): (Either[String, String], ResponseMetadata) => Either[OpenAIException, T] = {
-    case (Left(body), meta) =>
-      Left(httpToOpenAIError(HttpError(body, meta.code)))
-    case (Right(body), _) => doDeserialize.apply(body)
-  }
-
-  def deserializeJsonSnake[B: upickleApi.Reader: IsOption]: String => Either[DeserializationOpenAIException, B] = { (s: String) =>
-    try
-      Right(upickleApi.read[B](JsonInput.sanitize[B].apply(s)))
-    catch {
-      case e: Exception => Left(DeserializationOpenAIException(e))
-      case t: Throwable =>
-        // in ScalaJS, ArrayIndexOutOfBoundsException exceptions are wrapped in org.scalajs.linker.runtime.UndefinedBehaviorError
-        t.getCause match {
-          case e: ArrayIndexOutOfBoundsException => Left(DeserializationOpenAIException(e))
-          case _                                 => throw t
-        }
-    }
-  }
-
-  def asStringEither: ResponseAs[Either[OpenAIException, String]] =
-    asStringAlways
-      .mapWithMetadata { (string, metadata) =>
-        if (metadata.isSuccess) Right(string) else Left(httpToOpenAIError(HttpError(string, metadata.code)))
-      }
-      .showAs("either(as error, as string)")
-
-  private def httpToOpenAIError(he: HttpError[String]): OpenAIException = {
-    import sttp.model.StatusCode._
-    val errorMessageBody = upickleApi.read[ujson.Value](he.body).apply("error")
-    val error = upickleApi.read[Error](errorMessageBody)
-    import error._
-    he.statusCode match {
-      case TooManyRequests                              => new RateLimitException(message, `type`, param, code, he)
-      case BadRequest | NotFound | UnsupportedMediaType => new InvalidRequestException(message, `type`, param, code, he)
-      case Unauthorized                                 => new AuthenticationException(message, `type`, param, code, he)
-      case Forbidden                                    => new PermissionException(message, `type`, param, code, he)
-      case Conflict                                     => new TryAgain(message, `type`, param, code, he)
-      case ServiceUnavailable                           => new ServiceUnavailableException(message, `type`, param, code, he)
-      case _                                            => new APIException(message, `type`, param, code, he)
-    }
-  }
-  private case class Error(message: Option[String], `type`: Option[String], param: Option[String], code: Option[String])
-  private object Error {
-    implicit val errorR: upickleApi.Reader[Error] = upickleApi.macroR
-  }
 }

--- a/core/src/main/scala/sttp/openai/json/SttpOpenAIApi.scala
+++ b/core/src/main/scala/sttp/openai/json/SttpOpenAIApi.scala
@@ -1,0 +1,69 @@
+package sttp.openai.json
+
+import sttp.client4.json._
+import sttp.client4.upicklejson.SttpUpickleApi
+import sttp.client4._
+import sttp.model.StatusCode._
+import sttp.model.ResponseMetadata
+import sttp.openai.OpenAIExceptions.OpenAIException
+import sttp.openai.OpenAIExceptions.OpenAIException._
+
+/** An sttp upickle api extension that deserializes JSON with snake_case keys into case classes with fields corresponding to keys in
+  * camelCase and maps errors to OpenAIException subclasses.
+  */
+object SttpOpenAIApi extends SttpUpickleApi {
+  override val upickleApi: SnakePickle.type = SnakePickle
+
+  def asJsonSnake[B: upickleApi.Reader: IsOption]: ResponseAs[Either[OpenAIException, B]] =
+    asString.mapWithMetadata(deserializeRightWithMappedExceptions(deserializeJsonSnake)).showAsJson
+
+  private def deserializeRightWithMappedExceptions[T](
+      doDeserialize: String => Either[DeserializationOpenAIException, T]
+  ): (Either[String, String], ResponseMetadata) => Either[OpenAIException, T] = {
+    case (Left(body), meta) =>
+      Left(httpToOpenAIError(HttpError(body, meta.code)))
+    case (Right(body), _) => doDeserialize.apply(body)
+  }
+
+  def deserializeJsonSnake[B: upickleApi.Reader: IsOption]: String => Either[DeserializationOpenAIException, B] = { (s: String) =>
+    try
+      Right(upickleApi.read[B](JsonInput.sanitize[B].apply(s)))
+    catch {
+      case e: Exception => Left(DeserializationOpenAIException(e))
+      case t: Throwable =>
+        // in ScalaJS, ArrayIndexOutOfBoundsException exceptions are wrapped in org.scalajs.linker.runtime.UndefinedBehaviorError
+        t.getCause match {
+          case e: ArrayIndexOutOfBoundsException => Left(DeserializationOpenAIException(e))
+          case _                                 => throw t
+        }
+    }
+  }
+
+  def asStringEither: ResponseAs[Either[OpenAIException, String]] =
+    asStringAlways
+      .mapWithMetadata { (string, metadata) =>
+        if (metadata.isSuccess) Right(string) else Left(httpToOpenAIError(HttpError(string, metadata.code)))
+      }
+      .showAs("either(as error, as string)")
+
+  private def httpToOpenAIError(he: HttpError[String]): OpenAIException = {
+    val errorMessageBody = upickleApi.read[ujson.Value](he.body).apply("error")
+    val error = upickleApi.read[Error](errorMessageBody)
+    import error._
+
+    he.statusCode match {
+      case TooManyRequests                              => new RateLimitException(message, `type`, param, code, he)
+      case BadRequest | NotFound | UnsupportedMediaType => new InvalidRequestException(message, `type`, param, code, he)
+      case Unauthorized                                 => new AuthenticationException(message, `type`, param, code, he)
+      case Forbidden                                    => new PermissionException(message, `type`, param, code, he)
+      case Conflict                                     => new TryAgain(message, `type`, param, code, he)
+      case ServiceUnavailable                           => new ServiceUnavailableException(message, `type`, param, code, he)
+      case _                                            => new APIException(message, `type`, param, code, he)
+    }
+  }
+
+  private case class Error(message: Option[String], `type`: Option[String], param: Option[String], code: Option[String])
+  private object Error {
+    implicit val errorR: upickleApi.Reader[Error] = upickleApi.macroR
+  }
+}

--- a/core/src/test/scala/sttp/openai/requests/audio/AudioCreationDataSpec.scala
+++ b/core/src/test/scala/sttp/openai/requests/audio/AudioCreationDataSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.openai.fixtures
-import sttp.openai.json.SttpUpickleApiExtension
+import sttp.openai.json.SttpOpenAIApi
 
 class AudioCreationDataSpec extends AnyFlatSpec with Matchers with EitherValues {
   "Given audio generation response as Json" should "be properly deserialized to case class" in {
@@ -19,7 +19,7 @@ class AudioCreationDataSpec extends AnyFlatSpec with Matchers with EitherValues 
     )
 
     // when
-    val deserializedJsonResponse = SttpUpickleApiExtension.deserializeJsonSnake.apply(jsonResponse)
+    val deserializedJsonResponse = SttpOpenAIApi.deserializeJsonSnake.apply(jsonResponse)
 
     // then
     deserializedJsonResponse.value shouldBe expectedResponse

--- a/core/src/test/scala/sttp/openai/requests/completions/CompletionsDataSpec.scala
+++ b/core/src/test/scala/sttp/openai/requests/completions/CompletionsDataSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.openai.fixtures
-import sttp.openai.json.{SnakePickle, SttpUpickleApiExtension}
+import sttp.openai.json.{SnakePickle, SttpOpenAIApi}
 import sttp.openai.requests.completions.Stop.SingleStop
 
 class CompletionsDataSpec extends AnyFlatSpec with Matchers with EitherValues {
@@ -36,7 +36,7 @@ class CompletionsDataSpec extends AnyFlatSpec with Matchers with EitherValues {
     )
 
     // when
-    val givenResponse: Either[Exception, CompletionsResponse] = SttpUpickleApiExtension.deserializeJsonSnake.apply(jsonResponse)
+    val givenResponse: Either[Exception, CompletionsResponse] = SttpOpenAIApi.deserializeJsonSnake.apply(jsonResponse)
 
     // then
     givenResponse.value shouldBe expectedResponse
@@ -102,7 +102,7 @@ class CompletionsDataSpec extends AnyFlatSpec with Matchers with EitherValues {
     )
 
     // when
-    val givenResponse: Either[Exception, CompletionsResponse] = SttpUpickleApiExtension.deserializeJsonSnake.apply(jsonResponse)
+    val givenResponse: Either[Exception, CompletionsResponse] = SttpOpenAIApi.deserializeJsonSnake.apply(jsonResponse)
 
     // then
     givenResponse.value shouldBe expectedResponse

--- a/core/src/test/scala/sttp/openai/requests/completions/EditDataSpec.scala
+++ b/core/src/test/scala/sttp/openai/requests/completions/EditDataSpec.scala
@@ -4,7 +4,7 @@ import sttp.openai.fixtures
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import sttp.openai.json.{SnakePickle, SttpUpickleApiExtension}
+import sttp.openai.json.{SnakePickle, SttpOpenAIApi}
 import sttp.openai.requests.completions.edit.EditRequestBody._
 import sttp.openai.requests.completions.edit.EditRequestBody.EditModel.TextDavinciEdit001
 
@@ -36,7 +36,7 @@ class EditDataSpec extends AnyFlatSpec with Matchers with EitherValues {
     )
 
     // when
-    val givenResponse: Either[Exception, EditResponse] = SttpUpickleApiExtension.deserializeJsonSnake.apply(jsonResponse)
+    val givenResponse: Either[Exception, EditResponse] = SttpOpenAIApi.deserializeJsonSnake.apply(jsonResponse)
 
     // then
     givenResponse.value shouldBe expectedResponse

--- a/core/src/test/scala/sttp/openai/requests/completions/chat/ChatDataSpec.scala
+++ b/core/src/test/scala/sttp/openai/requests/completions/chat/ChatDataSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.openai.fixtures
-import sttp.openai.json.{SnakePickle, SttpUpickleApiExtension}
+import sttp.openai.json.{SnakePickle, SttpOpenAIApi}
 import sttp.openai.requests.completions.Usage
 import sttp.openai.requests.completions.Stop.SingleStop
 import sttp.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
@@ -46,7 +46,7 @@ class ChatDataSpec extends AnyFlatSpec with Matchers with EitherValues {
     )
 
     // when
-    val givenResponse: Either[Exception, ChatResponse] = SttpUpickleApiExtension.deserializeJsonSnake.apply(jsonResponse)
+    val givenResponse: Either[Exception, ChatResponse] = SttpOpenAIApi.deserializeJsonSnake.apply(jsonResponse)
 
     // then
     givenResponse.value shouldBe expectedResponse

--- a/core/src/test/scala/sttp/openai/requests/embeddings/EmbeddingsDataSpec.scala
+++ b/core/src/test/scala/sttp/openai/requests/embeddings/EmbeddingsDataSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.openai.fixtures
-import sttp.openai.json.SttpUpickleApiExtension
+import sttp.openai.json.SttpOpenAIApi
 import EmbeddingsResponseBody._
 import sttp.openai.requests.embeddings.EmbeddingsRequestBody.EmbeddingsModel
 
@@ -31,7 +31,7 @@ class EmbeddingsDataSpec extends AnyFlatSpec with Matchers with EitherValues {
     )
     // when
     val givenResponse: Either[Exception, EmbeddingResponse] =
-      SttpUpickleApiExtension.deserializeJsonSnake[EmbeddingResponse].apply(listFilesResponse)
+      SttpOpenAIApi.deserializeJsonSnake[EmbeddingResponse].apply(listFilesResponse)
 
     // then
     givenResponse.value shouldBe expectedResponse

--- a/core/src/test/scala/sttp/openai/requests/files/FilesResponseDataSpec.scala
+++ b/core/src/test/scala/sttp/openai/requests/files/FilesResponseDataSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.openai.fixtures
-import sttp.openai.json.SttpUpickleApiExtension
+import sttp.openai.json.SttpOpenAIApi
 import sttp.openai.requests.files.FilesResponseData.{DeletedFileData, FileData, FilesResponse}
 import sttp.openai.requests.files.FilesResponseData.FilesResponse._
 
@@ -29,7 +29,7 @@ class FilesResponseDataSpec extends AnyFlatSpec with Matchers with EitherValues 
     )
 
     // when
-    val givenResponse: Either[Exception, FilesResponse] = SttpUpickleApiExtension.deserializeJsonSnake.apply(listFilesResponse)
+    val givenResponse: Either[Exception, FilesResponse] = SttpOpenAIApi.deserializeJsonSnake.apply(listFilesResponse)
 
     // then
     givenResponse.value shouldBe expectedResponse
@@ -51,7 +51,7 @@ class FilesResponseDataSpec extends AnyFlatSpec with Matchers with EitherValues 
       )
 
     // when
-    val givenResponse: Either[Exception, FileData] = SttpUpickleApiExtension.deserializeJsonSnake[FileData].apply(singleFileJsonResponse)
+    val givenResponse: Either[Exception, FileData] = SttpOpenAIApi.deserializeJsonSnake[FileData].apply(singleFileJsonResponse)
 
     // then
     givenResponse.value shouldBe expectedResponse
@@ -68,7 +68,7 @@ class FilesResponseDataSpec extends AnyFlatSpec with Matchers with EitherValues 
 
     // when
     val givenResponse: Either[Exception, DeletedFileData] =
-      SttpUpickleApiExtension.deserializeJsonSnake[DeletedFileData].apply(listFilesResponse)
+      SttpOpenAIApi.deserializeJsonSnake[DeletedFileData].apply(listFilesResponse)
 
     // then
     givenResponse.value shouldBe expectedResponse
@@ -89,7 +89,7 @@ class FilesResponseDataSpec extends AnyFlatSpec with Matchers with EitherValues 
     )
 
     // when
-    val givenResponse: Either[Exception, FileData] = SttpUpickleApiExtension.deserializeJsonSnake[FileData].apply(retrieveFileJsonResponse)
+    val givenResponse: Either[Exception, FileData] = SttpOpenAIApi.deserializeJsonSnake[FileData].apply(retrieveFileJsonResponse)
 
     // then
     givenResponse.value shouldBe expectedResponse

--- a/core/src/test/scala/sttp/openai/requests/finetunes/FineTunesDataSpec.scala
+++ b/core/src/test/scala/sttp/openai/requests/finetunes/FineTunesDataSpec.scala
@@ -3,7 +3,7 @@ package sttp.openai.requests.finetunes
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import sttp.openai.json.{SnakePickle, SttpUpickleApiExtension}
+import sttp.openai.json.{SnakePickle, SttpOpenAIApi}
 import sttp.openai.fixtures
 import sttp.openai.requests.files.FilesResponseData.FileData
 import sttp.openai.requests.finetunes.FineTunesResponseData._
@@ -56,7 +56,7 @@ class FineTunesDataSpec extends AnyFlatSpec with Matchers with EitherValues {
 
     // when
     val deserializedJsonResponse: Either[Exception, FineTuneResponse] =
-      SttpUpickleApiExtension.deserializeJsonSnake[FineTuneResponse].apply(jsonResponse)
+      SttpOpenAIApi.deserializeJsonSnake[FineTuneResponse].apply(jsonResponse)
 
     // then
     deserializedJsonResponse.value shouldBe expectedResponse
@@ -140,7 +140,7 @@ class FineTunesDataSpec extends AnyFlatSpec with Matchers with EitherValues {
 
     // when
     val deserializedJsonResponse: Either[Exception, GetFineTunesResponse] =
-      SttpUpickleApiExtension.deserializeJsonSnake[GetFineTunesResponse].apply(jsonResponse)
+      SttpOpenAIApi.deserializeJsonSnake[GetFineTunesResponse].apply(jsonResponse)
 
     // then
     deserializedJsonResponse.value shouldBe expectedResponse
@@ -264,7 +264,7 @@ class FineTunesDataSpec extends AnyFlatSpec with Matchers with EitherValues {
 
     // when
     val deserializedJsonResponse: Either[Exception, FineTuneResponse] =
-      SttpUpickleApiExtension.deserializeJsonSnake[FineTuneResponse].apply(jsonResponse)
+      SttpOpenAIApi.deserializeJsonSnake[FineTuneResponse].apply(jsonResponse)
 
     // then
     deserializedJsonResponse.value shouldBe expectedResponse
@@ -281,7 +281,7 @@ class FineTunesDataSpec extends AnyFlatSpec with Matchers with EitherValues {
     )
     // when
     val deserializedJsonResponse: Either[Exception, DeleteFineTuneModelResponse] =
-      SttpUpickleApiExtension.deserializeJsonSnake[DeleteFineTuneModelResponse].apply(jsonResponse)
+      SttpOpenAIApi.deserializeJsonSnake[DeleteFineTuneModelResponse].apply(jsonResponse)
 
     // then
     deserializedJsonResponse.value shouldBe expectedResponse
@@ -365,7 +365,7 @@ class FineTunesDataSpec extends AnyFlatSpec with Matchers with EitherValues {
 
     // when
     val deserializedJsonResponse: Either[Exception, FineTuneEventsResponse] =
-      SttpUpickleApiExtension.deserializeJsonSnake[FineTuneEventsResponse].apply(jsonResponse)
+      SttpOpenAIApi.deserializeJsonSnake[FineTuneEventsResponse].apply(jsonResponse)
 
     // then
     deserializedJsonResponse.value shouldBe expectedResponse
@@ -411,7 +411,7 @@ class FineTunesDataSpec extends AnyFlatSpec with Matchers with EitherValues {
 
     // when
     val deserializedJsonResponse: Either[Exception, FineTuneResponse] =
-      SttpUpickleApiExtension.deserializeJsonSnake[FineTuneResponse].apply(jsonResponse)
+      SttpOpenAIApi.deserializeJsonSnake[FineTuneResponse].apply(jsonResponse)
 
     // then
     deserializedJsonResponse.value shouldBe expectedResponse

--- a/core/src/test/scala/sttp/openai/requests/images/creation/ImageCreationDataSpec.scala
+++ b/core/src/test/scala/sttp/openai/requests/images/creation/ImageCreationDataSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.openai.fixtures
-import sttp.openai.json.{SnakePickle, SttpUpickleApiExtension}
+import sttp.openai.json.{SnakePickle, SttpOpenAIApi}
 import sttp.openai.requests.images.{ResponseFormat, Size}
 class ImageCreationDataSpec extends AnyFlatSpec with Matchers with EitherValues {
 
@@ -24,7 +24,7 @@ class ImageCreationDataSpec extends AnyFlatSpec with Matchers with EitherValues 
       data = generatedImageData
     )
     // when
-    val givenResponse = SttpUpickleApiExtension.deserializeJsonSnake.apply(jsonResponse)
+    val givenResponse = SttpOpenAIApi.deserializeJsonSnake.apply(jsonResponse)
 
     // then
     givenResponse.value shouldBe expectedResponse

--- a/core/src/test/scala/sttp/openai/requests/models/ModelsGetResponseDataSpec.scala
+++ b/core/src/test/scala/sttp/openai/requests/models/ModelsGetResponseDataSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import ModelsResponseData.{ModelData, ModelPermission, ModelsResponse}
 import ModelsResponseData.ModelsResponse._
 import sttp.openai.fixtures
-import sttp.openai.json.SttpUpickleApiExtension
+import sttp.openai.json.SttpOpenAIApi
 
 class ModelsGetResponseDataSpec extends AnyFlatSpec with Matchers with EitherValues {
 
@@ -74,7 +74,7 @@ class ModelsGetResponseDataSpec extends AnyFlatSpec with Matchers with EitherVal
     val expectedResponse: ModelsResponse = ModelsResponse(`object` = "list", data = serializedData)
     // when
 
-    val givenResponse: Either[Exception, ModelsResponse] = SttpUpickleApiExtension.deserializeJsonSnake.apply(response)
+    val givenResponse: Either[Exception, ModelsResponse] = SttpOpenAIApi.deserializeJsonSnake.apply(response)
 
     // then
     givenResponse.value shouldBe expectedResponse

--- a/core/src/test/scala/sttp/openai/requests/moderations/ModerationsDataSpec.scala
+++ b/core/src/test/scala/sttp/openai/requests/moderations/ModerationsDataSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.openai.fixtures
-import sttp.openai.json.SttpUpickleApiExtension
+import sttp.openai.json.SttpOpenAIApi
 import sttp.openai.requests.moderations.ModerationsRequestBody.ModerationModel
 import sttp.openai.requests.moderations.ModerationsResponseData._
 
@@ -41,7 +41,7 @@ class ModerationsDataSpec extends AnyFlatSpec with Matchers with EitherValues {
     )
     // when
     val givenResponse: Either[Exception, ModerationData] =
-      SttpUpickleApiExtension.deserializeJsonSnake[ModerationData].apply(listFilesResponse)
+      SttpOpenAIApi.deserializeJsonSnake[ModerationData].apply(listFilesResponse)
 
     // then
     givenResponse.value shouldBe expectedResponse

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   object V {
     val scalaTest = "3.2.17"
-    val sttpClient = "4.0.0-M4"
+    val sttpClient = "4.0.0-M6"
     val uPickle = "3.1.3"
   }
 


### PR DESCRIPTION
This PR updates the sttp library to version 4.0.0-M6 and incorporates the latest changes. Additionally, it enhances code readability by extracting and renaming the `SttpUpickleApiExtension` to `SttpOpenAIApi` for improved organization.