### PR TITLE
Add support for Structured Outputs #190

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ import com.softwaremill.SbtSoftwareMillCommon.commonSmlBuildSettings
 import com.softwaremill.Publish.ossPublishSettings
 import Dependencies._
 
-val scala2 = List("2.13.14")
-val scala3 = List("3.3.3")
+val scala2 = List("2.13.15")
+val scala3 = List("3.5.1")
 
 def dependenciesFor(version: String)(deps: (Option[(Long, Long)] => ModuleID)*): Seq[ModuleID] =
   deps.map(_.apply(CrossVersion.partialVersion(version)))
@@ -94,7 +94,7 @@ lazy val examples = (projectMatrix in file("examples"))
     libraryDependencies ++= Seq(
       "com.softwaremill.sttp.tapir" %% "tapir-netty-server-sync" % "1.11.4",
       "com.softwaremill.sttp.client4" %% "ox" % "4.0.0-M17",
-      "ch.qos.logback" % "logback-classic" % "1.5.6"
+      "ch.qos.logback" % "logback-classic" % "1.5.8"
     ),
     publish / skip := true
   )

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.softwaremill.Publish.ossPublishSettings
 import Dependencies._
 
 val scala2 = List("2.13.15")
-val scala3 = List("3.5.1")
+val scala3 = List("3.3.3")
 
 def dependenciesFor(version: String)(deps: (Option[(Long, Long)] => ModuleID)*): Seq[ModuleID] =
   deps.map(_.apply(CrossVersion.partialVersion(version)))

--- a/core/src/test/scala/sttp/openai/requests/completions/chat/ChatStructuredOutputSpec.scala
+++ b/core/src/test/scala/sttp/openai/requests/completions/chat/ChatStructuredOutputSpec.scala
@@ -1,0 +1,79 @@
+package sttp.openai.requests.completions.chat
+
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks.forAll
+import org.scalatest.prop.Tables.Table
+import sttp.openai.json.SnakePickle
+import sttp.openai.requests.completions.chat.ChatRequestBody._
+import ResponseFormat._
+import sttp.openai.requests.completions.chat.message.{Content, Message}
+
+class ChatStructuredOutputSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  "ResponseFormat" should "serialize and deserialize correctly" in {
+    val testCases = Table(
+      ("format", "expectedJson"),
+      (ResponseFormat.JsonSchema(schemaObj, true), ujson.Obj("type" -> "json_schema", "json_schema" -> ujson.Obj("schema" -> schemaObj, "strict" -> true))),
+      (ResponseFormat.JsonSchema(schemaObj, false), ujson.Obj("type" -> "json_schema", "json_schema" -> ujson.Obj("schema" -> schemaObj))),
+      (ResponseFormat.Text, ujson.Obj("type" -> "text")),
+      (ResponseFormat.JsonObject, ujson.Obj("type" -> "json_object"))
+    )
+
+    forAll(testCases) { (format: ResponseFormat, expectedJson) =>
+      val serialized = SnakePickle.write(format)
+      val deserialized = SnakePickle.read[ResponseFormat](serialized)
+
+      deserialized shouldBe format
+      ujson.read(serialized) shouldBe expectedJson
+    }
+  }
+
+  "ChatRequestBody" should "include JsonSchema response format when serialized" in {
+    val chatBody = ChatBody(
+      messages = Seq(Message.UserMessage(Content.TextContent("Generate a person's details"))),
+      model = ChatCompletionModel.GPT4o,
+      responseFormat = Some(ResponseFormat.JsonSchema(schemaObj, true))
+    )
+
+    val serialized = SnakePickle.write(chatBody)
+    val json = ujson.read(serialized)
+
+    json("response_format") shouldBe ujson.Obj(
+      "type" -> "json_schema",
+      "json_schema" -> ujson.Obj(
+        "schema" -> schemaObj,
+        "strict" -> true
+      )
+    )
+  }
+
+  it should "handle JsonSchema with strict set to false" in {
+    val chatBody = ChatBody(
+      messages = Seq(Message.UserMessage(Content.TextContent("Generate a person's details"))),
+      model = ChatCompletionModel.GPT4o,
+      responseFormat = Some(ResponseFormat.JsonSchema(schemaObj, false))
+    )
+
+    val serialized = SnakePickle.write(chatBody)
+    val json = ujson.read(serialized)
+
+    json("response_format") shouldBe ujson.Obj(
+      "type" -> "json_schema",
+      "json_schema" -> ujson.Obj(
+        "schema" -> schemaObj,
+      )
+    )
+  }
+
+  private lazy val schemaObj = ujson.Obj(
+    "type" -> "object",
+    "properties" -> ujson.Obj(
+      "name" -> ujson.Obj("type" -> "string"),
+      "age" -> ujson.Obj("type" -> "integer")
+    ),
+    "required" -> ujson.Arr("name", "age"),
+    "additionalProperties" -> false
+  )
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,8 +8,8 @@ object Dependencies {
 
     val sttpClient = "4.0.0-M17"
     val pekkoStreams = "1.1.1"
-    val akkaStreams = "2.6.20"
-    val uPickle = "3.1.4"
+    val akkaStreams = "2.6.21"
+    val uPickle = "3.3.1"
   }
 
   object Libraries {


### PR DESCRIPTION
**I haven't tested the changes with the actual OpenAI API yet.**

Structured Outputs have two aspects: generating parameters for function calling and formatting responses. In both cases, the new Structured Outputs option can be enabled by setting `strict=true`. By default, it is set to `false`.

### Infos
Issue: #190 
OpenAI Announcement: https://openai.com/index/introducing-structured-outputs-in-the-api
OpenAI Docs: https://platform.openai.com/docs/guides/structured-outputs/introduction
OpenAI API Reference: https://platform.openai.com/docs/api-reference/chat/create