### PR TITLE
Add Pekko streaming support for chat completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,18 +140,14 @@ object Main extends IOApp {
 ```
 
 #### Create completion with streaming:
-The Chat Completion API features streaming support via server-sent events. Currently, we only support streaming using `Fs2` and `ZIO` 
 
-To use `Fs2` add the following import:
+To enable streaming support for the Chat Completion API using server-sent events, you must include the appropriate
+dependency for your chosen streaming library. We provide support for the following libraries: _Fs2_, _ZIO_, _Pekko Streams_
+
+For example, to use `Fs2` add the following import:
 
 ```scala
 import sttp.openai.streaming.fs2._
-```
-
-To use `ZIO` add the following import:
-
-```scala
-import sttp.openai.streaming.zio._
 ```
 
 Example below uses `HttpClientFs2Backend` as a backend.

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ lazy val root = (project in file("."))
 lazy val allAgregates = core.projectRefs ++
   fs2.projectRefs ++
   zio.projectRefs ++
+  pekko.projectRefs ++
   docs.projectRefs
 
 lazy val core = (projectMatrix in file("core"))

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,16 @@ lazy val zio = (projectMatrix in file("streaming/zio"))
   )
   .dependsOn(core % "compile->compile;test->test")
 
+lazy val pekko = (projectMatrix in file("streaming/pekko"))
+  .jvmPlatform(
+    scalaVersions = scala2 ++ scala3
+  )
+  .settings(commonSettings)
+  .settings(
+    libraryDependencies ++= Libraries.sttpClientPekko
+  )
+  .dependsOn(core % "compile->compile;test->test")
+
 val compileDocs: TaskKey[Unit] = taskKey[Unit]("Compiles docs module throwing away its output")
 compileDocs := {
   (docs.jvm(scala2.head) / mdoc).toTask(" --out target/sttp-openai-docs").value

--- a/core/src/main/scala/sttp/openai/requests/completions/chat/ChatChunkRequestResponseData.scala
+++ b/core/src/main/scala/sttp/openai/requests/completions/chat/ChatChunkRequestResponseData.scala
@@ -1,6 +1,7 @@
 package sttp.openai.requests.completions.chat
 
 import sttp.openai.json.SnakePickle
+import sttp.model.sse.ServerSentEvent
 
 object ChatChunkRequestResponseData {
 
@@ -37,6 +38,7 @@ object ChatChunkRequestResponseData {
 
   object ChatChunkResponse {
     val DoneEventMessage = "[DONE]"
+    val DoneEvent = ServerSentEvent(Some(DoneEventMessage))
 
     implicit val chunkChatR: SnakePickle.Reader[ChatChunkResponse] = SnakePickle.macroR[ChatChunkResponse]
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,7 @@ object Dependencies {
     val scalaTestCats = "1.5.0"
 
     val sttpClient = "4.0.0-M6"
+    val pekko = "1.0.1"
     val uPickle = "3.1.3"
   }
 
@@ -25,6 +26,11 @@ object Dependencies {
     )
 
     val sttpClientZio = "com.softwaremill.sttp.client4" %% "zio" % V.sttpClient
+
+    val sttpClientPekko = Seq(
+      "com.softwaremill.sttp.client4" %% "pekko-http-backend" % V.sttpClient,
+      "org.apache.pekko" %% "pekko-stream" % V.pekko
+    )
 
     val uPickle = "com.lihaoyi" %% "upickle" % V.uPickle
 

--- a/streaming/fs2/src/main/scala/sttp/openai/streaming/fs2/package.scala
+++ b/streaming/fs2/src/main/scala/sttp/openai/streaming/fs2/package.scala
@@ -12,7 +12,7 @@ import sttp.openai.requests.completions.chat.ChatChunkRequestResponseData.ChatCh
 import sttp.openai.requests.completions.chat.ChatRequestBody.ChatBody
 
 package object fs2 {
-  import ChatChunkResponse.DoneEventMessage
+  import ChatChunkResponse.DoneEvent
 
   implicit class extension(val client: OpenAI) {
 
@@ -41,8 +41,8 @@ package object fs2 {
     )
 
   private def deserializeEvent[F[_]]: Pipe[F, ServerSentEvent, Either[OpenAIException, ChatChunkResponse]] =
-    _.collect {
-      case ServerSentEvent(Some(data), _, _, _) if data != DoneEventMessage =>
+    _.takeWhile(_ != DoneEvent)
+      .collect { case ServerSentEvent(Some(data), _, _, _) =>
         deserializeJsonSnake[ChatChunkResponse].apply(data)
-    }
+      }
 }

--- a/streaming/fs2/src/test/scala/sttp/openai/streaming/fs2/Fs2ClientSpec.scala
+++ b/streaming/fs2/src/test/scala/sttp/openai/streaming/fs2/Fs2ClientSpec.scala
@@ -5,12 +5,12 @@ import org.scalatest.flatspec.AsyncFlatSpec
 import cats.effect.testing.scalatest.AsyncIOSpec
 import org.scalatest.matchers.should.Matchers
 import cats.effect.IO
-import fs2.{Stream, text}
-import sttp.client4.DeserializationException
+import fs2.{text, Stream}
 import sttp.client4.httpclient.fs2.HttpClientFs2Backend
 import sttp.client4.testing.RawStream
 import sttp.model.sse.ServerSentEvent
 import sttp.openai.OpenAI
+import sttp.openai.OpenAIExceptions.OpenAIException.DeserializationOpenAIException
 import sttp.openai.fixtures.ErrorFixture
 import sttp.openai.json.SnakePickle._
 import sttp.openai.requests.completions.chat.ChatChunkRequestResponseData.ChatChunkResponse
@@ -73,7 +73,7 @@ class Fs2ClientSpec extends AsyncFlatSpec with AsyncIOSpec with Matchers with Ei
       .flatMap(_.compile.drain)
 
     // then
-    response.attempt.asserting(_ shouldBe a[Left[DeserializationException[_], _]])
+    response.attempt.asserting(_ shouldBe a[Left[DeserializationOpenAIException, _]])
   }
 
   "Creating chat completions with successful response" should "return properly deserialized list of chunks" in {

--- a/streaming/pekko/src/main/scala/sttp/openai/streaming/pekko/package.scala
+++ b/streaming/pekko/src/main/scala/sttp/openai/streaming/pekko/package.scala
@@ -1,0 +1,51 @@
+package sttp.openai.streaming
+
+import org.apache.pekko.stream.scaladsl.{Flow, Source}
+import org.apache.pekko.util.ByteString
+import sttp.capabilities.pekko.PekkoStreams
+import sttp.client4.StreamRequest
+import sttp.model.sse.ServerSentEvent
+import sttp.openai.OpenAI
+import sttp.openai.OpenAIExceptions.OpenAIException
+import sttp.openai.json.SttpUpickleApiExtension.deserializeJsonSnake
+import sttp.openai.requests.completions.chat.ChatChunkRequestResponseData.ChatChunkResponse
+import sttp.openai.requests.completions.chat.ChatRequestBody.ChatBody
+import sttp.client4.pekkohttp.PekkoHttpServerSentEvents
+
+package object pekko {
+  import ChatChunkResponse.DoneEventMessage
+
+  implicit class extension(val client: OpenAI) {
+
+    /** Creates and streams a model response as chunk objects for the given chat conversation defined in chatBody.
+      *
+      * [[https://platform.openai.com/docs/api-reference/chat/create]]
+      *
+      * @param chatBody
+      *   Chat request body.
+      */
+    def createStreamedChatCompletion(
+        chatBody: ChatBody
+    ): StreamRequest[Either[OpenAIException, Source[ChatChunkResponse, Any]], PekkoStreams] =
+      client
+        .createChatCompletion(PekkoStreams, chatBody)
+        .mapResponse(mapEventToResponse)
+  }
+
+  private def mapEventToResponse(
+      response: Either[OpenAIException, Source[ByteString, Any]]
+  ): Either[OpenAIException, Source[ChatChunkResponse, Any]] =
+    response.map(
+      _.via(PekkoHttpServerSentEvents.parse)
+        .via(deserializeEvent)
+    )
+
+  private def deserializeEvent: Flow[ServerSentEvent, ChatChunkResponse, Any] =
+    Flow[ServerSentEvent].collect {
+      case ServerSentEvent(Some(data), _, _, _) if data != DoneEventMessage =>
+        deserializeJsonSnake[ChatChunkResponse].apply(data) match {
+          case Left(exception) => throw exception
+          case Right(value)    => value
+        }
+    }
+}

--- a/streaming/pekko/src/test/scala/sttp/openai/streaming/pekko/PekkoClientSpec.scala
+++ b/streaming/pekko/src/test/scala/sttp/openai/streaming/pekko/PekkoClientSpec.scala
@@ -1,0 +1,108 @@
+package sttp.openai.streaming.pekko
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl._
+import org.apache.pekko.util.ByteString
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.client4.pekkohttp.PekkoHttpBackend
+import sttp.client4.testing.RawStream
+import sttp.model.sse.ServerSentEvent
+import sttp.openai.OpenAI
+import sttp.openai.OpenAIExceptions.OpenAIException.DeserializationOpenAIException
+import sttp.openai.fixtures.ErrorFixture
+import sttp.openai.json.SnakePickle._
+import sttp.openai.requests.completions.chat.ChatChunkRequestResponseData.ChatChunkResponse
+import sttp.openai.requests.completions.chat.ChatChunkRequestResponseData.ChatChunkResponse.DoneEventMessage
+import sttp.openai.requests.completions.chat.ChatRequestBody.{ChatBody, ChatCompletionModel}
+import sttp.openai.utils.JsonUtils.compactJson
+
+class PekkoClientSpec extends AsyncFlatSpec with Matchers with EitherValues {
+  implicit val system: ActorSystem = ActorSystem()
+
+  for ((statusCode, expectedError) <- ErrorFixture.testData)
+    s"Service response with status code: $statusCode" should s"return properly deserialized ${expectedError.getClass.getSimpleName}" in {
+      // given
+      val pekkoBackendStub = PekkoHttpBackend.stub.whenAnyRequest.thenRespondWithCode(statusCode, ErrorFixture.errorResponse)
+      val client = new OpenAI("test-token")
+
+      val givenRequest = ChatBody(
+        model = ChatCompletionModel.GPT35Turbo,
+        messages = Seq.empty
+      )
+
+      // when
+      val caught = client
+        .createStreamedChatCompletion(givenRequest)
+        .send(pekkoBackendStub)
+        .map(_.body.left.value)
+
+      // then
+      caught.map { c =>
+        c.getClass shouldBe expectedError.getClass
+        c.message shouldBe expectedError.message
+        c.cause shouldBe expectedError.cause
+        c.code shouldBe expectedError.code
+        c.param shouldBe expectedError.param
+        c.`type` shouldBe expectedError.`type`
+      }
+    }
+
+  "Creating chat completions with failed stream due to invalid deserialization" should "return properly deserialized error" in {
+    // given
+    val invalidJson = Some("invalid json")
+    val invalidEvent = ServerSentEvent(invalidJson)
+
+    val streamedResponse = Source
+      .single(invalidEvent.toString)
+      .map(ByteString(_))
+
+    val pekkoBackendStub = PekkoHttpBackend.stub.whenAnyRequest.thenRespond(RawStream(streamedResponse))
+    val client = new OpenAI(authToken = "test-token")
+
+    val givenRequest = ChatBody(
+      model = ChatCompletionModel.GPT35Turbo,
+      messages = Seq.empty
+    )
+
+    // when
+    val response = client
+      .createStreamedChatCompletion(givenRequest)
+      .send(pekkoBackendStub)
+      .map(_.body.value)
+      .flatMap(_.run())
+
+    // then
+    response.failed.map(_ shouldBe a[DeserializationOpenAIException])
+  }
+
+  "Creating chat completions with successful response" should "return properly deserialized list of chunks" in {
+    // given
+    val chatChunks = Seq.fill(3)(sttp.openai.fixtures.ChatChunkFixture.jsonResponse).map(compactJson)
+    val events = chatChunks.map(data => ServerSentEvent(Some(data))) :+ ServerSentEvent(Some(DoneEventMessage))
+    val delimiter = "\n\n"
+    val streamedResponse = Source(events)
+      .map(_.toString + delimiter)
+      .map(ByteString(_))
+
+    val pekkoBackendStub = PekkoHttpBackend.stub.whenAnyRequest.thenRespond(RawStream(streamedResponse))
+    val client = new OpenAI(authToken = "test-token")
+
+    val givenRequest = ChatBody(
+      model = ChatCompletionModel.GPT35Turbo,
+      messages = Seq.empty
+    )
+
+    // when
+    val response = client
+      .createStreamedChatCompletion(givenRequest)
+      .send(pekkoBackendStub)
+      .map(_.body.value)
+      .flatMap(_.runWith(Sink.seq))
+
+    // then
+    val expectedResponse = chatChunks.map(read[ChatChunkResponse](_))
+    response.map(_ shouldBe expectedResponse)
+  }
+}

--- a/streaming/zio/src/test/scala/sttp/openai/streaming/zio/ZioClientSpec.scala
+++ b/streaming/zio/src/test/scala/sttp/openai/streaming/zio/ZioClientSpec.scala
@@ -3,10 +3,10 @@ package sttp.openai.streaming.zio
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import sttp.client4.DeserializationException
 import sttp.client4.httpclient.zio.HttpClientZioBackend
 import sttp.client4.testing.RawStream
 import sttp.model.sse.ServerSentEvent
+import sttp.openai.OpenAIExceptions.OpenAIException.DeserializationOpenAIException
 import sttp.openai.fixtures.ErrorFixture
 import sttp.openai.json.SnakePickle._
 import sttp.openai.requests.completions.chat.ChatChunkRequestResponseData.ChatChunkResponse
@@ -74,7 +74,7 @@ class ZioClientSpec extends AnyFlatSpec with Matchers with EitherValues {
     val response = unsafeRun(responseEffect.either)
 
     // then
-    response shouldBe a[Left[DeserializationException[_], _]]
+    response shouldBe a[Left[DeserializationOpenAIException, _]]
   }
 
   "Creating chat completions with successful response" should "return properly deserialized list of chunks" in {


### PR DESCRIPTION
This PR adds streaming support for [Create chat completion](https://platform.openai.com/docs/api-reference/chat/create) endpoint using Pekko Streams as a streams implementation.

Here are the main changes made in this PR:
- **out-of-the-box** streaming support has been added using the Pekko Streams library by extending current OpenAI class.
- integration tests have been added using `PekkoHttpBackend.stub`

_Minor change_:
- `DeserializationException` was replaced with more detailed `DeserializationOpenAIException` during tests