### PR TITLE
Implement JSON schema support with apispec

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ and support for JSON Schema, you can use `ResponseFormat.JsonSchema` when creati
 The example below produces a JSON object:
 
 ```scala mdoc:compile-only
-//> using dep com.softwaremill.sttp.openai::core:0.2.3
+//> using dep com.softwaremill.sttp.openai::core:0.2.4
 
 import scala.collection.immutable.ListMap
 import sttp.apispec.{Schema, SchemaType}
@@ -514,6 +514,8 @@ To derive the same math reasoning schema used above, you can use
 [Tapir's support for generating a JSON schema from a Tapir schema](https://tapir.softwaremill.com/en/latest/docs/json-schema.html):
 
 ```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.tapir::tapir-apispec-docs:1.11.7
+
 import sttp.apispec.{Schema => ASchema}
 import sttp.tapir.Schema
 import sttp.tapir.docs.apispec.schema.TapirSchemaToJsonSchema

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,11 @@ lazy val core = (projectMatrix in file("core"))
     scalaVersions = scala2 ++ scala3
   )
   .settings(
-    libraryDependencies ++= Seq(Libraries.uPickle) ++ Libraries.sttpClient ++ Seq(Libraries.scalaTest)
+    libraryDependencies ++= Seq(
+      Libraries.tapirApispecDocs,
+      Libraries.uJsonCirce,
+      Libraries.uPickle
+    ) ++ Libraries.sttpApispec ++ Libraries.sttpClient ++ Seq(Libraries.scalaTest)
   )
   .settings(commonSettings: _*)
 

--- a/core/src/test/scala/sttp/openai/fixtures/JsonSchemaFixture.scala
+++ b/core/src/test/scala/sttp/openai/fixtures/JsonSchemaFixture.scala
@@ -1,0 +1,69 @@
+package sttp.openai.fixtures
+
+object JsonSchemaFixture {
+
+  val stringSchema: String =
+    """{
+      |  "type": "json_schema",
+      |  "json_schema": {
+      |    "name": "testString",
+      |    "strict": true,
+      |    "schema": {
+      |      "type": "string"
+      |    }
+      |  }
+      |}""".stripMargin
+
+  val numberSchema: String =
+    """{
+      |  "type": "json_schema",
+      |  "json_schema": {
+      |    "name": "testNumber",
+      |    "strict": true,
+      |    "schema": {
+      |      "type": "number"
+      |    }
+      |  }
+      |}""".stripMargin
+
+  val objectSchema: String =
+    """{
+      |  "type": "json_schema",
+      |  "json_schema": {
+      |    "name": "testObject",
+      |    "strict": true,
+      |    "schema": {
+      |      "additionalProperties": false,
+      |      "required": [
+      |        "foo",
+      |        "bar"
+      |      ],
+      |      "type": "object",
+      |      "properties": {
+      |        "foo": {
+      |          "type": "string"
+      |        },
+      |        "bar": {
+      |          "type": "number"
+      |        }
+      |      }
+      |    }
+      |  }
+      |}""".stripMargin
+
+  val arraySchema: String =
+    """{
+      |  "type": "json_schema",
+      |  "json_schema": {
+      |    "name": "testArray",
+      |    "strict": true,
+      |    "schema": {
+      |      "type": "array",
+      |      "items": {
+      |        "type": "string"
+      |      }
+      |    }
+      |  }
+      |}""".stripMargin
+
+}

