### PR TITLE
change protected openAI requests to lazy val

### DIFF
--- a/core/src/main/scala/sttp/openai/OpenAI.scala
+++ b/core/src/main/scala/sttp/openai/OpenAI.scala
@@ -1495,10 +1495,10 @@ class OpenAI(authToken: String, baseUri: Uri = OpenAIUris.OpenAIBaseUri) {
       .delete(openAIUris.adminApiKey(keyId))
       .response(asJson_parseErrors[DeleteAdminApiKeyResponse])
 
-  protected val openAIAuthRequest: PartialRequest[Either[String, String]] = basicRequest.auth
+  protected lazy val openAIAuthRequest: PartialRequest[Either[String, String]] = basicRequest.auth
     .bearer(authToken)
 
-  protected val betaOpenAIAuthRequest: PartialRequest[Either[String, String]] =
+  protected lazy val betaOpenAIAuthRequest: PartialRequest[Either[String, String]] =
     openAIAuthRequest.withHeaders(openAIAuthRequest.headers :+ Header("OpenAI-Beta", "assistants=v2"))
 }
 


### PR DESCRIPTION
this would allow me to override it with extra headers to provide to openai compat proxy in middle