### PR TITLE
Deserialize to custom model where possible

### DIFF
--- a/core/src/main/scala/sttp/openai/requests/completions/CompletionsRequestBody.scala
+++ b/core/src/main/scala/sttp/openai/requests/completions/CompletionsRequestBody.scala
@@ -77,7 +77,7 @@ object CompletionsRequestBody {
         jsonValue =>
           SnakePickle.read[ujson.Value](jsonValue) match {
             case Str(value) =>
-              byCompletionModelValue.getOrElse(value, throw DeserializationOpenAIException(new Exception(s"Could not deserialize: $value")))
+              byCompletionModelValue.getOrElse(value, CustomCompletionModel(value))
             case e => throw DeserializationOpenAIException(new Exception(s"Could not deserialize: $e"))
           }
       )

--- a/core/src/main/scala/sttp/openai/requests/completions/chat/ChatRequestBody.scala
+++ b/core/src/main/scala/sttp/openai/requests/completions/chat/ChatRequestBody.scala
@@ -231,7 +231,7 @@ object ChatRequestBody {
         jsonValue =>
           SnakePickle.read[ujson.Value](jsonValue) match {
             case Str(value) =>
-              byChatModelValue.getOrElse(value, throw DeserializationOpenAIException(new Exception(s"Could not deserialize: $value")))
+              byChatModelValue.getOrElse(value, CustomChatCompletionModel(value))
             case e => throw DeserializationOpenAIException(new Exception(s"Could not deserialize: $e"))
           }
       )

--- a/core/src/main/scala/sttp/openai/requests/completions/edit/EditRequestBody.scala
+++ b/core/src/main/scala/sttp/openai/requests/completions/edit/EditRequestBody.scala
@@ -44,7 +44,7 @@ object EditRequestBody {
         jsonValue =>
           SnakePickle.read[ujson.Value](jsonValue) match {
             case Str(value) =>
-              byEditModelValue.getOrElse(value, throw DeserializationOpenAIException(new Exception(s"Could not deserialize: $value")))
+              byEditModelValue.getOrElse(value, CustomEditModel(value))
             case e => throw DeserializationOpenAIException(new Exception(s"Could not deserialize: $e"))
           }
       )

--- a/core/src/main/scala/sttp/openai/requests/finetunes/FineTunesRequestBody.scala
+++ b/core/src/main/scala/sttp/openai/requests/finetunes/FineTunesRequestBody.scala
@@ -65,7 +65,7 @@ object FineTuneModel {
       jsonValue =>
         SnakePickle.read[ujson.Value](jsonValue) match {
           case Str(value) =>
-            byFineTuneModelValue.getOrElse(value, throw DeserializationOpenAIException(new Exception(s"Could not deserialize: $value")))
+            byFineTuneModelValue.getOrElse(value, CustomFineTuneModel(value))
           case e => throw DeserializationOpenAIException(new Exception(s"Could not deserialize: $e"))
         }
     )


### PR DESCRIPTION
When using the library with a locally running instance of [Ollama](https://ollama.com/), a `DeserializationOpenAIException` is thrown when passing a custom model.

This PR deserializes to a custom model where applicable to avoid this exception.