--- a/core/src/test/scala/sttp/openai/requests/completions/chat/JsonSchemaSpec.scala
+++ b/core/src/test/scala/sttp/openai/requests/completions/chat/JsonSchemaSpec.scala
@@ -1,0 +1,53 @@
+package sttp.openai.requests.completions.chat
+
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scala.collection.immutable.ListMap
+import sttp.apispec.{Schema, SchemaType}
+import sttp.openai.fixtures
+import sttp.openai.json.SnakePickle
+import sttp.openai.requests.completions.chat.ChatRequestBody.ResponseFormat.JsonSchema
+
+class JsonSchemaSpec extends AnyFlatSpec with Matchers with EitherValues {
+  "Given string JSON schema" should "be properly serialized to Json" in {
+    val schema = Schema(SchemaType.String)
+
+    val jsonStringSchema = ujson.read(fixtures.JsonSchemaFixture.stringSchema)
+
+    val serializedSchema = SnakePickle.writeJs(JsonSchema("testString", true, schema))
+
+    serializedSchema shouldBe jsonStringSchema
+  }
+
+  "Given number JSON schema" should "be properly serialized to Json" in {
+    val schema = Schema(SchemaType.Number)
+
+    val jsonNumberSchema = ujson.read(fixtures.JsonSchemaFixture.numberSchema)
+
+    val serializedSchema = SnakePickle.writeJs(JsonSchema("testNumber", true, schema))
+
+    serializedSchema shouldBe jsonNumberSchema
+  }
+
+  "Given object JSON schema" should "be properly serialized to Json" in {
+    val schema = Schema(SchemaType.Object)
+      .copy(properties = ListMap("foo" -> Schema(SchemaType.String), "bar" -> Schema(SchemaType.Number)))
+
+    val jsonObjectSchema = ujson.read(fixtures.JsonSchemaFixture.objectSchema)
+
+    val serializedSchema = SnakePickle.writeJs(JsonSchema("testObject", true, schema))
+
+    serializedSchema shouldBe jsonObjectSchema
+  }
+
+  "Given array JSON schema" should "be properly serialized to Json" in {
+    val schema = Schema(SchemaType.Array).copy(items = Some(Schema(SchemaType.String)))
+
+    val jsonArraySchema = ujson.read(fixtures.JsonSchemaFixture.arraySchema)
+
+    val serializedSchema = SnakePickle.writeJs(JsonSchema("testArray", true, schema))
+
+    serializedSchema shouldBe jsonArraySchema
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,15 +6,22 @@ object Dependencies {
     val scalaTest = "3.2.19"
     val scalaTestCats = "1.5.0"
 
+    val sttpApispec = "0.11.3"
     val sttpClient = "4.0.0-M18"
     val pekkoStreams = "1.1.2"
     val akkaStreams = "2.6.20"
+    val tapir = "1.11.7"
     val uPickle = "3.1.4"
   }
 
   object Libraries {
 
     val scalaTest = "org.scalatest" %% "scalatest" % V.scalaTest % Test
+
+    val sttpApispec = Seq(
+      "com.softwaremill.sttp.apispec" %% "apispec-model" % V.sttpApispec,
+      "com.softwaremill.sttp.apispec" %% "jsonschema-circe" % V.sttpApispec
+    )
 
     val sttpClient = Seq(
       "com.softwaremill.sttp.client4" %% "core" % V.sttpClient,
@@ -41,6 +48,10 @@ object Dependencies {
     val sttpClientOx = Seq(
       "com.softwaremill.sttp.client4" %% "ox" % V.sttpClient
     )
+
+    val tapirApispecDocs = "com.softwaremill.sttp.tapir" %% "tapir-apispec-docs" % V.tapir
+
+    val uJsonCirce = "com.lihaoyi" %% "ujson-circe" % V.uPickle
 
     val uPickle = "com.lihaoyi" %% "upickle" % V.uPickle
 


### PR DESCRIPTION
Fixes #216 

@adamw re: your suggestion:

> An extension to this idea would be to derive a Tapir schema from a case class, and then [serialize it as JSON Schema](https://tapir.softwaremill.com/en/latest/docs/json-schema.html).

I chose to use the `Schema` type from [sttp-apispec](https://github.com/softwaremill/sttp-apispec) to implement this, but I didn't add explicit support for passing a Tapir schema and having it be converted automatically -- I figured downstream users could do the conversion themselves if they wanted to.

OpenAI only [supports a subset of JSON schema](https://platform.openai.com/docs/guides/structured-outputs/supported-schemas) and has some limitations, which I described in a comment in `ChatRequestBody.scala`.

I don't think it's reasonable to enforce all of these constraints in this library, users will just have to be cognizant of whether their schema violates any of them. If it does, the API returns an error like this:

```json
{
  "error": {
    "message": "Invalid schema for response_format 'schemaName': ... reason why schema was invalid ...",
    "type": "invalid_request_error",
    "param": "response_format",
    "code": null
  }
}
```