### PR TITLE
BeforeToolCall and afterToolCall hooks in the agent loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,7 @@ import sttp.ai.core.json.SnakePickle
 import sttp.ai.openai.OpenAI
 import sttp.ai.openai.agent.OpenAIAgent
 import sttp.client4.DefaultSyncBackend
+import sttp.shared.Identity
 import sttp.tapir.Schema
 
 object BasicExample extends App {
@@ -689,7 +690,7 @@ object BasicExample extends App {
     s"The weather in ${input.location} is 22°C, sunny"
   }
 
-  val config = AgentConfig(
+  val config = AgentConfig[Identity](
     maxIterations = 5,
     userTools = Seq(weatherTool)
   )
@@ -714,14 +715,30 @@ object BasicExample extends App {
 
 #### Agent Configuration
 
+`AgentConfig` is parameterized by the effect type `F` (matching `Agent[F]`); use `AgentConfig[Identity]` for the synchronous clients, or `AgentConfig[IO]` / `AgentConfig[Task]` / etc. for an effect system.
+
 ```scala
-val config = AgentConfig(
+val config = AgentConfig[Identity](
   maxIterations = 10,                              // Max reasoning steps
   systemPrompt = Some("Custom prompt"),            // Optional instructions
   userTools = Seq(tool1, tool2),                   // Your tools
   responseSchema = Some(ResponseSchema.derived[T]) // Optional typed result (see runAs[T] below)
 )
 ```
+
+#### Hooks
+
+If defined, the loop invokes an effectful hook `afterToolCall` once after each tool call, passing the `ToolCallRecord`.
+
+```scala
+val config = AgentConfig[IO](
+  maxIterations = 10,
+  userTools = Seq(tool1, tool2)
+).hookAfterToolCall(call => IO.println(s"[step ${call.iteration}] ${call.toolName} -> ${call.output}"))
+```
+
+`ToolCallRecord` carries `toolName`, `input`, `output` (the successful output, or the error message fed back to the LLM on failure), and `iteration`.
+An error in the hook will interrupt the agent loop.
 
 #### Exception Handling
 
@@ -738,7 +755,7 @@ The `ExceptionHandler` controls how tool execution errors and argument parsing f
 **Default Handler (recommended):**
 
 ```scala
-val config = AgentConfig(
+val config = AgentConfig[Identity](
   maxIterations = 5,
   userTools = Seq(myTool),
   exceptionHandler = ExceptionHandler.default  // This is the default, can be omitted
@@ -752,7 +769,7 @@ The default handler:
 **Send All to LLM:**
 
 ```scala
-val config = AgentConfig(
+val config = AgentConfig[Identity](
   maxIterations = 5,
   userTools = Seq(myTool),
   exceptionHandler = ExceptionHandler.sendAllToLLM
@@ -764,7 +781,7 @@ All errors are converted to messages and sent to the LLM, giving it maximum oppo
 **Propagate All (Strict Mode):**
 
 ```scala
-val config = AgentConfig(
+val config = AgentConfig[Identity](
   maxIterations = 5,
   userTools = Seq(myTool),
   exceptionHandler = ExceptionHandler.propagateAll
@@ -793,7 +810,7 @@ val customHandler = new ExceptionHandler {
     Left(s"Invalid arguments for $toolName - please check the schema")
 }
 
-val config = AgentConfig(
+val config = AgentConfig[Identity](
   maxIterations = 5,
   userTools = Seq(myTool),
   exceptionHandler = customHandler
@@ -860,6 +877,7 @@ import sttp.ai.core.json.SnakePickle
 import sttp.ai.openai.OpenAI
 import sttp.ai.openai.agent.OpenAIAgent
 import sttp.client4.DefaultSyncBackend
+import sttp.shared.Identity
 import sttp.tapir.Schema
 
 case class TripSummary(weather: String, calculation: String, conclusion: String) derives SnakePickle.ReadWriter, Schema
@@ -870,7 +888,7 @@ object TypedAgentExample extends App {
     (input: WeatherInput) => s"The weather in ${input.location} is 22°C, sunny"
   }
 
-  val cfg = AgentConfig(
+  val cfg = AgentConfig[Identity](
     maxIterations = 5,
     userTools = Seq(weatherTool),
     responseSchema = Some(ResponseSchema.derived[TripSummary]())
@@ -926,7 +944,7 @@ import sttp.ai.openai.agent.OpenAIAgent
 
 object CatsEffectExample extends IOApp.Simple {
   def run: IO[Unit] = {
-    val config = AgentConfig(maxIterations = 5, userTools = Seq(weatherTool))
+    val config = AgentConfig[IO](maxIterations = 5, userTools = Seq(weatherTool))
     HttpClientCatsBackend.resource[IO]().use { backend =>
       val agent = OpenAIAgent[IO](OpenAI.fromEnv, "gpt-4o-mini", config)
       agent.run("What's the weather in London?")(backend)
@@ -945,7 +963,7 @@ import sttp.ai.openai.agent.OpenAIAgent
 
 object ZIOExample extends ZIOAppDefault {
   def run = {
-    val config = AgentConfig(maxIterations = 5, userTools = Seq(weatherTool))
+    val config = AgentConfig[Task](maxIterations = 5, userTools = Seq(weatherTool))
     ZIO.scoped {
       for {
         backend <- HttpClientZioBackend.scoped()

--- a/README.md
+++ b/README.md
@@ -677,7 +677,6 @@ import sttp.ai.core.json.SnakePickle
 import sttp.ai.openai.OpenAI
 import sttp.ai.openai.agent.OpenAIAgent
 import sttp.client4.DefaultSyncBackend
-import sttp.shared.Identity
 import sttp.tapir.Schema
 
 object BasicExample extends App {
@@ -690,14 +689,13 @@ object BasicExample extends App {
     s"The weather in ${input.location} is 22°C, sunny"
   }
 
-  val config = AgentConfig[Identity](
-    maxIterations = 5,
-    userTools = Seq(weatherTool)
-  )
-
   val backend = DefaultSyncBackend()
   try {
-    val agent = OpenAIAgent.synchronous(OpenAI.fromEnv, "gpt-4o-mini", config)
+    val agent = OpenAIAgent
+      .synchronous(OpenAI.fromEnv, "gpt-4o-mini")
+      .maxIterations(5)
+      .tools(weatherTool)
+      .build
 
     val result = agent.run("What's the weather in Paris?")(backend)
 
@@ -707,23 +705,24 @@ object BasicExample extends App {
 }
 ```
 
-**For Claude:** Use `ClaudeAgent.synchronous(ClaudeConfig.fromEnv, "claude-3-haiku-20240307", config)` instead.
+**For Claude:** Use `ClaudeAgent.synchronous(ClaudeConfig.fromEnv, "claude-3-haiku-20240307")` instead.
 
-**For effect systems:** use `OpenAIAgent.apply[F]` and `ClaudeAgent.apply[F]`.
+**For effect systems:** use `OpenAIAgent.builder[F]` / `ClaudeAgent.builder[F]` (e.g. `builder[IO]`), then add configuration and `.build`.
 
 ### Core Components
 
 #### Agent Configuration
 
-`AgentConfig` is parameterized by the effect type `F` (matching `Agent[F]`); use `AgentConfig[Identity]` for the synchronous clients, or `AgentConfig[IO]` / `AgentConfig[Task]` / etc. for an effect system.
+Configure the agent with the fluent builder. Use `OpenAIAgent.builder[F]` / `ClaudeAgent.builder[F]` for an effect system (e.g. `builder[IO]`), or `synchronous(...)` for the blocking `Identity` clients:
 
 ```scala
-val config = AgentConfig[Identity](
-  maxIterations = 10,                              // Max reasoning steps
-  systemPrompt = Some("Custom prompt"),            // Optional instructions
-  userTools = Seq(tool1, tool2),                   // Your tools
-  responseSchema = Some(ResponseSchema.derived[T]) // Optional typed result (see runAs[T] below)
-)
+val agent = OpenAIAgent
+  .synchronous(OpenAI.fromEnv, "gpt-4o-mini")
+  .maxIterations(10)                               // Max reasoning steps
+  .systemPrompt("Custom prompt")                   // Optional instructions
+  .tools(tool1, tool2)                             // Your tools
+  .deriveResponseSchema[T]                          // Optional typed result (see runAs[T] below)
+  .build
 ```
 
 #### Hooks
@@ -735,10 +734,11 @@ The loop can invoke optional effectful hooks around each tool call. Both run ins
 If defined, the loop invokes `beforeToolCall` once before each tool call is executed, passing the pending `ToolCall`.
 
 ```scala
-val config = AgentConfig[IO](
-  maxIterations = 10,
-  userTools = Seq(tool1, tool2)
-).hookBeforeToolCall(call => IO.println(s"calling ${call.toolName}(${call.input})"))
+val agent = OpenAIAgent.builder[IO](OpenAI.fromEnv, "gpt-4o-mini")
+  .maxIterations(10)
+  .tools(tool1, tool2)
+  .hookBeforeToolCall(call => IO.println(s"calling ${call.toolName}(${call.input})"))
+  .build
 ```
 
 `ToolCall` carries `id`, `toolName`, and `input`.
@@ -748,10 +748,11 @@ val config = AgentConfig[IO](
 If defined, the loop invokes `afterToolCall` once after each tool call, passing the `ToolCallRecord`.
 
 ```scala
-val config = AgentConfig[IO](
-  maxIterations = 10,
-  userTools = Seq(tool1, tool2)
-).hookAfterToolCall(call => IO.println(s"[step ${call.iteration}] ${call.toolName} -> ${call.output}"))
+val agent = OpenAIAgent.builder[IO](OpenAI.fromEnv, "gpt-4o-mini")
+  .maxIterations(10)
+  .tools(tool1, tool2)
+  .hookAfterToolCall(call => IO.println(s"[step ${call.iteration}] ${call.toolName} -> ${call.output}"))
+  .build
 ```
 
 `ToolCallRecord` carries `id`, `toolName`, `input`, `output` (the successful output, or the error message fed back to the LLM on failure), and `iteration`.
@@ -771,11 +772,12 @@ The `ExceptionHandler` controls how tool execution errors and argument parsing f
 **Default Handler (recommended):**
 
 ```scala
-val config = AgentConfig[Identity](
-  maxIterations = 5,
-  userTools = Seq(myTool),
-  exceptionHandler = ExceptionHandler.default  // This is the default, can be omitted
-)
+val agent = OpenAIAgent
+  .synchronous(OpenAI.fromEnv, "gpt-4o-mini")
+  .maxIterations(5)
+  .tools(myTool)
+  .exceptionHandler(ExceptionHandler.default) // This is the default, can be omitted
+  .build
 ```
 
 The default handler:
@@ -785,11 +787,12 @@ The default handler:
 **Send All to LLM:**
 
 ```scala
-val config = AgentConfig[Identity](
-  maxIterations = 5,
-  userTools = Seq(myTool),
-  exceptionHandler = ExceptionHandler.sendAllToLLM
-)
+val agent = OpenAIAgent
+  .synchronous(OpenAI.fromEnv, "gpt-4o-mini")
+  .maxIterations(5)
+  .tools(myTool)
+  .exceptionHandler(ExceptionHandler.sendAllToLLM)
+  .build
 ```
 
 All errors are converted to messages and sent to the LLM, giving it maximum opportunity to recover.
@@ -797,11 +800,12 @@ All errors are converted to messages and sent to the LLM, giving it maximum oppo
 **Propagate All (Strict Mode):**
 
 ```scala
-val config = AgentConfig[Identity](
-  maxIterations = 5,
-  userTools = Seq(myTool),
-  exceptionHandler = ExceptionHandler.propagateAll
-)
+val agent = OpenAIAgent
+  .synchronous(OpenAI.fromEnv, "gpt-4o-mini")
+  .maxIterations(5)
+  .tools(myTool)
+  .exceptionHandler(ExceptionHandler.propagateAll)
+  .build
 ```
 
 All errors immediately terminate the agent loop by propagating the exception. Use this for strict error handling where any failure should stop execution.
@@ -826,11 +830,12 @@ val customHandler = new ExceptionHandler {
     Left(s"Invalid arguments for $toolName - please check the schema")
 }
 
-val config = AgentConfig[Identity](
-  maxIterations = 5,
-  userTools = Seq(myTool),
-  exceptionHandler = customHandler
-)
+val agent = OpenAIAgent
+  .synchronous(OpenAI.fromEnv, "gpt-4o-mini")
+  .maxIterations(5)
+  .tools(myTool)
+  .exceptionHandler(customHandler)
+  .build
 ```
 
 Return `Left(message)` to send the error to the LLM and continue the loop, or `Right(exception)` to propagate and terminate.
@@ -893,7 +898,6 @@ import sttp.ai.core.json.SnakePickle
 import sttp.ai.openai.OpenAI
 import sttp.ai.openai.agent.OpenAIAgent
 import sttp.client4.DefaultSyncBackend
-import sttp.shared.Identity
 import sttp.tapir.Schema
 
 case class TripSummary(weather: String, calculation: String, conclusion: String) derives SnakePickle.ReadWriter, Schema
@@ -904,15 +908,14 @@ object TypedAgentExample extends App {
     (input: WeatherInput) => s"The weather in ${input.location} is 22°C, sunny"
   }
 
-  val cfg = AgentConfig[Identity](
-    maxIterations = 5,
-    userTools = Seq(weatherTool),
-    responseSchema = Some(ResponseSchema.derived[TripSummary]())
-  )
-
   val backend = DefaultSyncBackend()
   try {
-    val agent = OpenAIAgent.synchronous(OpenAI.fromEnv, "gpt-4o-mini", cfg)
+    val agent = OpenAIAgent
+      .synchronous(OpenAI.fromEnv, "gpt-4o-mini")
+      .maxIterations(5)
+      .tools(weatherTool)
+      .deriveResponseSchema[TripSummary]
+      .build
     agent.runAs[TripSummary]("What's the weather in Paris?")(backend).finalAnswer match {
       case Right(summary) => println(s"Weather: ${summary.weather}")
       case Left(err)      => println(s"Parse failed: ${err.cause.getMessage}; raw=${err.rawAnswer}")
@@ -960,9 +963,8 @@ import sttp.ai.openai.agent.OpenAIAgent
 
 object CatsEffectExample extends IOApp.Simple {
   def run: IO[Unit] = {
-    val config = AgentConfig[IO](maxIterations = 5, userTools = Seq(weatherTool))
+    val agent = OpenAIAgent.builder[IO](OpenAI.fromEnv, "gpt-4o-mini").maxIterations(5).tools(weatherTool).build
     HttpClientCatsBackend.resource[IO]().use { backend =>
-      val agent = OpenAIAgent[IO](OpenAI.fromEnv, "gpt-4o-mini", config)
       agent.run("What's the weather in London?")(backend)
         .flatMap(r => IO.println(s"Answer: ${r.finalAnswer}"))
     }
@@ -979,11 +981,10 @@ import sttp.ai.openai.agent.OpenAIAgent
 
 object ZIOExample extends ZIOAppDefault {
   def run = {
-    val config = AgentConfig[Task](maxIterations = 5, userTools = Seq(weatherTool))
+    val agent = OpenAIAgent.builder[Task](OpenAI.fromEnv, "gpt-4o-mini").maxIterations(5).tools(weatherTool).build
     ZIO.scoped {
       for {
         backend <- HttpClientZioBackend.scoped()
-        agent = OpenAIAgent[Task](OpenAI.fromEnv, "gpt-4o-mini", config)
         result <- agent.run("What's the weather in London?")(backend)
         _ <- Console.printLine(s"Answer: ${result.finalAnswer}")
       } yield ()

--- a/README.md
+++ b/README.md
@@ -728,7 +728,24 @@ val config = AgentConfig[Identity](
 
 #### Hooks
 
-If defined, the loop invokes an effectful hook `afterToolCall` once after each tool call, passing the `ToolCallRecord`.
+The loop can invoke optional effectful hooks around each tool call. Both run inside the agent loop, so an error in either hook interrupts the run.
+
+##### beforeToolCall
+
+If defined, the loop invokes `beforeToolCall` once before each tool call is executed, passing the pending `ToolCall`.
+
+```scala
+val config = AgentConfig[IO](
+  maxIterations = 10,
+  userTools = Seq(tool1, tool2)
+).hookBeforeToolCall(call => IO.println(s"calling ${call.toolName}(${call.input})"))
+```
+
+`ToolCall` carries `id`, `toolName`, and `input`.
+
+##### afterToolCall
+
+If defined, the loop invokes `afterToolCall` once after each tool call, passing the `ToolCallRecord`.
 
 ```scala
 val config = AgentConfig[IO](
@@ -737,8 +754,7 @@ val config = AgentConfig[IO](
 ).hookAfterToolCall(call => IO.println(s"[step ${call.iteration}] ${call.toolName} -> ${call.output}"))
 ```
 
-`ToolCallRecord` carries `toolName`, `input`, `output` (the successful output, or the error message fed back to the LLM on failure), and `iteration`.
-An error in the hook will interrupt the agent loop.
+`ToolCallRecord` carries `id`, `toolName`, `input`, `output` (the successful output, or the error message fed back to the LLM on failure), and `iteration`.
 
 #### Exception Handling
 

--- a/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
+++ b/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
@@ -142,45 +142,26 @@ private[claude] class ClaudeAgentBackend[F[_]](
 }
 
 object ClaudeAgent {
-  def apply[F[_]](
-      claudeConfig: ClaudeConfig,
-      modelName: String,
-      config: AgentConfig[F]
-  )(implicit monad: sttp.monad.MonadError[F]): Agent[F] = {
-    val backend = new ClaudeAgentBackend[F](
-      ClaudeClient(claudeConfig),
-      modelName,
-      config.userTools,
-      config.systemPrompt,
-      config.responseSchema
-    )
-    Agent(backend, config)
-  }
 
-  def apply[F[_]](
+  def builder[F[_]](
+      claudeConfig: ClaudeConfig,
+      modelName: String
+  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
+    builder(ClaudeClient(claudeConfig), modelName)
+
+  def builder[F[_]](
       client: ClaudeClient,
-      modelName: String,
-      config: AgentConfig[F]
-  )(implicit monad: sttp.monad.MonadError[F]): Agent[F] = {
-    val backend = new ClaudeAgentBackend[F](
-      client,
-      modelName,
-      config.userTools,
-      config.systemPrompt,
-      config.responseSchema
-    )
-    Agent(backend, config)
-  }
+      modelName: String
+  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
+    AgentBuilder[F](config => new ClaudeAgentBackend[F](client, modelName, config.userTools, config.systemPrompt, config.responseSchema))
 
   def synchronous(
       claudeConfig: ClaudeConfig,
-      modelName: String,
-      config: AgentConfig[Identity]
-  ): Agent[Identity] = apply(claudeConfig, modelName, config)(IdentityMonad)
+      modelName: String
+  ): AgentBuilder[Identity] = builder[Identity](claudeConfig, modelName)(IdentityMonad)
 
   def synchronous(
       client: ClaudeClient,
-      modelName: String,
-      config: AgentConfig[Identity]
-  ): Agent[Identity] = apply(client, modelName, config)(IdentityMonad)
+      modelName: String
+  ): AgentBuilder[Identity] = builder[Identity](client, modelName)(IdentityMonad)
 }

--- a/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
+++ b/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
@@ -145,7 +145,7 @@ object ClaudeAgent {
   def apply[F[_]](
       claudeConfig: ClaudeConfig,
       modelName: String,
-      config: AgentConfig
+      config: AgentConfig[F]
   )(implicit monad: sttp.monad.MonadError[F]): Agent[F] = {
     val backend = new ClaudeAgentBackend[F](
       ClaudeClient(claudeConfig),
@@ -160,7 +160,7 @@ object ClaudeAgent {
   def apply[F[_]](
       client: ClaudeClient,
       modelName: String,
-      config: AgentConfig
+      config: AgentConfig[F]
   )(implicit monad: sttp.monad.MonadError[F]): Agent[F] = {
     val backend = new ClaudeAgentBackend[F](
       client,
@@ -175,12 +175,12 @@ object ClaudeAgent {
   def synchronous(
       claudeConfig: ClaudeConfig,
       modelName: String,
-      config: AgentConfig
+      config: AgentConfig[Identity]
   ): Agent[Identity] = apply(claudeConfig, modelName, config)(IdentityMonad)
 
   def synchronous(
       client: ClaudeClient,
       modelName: String,
-      config: AgentConfig
+      config: AgentConfig[Identity]
   ): Agent[Identity] = apply(client, modelName, config)(IdentityMonad)
 }

--- a/claude/src/test/scala/sttp/ai/claude/integration/ClaudeAgentIntegrationSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/integration/ClaudeAgentIntegrationSpec.scala
@@ -31,12 +31,11 @@ class ClaudeAgentIntegrationSpec extends AgentIntegrationSpecBase {
       maxIterations: Int,
       tools: Seq[AgentTool[_]],
       responseSchema: ResponseSchema[T]
-  ): Agent[Identity] = {
-    val agentConfig = AgentConfig[Identity](
-      maxIterations = maxIterations,
-      userTools = tools,
-      responseSchema = Some(responseSchema)
-    )
-    ClaudeAgent.synchronous(ClaudeConfig.fromEnv, "claude-haiku-4-5-20251001", agentConfig)
-  }
+  ): Agent[Identity] =
+    ClaudeAgent
+      .synchronous(ClaudeConfig.fromEnv, "claude-haiku-4-5-20251001")
+      .maxIterations(maxIterations)
+      .tools(tools)
+      .responseSchema(responseSchema)
+      .build
 }

--- a/claude/src/test/scala/sttp/ai/claude/integration/ClaudeAgentIntegrationSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/integration/ClaudeAgentIntegrationSpec.scala
@@ -16,7 +16,7 @@ class ClaudeAgentIntegrationSpec extends AgentIntegrationSpecBase {
   override def createAgent(maxIterations: Int, tools: Seq[AgentTool[_]]): Agent[Identity] = {
     val config = ClaudeConfig.fromEnv
     val client = ClaudeClient(config)
-    val agentConfig = AgentConfig(maxIterations = maxIterations, userTools = tools)
+    val agentConfig = AgentConfig[Identity](maxIterations = maxIterations, userTools = tools)
     val agentBackend = new ClaudeAgentBackend[Identity](
       client,
       "claude-haiku-4-5-20251001",
@@ -32,7 +32,7 @@ class ClaudeAgentIntegrationSpec extends AgentIntegrationSpecBase {
       tools: Seq[AgentTool[_]],
       responseSchema: ResponseSchema[T]
   ): Agent[Identity] = {
-    val agentConfig = AgentConfig(
+    val agentConfig = AgentConfig[Identity](
       maxIterations = maxIterations,
       userTools = tools,
       responseSchema = Some(responseSchema)

--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -12,6 +12,7 @@ class Agent[F[_]](
 
   private val toolMap = config.userTools.map(t => t.name -> t).toMap
 
+  private val beforeToolCall: ToolCall => F[Unit] = config.beforeToolCall.getOrElse((_: ToolCall) => monad.unit(()))
   private val afterToolCall: ToolCallRecord => F[Unit] = config.afterToolCall.getOrElse((_: ToolCallRecord) => monad.unit(()))
 
   def run(
@@ -91,10 +92,13 @@ class Agent[F[_]](
     toolCalls match {
       case Nil => monad.unit((history, results))
       case toolCall :: rest =>
-        runToolCall(toolCall, iteration).flatTap(afterToolCall).flatMap { record =>
-          val updatedHistory = history.addToolResult(toolCall.id, record.toolName, record.output)
-          runToolCalls(rest, iteration, updatedHistory, results :+ record)
-        }
+        for {
+          _ <- beforeToolCall(toolCall)
+          result <- runToolCall(toolCall, iteration)
+          _ <- afterToolCall(result)
+          updatedHistory = history.addToolResult(result)
+          acc <- runToolCalls(rest, iteration, updatedHistory, results :+ result)
+        } yield acc
     }
 
   private def runToolCall(
@@ -108,6 +112,7 @@ class Agent[F[_]](
 
     output.map { result =>
       ToolCallRecord(
+        id = toolCall.id,
         toolName = toolCall.toolName,
         input = toolCall.input,
         output = result,

--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -3,13 +3,16 @@ package sttp.ai.core.agent
 import sttp.ai.core.json.SnakePickle
 import sttp.client4.Backend
 import sttp.monad.MonadError
+import sttp.monad.syntax.MonadErrorOps
 
 class Agent[F[_]](
     agentBackend: AgentBackend[F],
-    config: AgentConfig
+    config: AgentConfig[F]
 )(implicit monad: MonadError[F]) {
 
   private val toolMap = config.userTools.map(t => t.name -> t).toMap
+
+  private val afterToolCall: ToolCallRecord => F[Unit] = config.afterToolCall.getOrElse((_: ToolCallRecord) => monad.unit(()))
 
   def run(
       initialPrompt: String
@@ -18,10 +21,9 @@ class Agent[F[_]](
 
     def loop(history: ConversationHistory, iteration: Int, toolCallRecords: Seq[ToolCallRecord]): F[AgentResult[String]] =
       if (iteration >= config.maxIterations) {
-        val finalAnswer = extractFinalAnswer(history)
         monad.unit(
           AgentResult(
-            finalAnswer = finalAnswer,
+            finalAnswer = extractFinalAnswer(history),
             iterations = iteration,
             toolCalls = toolCallRecords,
             finishReason = FinishReason.MaxIterations
@@ -36,7 +38,7 @@ class Agent[F[_]](
 
         val response = agentBackend.sendRequest(historyWithMarker, backend)
 
-        monad.flatMap(response) { response =>
+        response.flatMap { response =>
           if (response.stopReason == StopReason.MaxTokens) {
             monad.unit(
               AgentResult(
@@ -59,33 +61,10 @@ class Agent[F[_]](
           } else {
             val updatedHistory = history.addAssistantResponse(response.textContent, response.toolCalls)
 
-            val toolResults = response.toolCalls.map { toolCall =>
-              val tool = toolMap.get(toolCall.toolName)
-              val result: String = tool match {
-                case Some(t) =>
-                  executeTool(t, toolCall) match {
-                    case Right(successResult) => successResult
-                    case Left(errorForLLM)    => errorForLLM
-                  }
-                case None =>
-                  s"Tool not found: ${toolCall.toolName}"
-              }
-
-              val record = ToolCallRecord(
-                toolName = toolCall.toolName,
-                input = toolCall.input,
-                output = result,
-                iteration = iteration + 1
-              )
-
-              (toolCall, result, record)
+            runToolCalls(response.toolCalls.toList, iteration + 1, updatedHistory, toolCallRecords).flatMap {
+              case (historyWithResults, results) =>
+                loop(historyWithResults, iteration + 1, results)
             }
-
-            val historyWithResults = toolResults.foldLeft(updatedHistory) { case (hist, (toolCall, result, _)) =>
-              hist.addToolResult(toolCall.id, toolCall.toolName, result)
-            }
-
-            loop(historyWithResults, iteration + 1, toolCallRecords ++ toolResults.map(_._3))
           }
         }
       }
@@ -103,37 +82,60 @@ class Agent[F[_]](
       AgentResult(parsed, res.iterations, res.toolCalls, res.finishReason)
     }
 
-  private def executeTool[T](tool: AgentTool[T], toolCall: ToolCall): Either[String, String] = {
-    val parseResult: Either[Exception, T] =
-      try
-        Right(SnakePickle.read[T](toolCall.input)(tool.readWriter))
-      catch {
-        case e: Exception => Left(e)
-      }
-
-    parseResult match {
-      case Left(parseException) =>
-        config.exceptionHandler.handleParseError(
-          toolCall.toolName,
-          toolCall.input,
-          parseException
-        ) match {
-          case Left(errorMessage) => Left(errorMessage)
-          case Right(ex)          => throw ex
-        }
-
-      case Right(typedInput) =>
-        try
-          Right(tool.execute(typedInput))
-        catch {
-          case e: Exception =>
-            config.exceptionHandler.handleToolException(toolCall.toolName, e) match {
-              case Left(errorMessage) => Left(errorMessage)
-              case Right(ex)          => throw ex
-            }
+  private def runToolCalls(
+      toolCalls: List[ToolCall],
+      iteration: Int,
+      history: ConversationHistory,
+      results: Seq[ToolCallRecord]
+  ): F[(ConversationHistory, Seq[ToolCallRecord])] =
+    toolCalls match {
+      case Nil => monad.unit((history, results))
+      case toolCall :: rest =>
+        runToolCall(toolCall, iteration).flatTap(afterToolCall).flatMap { record =>
+          val updatedHistory = history.addToolResult(toolCall.id, record.toolName, record.output)
+          runToolCalls(rest, iteration, updatedHistory, results :+ record)
         }
     }
+
+  private def runToolCall(
+      toolCall: ToolCall,
+      iteration: Int
+  ): F[ToolCallRecord] = {
+    val output = toolMap.get(toolCall.toolName) match {
+      case Some(tool) => executeTool(tool, toolCall)
+      case None       => monad.unit(s"Tool not found: ${toolCall.toolName}")
+    }
+
+    output.map { result =>
+      ToolCallRecord(
+        toolName = toolCall.toolName,
+        input = toolCall.input,
+        output = result,
+        iteration = iteration
+      )
+    }
   }
+
+  private def executeTool[T](tool: AgentTool[T], toolCall: ToolCall): F[String] =
+    monad
+      .eval(SnakePickle.read[T](toolCall.input)(tool.readWriter))
+      .map[Either[String, T]](Right(_))
+      .handleError { case parseException: Exception =>
+        config.exceptionHandler.handleParseError(toolCall.toolName, toolCall.input, parseException) match {
+          case Left(errorMessage) => monad.unit(Left(errorMessage))
+          case Right(ex)          => monad.error(ex)
+        }
+      }
+      .flatMap {
+        case Left(errorMessage) => monad.unit(errorMessage)
+        case Right(typedInput) =>
+          monad.eval(tool.execute(typedInput)).handleError { case e: Exception =>
+            config.exceptionHandler.handleToolException(toolCall.toolName, e) match {
+              case Left(errorMessage) => monad.unit(errorMessage)
+              case Right(ex)          => monad.error(ex)
+            }
+          }
+      }
 
   private def extractFinalAnswer(history: ConversationHistory): String =
     history.entries.reverseIterator
@@ -147,7 +149,7 @@ class Agent[F[_]](
 object Agent {
   def apply[F[_]](
       agentBackend: AgentBackend[F],
-      config: AgentConfig
+      config: AgentConfig[F]
   )(implicit monad: MonadError[F]): Agent[F] =
     new Agent[F](agentBackend, config)(monad)
 }

--- a/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
@@ -1,0 +1,51 @@
+package sttp.ai.core.agent
+
+import sttp.ai.core.agent.AgentConfig.SystemPromptParameters
+import sttp.ai.core.json.SnakePickle
+import sttp.monad.MonadError
+import sttp.tapir.Schema
+
+final class AgentBuilder[F[_]] private (
+    makeBackend: AgentConfig[F] => AgentBackend[F],
+    val config: AgentConfig[F]
+)(implicit monad: MonadError[F]) {
+
+  private def withConfig(next: AgentConfig[F]): AgentBuilder[F] =
+    new AgentBuilder[F](makeBackend, next)
+
+  def maxIterations(value: Int): AgentBuilder[F] = withConfig(config.copy(maxIterations = value))
+
+  def systemPrompt(buildSystemPrompt: SystemPromptParameters => String): AgentBuilder[F] =
+    withConfig(config.copy(systemPromptBuilder = Some(buildSystemPrompt)))
+
+  def systemPrompt(prompt: String): AgentBuilder[F] = systemPrompt(_ => prompt)
+
+  def tools(values: Seq[AgentTool[_]]): AgentBuilder[F] = withConfig(config.copy(userTools = values))
+
+  def tools(first: AgentTool[_], rest: AgentTool[_]*): AgentBuilder[F] = tools(first +: rest)
+
+  def addTool(tool: AgentTool[_]): AgentBuilder[F] = withConfig(config.copy(userTools = config.userTools :+ tool))
+
+  def exceptionHandler(handler: ExceptionHandler): AgentBuilder[F] = withConfig(config.copy(exceptionHandler = handler))
+
+  def responseSchema(schema: ResponseSchema[_]): AgentBuilder[F] = withConfig(config.copy(responseSchema = Some(schema)))
+
+  def deriveResponseSchema[T](implicit schema: Schema[T], rw: SnakePickle.ReadWriter[T]): AgentBuilder[F] =
+    withConfig(config.copy(responseSchema = Some(ResponseSchema.derived[T](None))))
+
+  // NOTE: the description field is only forwarded to OpenAI. Claude's structured-output `output_config` has no description field.
+  def deriveResponseSchema[T](description: String)(implicit schema: Schema[T], rw: SnakePickle.ReadWriter[T]): AgentBuilder[F] =
+    withConfig(config.copy(responseSchema = Some(ResponseSchema.derived[T](Some(description)))))
+
+  def hookBeforeToolCall(hook: ToolCall => F[Unit]): AgentBuilder[F] = withConfig(config.copy(beforeToolCall = Some(hook)))
+
+  def hookAfterToolCall(hook: ToolCallRecord => F[Unit]): AgentBuilder[F] = withConfig(config.copy(afterToolCall = Some(hook)))
+
+  def build: Agent[F] = Agent(makeBackend(config), config)
+}
+
+object AgentBuilder {
+
+  def apply[F[_]](makeBackend: AgentConfig[F] => AgentBackend[F])(implicit monad: MonadError[F]): AgentBuilder[F] =
+    new AgentBuilder[F](makeBackend, AgentConfig[F]())
+}

--- a/core/src/main/scala/sttp/ai/core/agent/AgentConfig.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentConfig.scala
@@ -1,24 +1,30 @@
 package sttp.ai.core.agent
 
-case class AgentConfig private (
+case class AgentConfig[F[_]] private (
     maxIterations: Int,
     systemPrompt: Option[String],
     userTools: Seq[AgentTool[_]],
     exceptionHandler: ExceptionHandler,
-    responseSchema: Option[ResponseSchema[_]]
-)
+    responseSchema: Option[ResponseSchema[_]],
+    afterToolCall: Option[ToolCallRecord => F[Unit]]
+) {
+
+  def hookAfterToolCall(hook: ToolCallRecord => F[Unit]): AgentConfig[F] =
+    copy(afterToolCall = Some(hook))
+}
 
 object AgentConfig {
 
-  def apply(
+  def apply[F[_]](
       maxIterations: Int = 10,
       systemPrompt: Option[String] = None,
       userTools: Seq[AgentTool[_]] = Seq.empty,
       exceptionHandler: ExceptionHandler = ExceptionHandler.default,
-      responseSchema: Option[ResponseSchema[_]] = None
-  ): AgentConfig = {
+      responseSchema: Option[ResponseSchema[_]] = None,
+      afterToolCall: Option[ToolCallRecord => F[Unit]] = None
+  ): AgentConfig[F] = {
     val finalSystemPrompt = systemPrompt.orElse(Some(buildSystemPrompt(maxIterations)))
-    new AgentConfig(maxIterations, finalSystemPrompt, userTools, exceptionHandler, responseSchema)
+    new AgentConfig[F](maxIterations, finalSystemPrompt, userTools, exceptionHandler, responseSchema, afterToolCall)
   }
 
   private def buildSystemPrompt(maxIterations: Int): String =

--- a/core/src/main/scala/sttp/ai/core/agent/AgentConfig.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentConfig.scala
@@ -1,42 +1,28 @@
 package sttp.ai.core.agent
 
-case class AgentConfig[F[_]] private (
-    maxIterations: Int,
-    systemPrompt: Option[String],
-    userTools: Seq[AgentTool[_]],
-    exceptionHandler: ExceptionHandler,
-    responseSchema: Option[ResponseSchema[_]],
-    beforeToolCall: Option[ToolCall => F[Unit]],
-    afterToolCall: Option[ToolCallRecord => F[Unit]]
+import sttp.ai.core.agent.AgentConfig.SystemPromptParameters
+
+case class AgentConfig[F[_]](
+    maxIterations: Int = 10,
+    systemPromptBuilder: Option[SystemPromptParameters => String] = Some(AgentConfig.buildSystemPrompt),
+    userTools: Seq[AgentTool[_]] = Seq.empty,
+    exceptionHandler: ExceptionHandler = ExceptionHandler.default,
+    responseSchema: Option[ResponseSchema[_]] = None,
+    beforeToolCall: Option[ToolCall => F[Unit]] = None,
+    afterToolCall: Option[ToolCallRecord => F[Unit]] = None
 ) {
-
-  def hookBeforeToolCall(hook: ToolCall => F[Unit]): AgentConfig[F] =
-    copy(beforeToolCall = Some(hook))
-
-  def hookAfterToolCall(hook: ToolCallRecord => F[Unit]): AgentConfig[F] =
-    copy(afterToolCall = Some(hook))
+  val systemPrompt: Option[String] = systemPromptBuilder.map(_.apply(SystemPromptParameters(maxIterations)))
 }
 
 object AgentConfig {
 
-  def apply[F[_]](
-      maxIterations: Int = 10,
-      systemPrompt: Option[String] = None,
-      userTools: Seq[AgentTool[_]] = Seq.empty,
-      exceptionHandler: ExceptionHandler = ExceptionHandler.default,
-      responseSchema: Option[ResponseSchema[_]] = None,
-      beforeToolCall: Option[ToolCall => F[Unit]] = None,
-      afterToolCall: Option[ToolCallRecord => F[Unit]] = None
-  ): AgentConfig[F] = {
-    val finalSystemPrompt = systemPrompt.orElse(Some(buildSystemPrompt(maxIterations)))
-    new AgentConfig[F](maxIterations, finalSystemPrompt, userTools, exceptionHandler, responseSchema, beforeToolCall, afterToolCall)
-  }
+  case class SystemPromptParameters(maxIterations: Int)
 
-  private def buildSystemPrompt(maxIterations: Int): String =
+  private def buildSystemPrompt(params: SystemPromptParameters): String =
     s"""You are a simple loop-based agent that solves the user's task step by step using tool calling when appropriate.
          |
          |OPERATING RULES:
-         |1. The agent may run for a maximum of $maxIterations iterations.
+         |1. The agent may run for a maximum of ${params.maxIterations} iterations.
          |2. In each iteration, decide whether to:
          |   - continue reasoning about the task and use one of the available tools to make progress,
          |   - or provide your final answer.

--- a/core/src/main/scala/sttp/ai/core/agent/AgentConfig.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentConfig.scala
@@ -6,8 +6,12 @@ case class AgentConfig[F[_]] private (
     userTools: Seq[AgentTool[_]],
     exceptionHandler: ExceptionHandler,
     responseSchema: Option[ResponseSchema[_]],
+    beforeToolCall: Option[ToolCall => F[Unit]],
     afterToolCall: Option[ToolCallRecord => F[Unit]]
 ) {
+
+  def hookBeforeToolCall(hook: ToolCall => F[Unit]): AgentConfig[F] =
+    copy(beforeToolCall = Some(hook))
 
   def hookAfterToolCall(hook: ToolCallRecord => F[Unit]): AgentConfig[F] =
     copy(afterToolCall = Some(hook))
@@ -21,10 +25,11 @@ object AgentConfig {
       userTools: Seq[AgentTool[_]] = Seq.empty,
       exceptionHandler: ExceptionHandler = ExceptionHandler.default,
       responseSchema: Option[ResponseSchema[_]] = None,
+      beforeToolCall: Option[ToolCall => F[Unit]] = None,
       afterToolCall: Option[ToolCallRecord => F[Unit]] = None
   ): AgentConfig[F] = {
     val finalSystemPrompt = systemPrompt.orElse(Some(buildSystemPrompt(maxIterations)))
-    new AgentConfig[F](maxIterations, finalSystemPrompt, userTools, exceptionHandler, responseSchema, afterToolCall)
+    new AgentConfig[F](maxIterations, finalSystemPrompt, userTools, exceptionHandler, responseSchema, beforeToolCall, afterToolCall)
   }
 
   private def buildSystemPrompt(maxIterations: Int): String =

--- a/core/src/main/scala/sttp/ai/core/agent/AgentResult.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentResult.scala
@@ -10,6 +10,7 @@ object FinishReason {
 }
 
 final case class ToolCallRecord(
+    id: String,
     toolName: String,
     input: String,
     output: String,

--- a/core/src/main/scala/sttp/ai/core/agent/ConversationHistory.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/ConversationHistory.scala
@@ -22,8 +22,8 @@ case class ConversationHistory(entries: Seq[ConversationEntry]) {
   def addAssistantResponse(content: String, toolCalls: Seq[ToolCall]): ConversationHistory =
     ConversationHistory(entries :+ ConversationEntry.AssistantResponse(content, toolCalls))
 
-  def addToolResult(toolCallId: String, toolName: String, result: String): ConversationHistory =
-    ConversationHistory(entries :+ ConversationEntry.ToolResult(toolCallId, toolName, result))
+  def addToolResult(result: ToolCallRecord): ConversationHistory =
+    ConversationHistory(entries :+ ConversationEntry.ToolResult(result.id, result.toolName, result.output))
 
   def addIterationMarker(currentIteration: Int, maxIterations: Int): ConversationHistory =
     ConversationHistory(entries :+ ConversationEntry.IterationMarker(currentIteration, maxIterations))

--- a/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
@@ -1,5 +1,6 @@
 package sttp.ai.core.agent
 
+import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.ai.core.json.SnakePickle
@@ -8,7 +9,7 @@ import sttp.monad.IdentityMonad
 import sttp.shared.Identity
 import sttp.tapir.Schema
 
-class AgentSpec extends AnyFlatSpec with Matchers {
+class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
 
   class StubAgentBackend(responses: Seq[AgentResponse]) extends AgentBackend[Identity] {
     private var callCount = 0
@@ -45,17 +46,11 @@ class AgentSpec extends AnyFlatSpec with Matchers {
     s"Result: ${input.a + input.b}"
   }
 
-  private def createLoop(responses: Seq[AgentResponse], config: AgentConfig[Identity]): (Agent[Identity], StubAgentBackend) = {
-    val stubBackend = new StubAgentBackend(responses)
-    val loop = new Agent[Identity](stubBackend, config)(IdentityMonad)
-    (loop, stubBackend)
-  }
+  private def agentBuilder(responses: AgentResponse*): AgentBuilder[Identity] =
+    AgentBuilder[Identity](_ => new StubAgentBackend(responses))(IdentityMonad)
 
-  private def runLoop(responses: Seq[AgentResponse], tools: Seq[AgentTool[_]] = Seq.empty): AgentResult[String] = {
-    val testConfig = AgentConfig[Identity](maxIterations = 5, userTools = tools)
-    val (loop, _) = createLoop(responses, testConfig)
-    loop.run("Test")(backend)
-  }
+  private def runLoop(builder: AgentBuilder[Identity]): AgentResult[String] =
+    builder.build.run("Test")(backend)
 
   case class DummyInput()
   implicit val dummyInputRW: SnakePickle.ReadWriter[DummyInput] = SnakePickle.macroRW
@@ -72,14 +67,13 @@ class AgentSpec extends AnyFlatSpec with Matchers {
     )((_: DummyInput) => "dummy result")
 
     val result = runLoop(
-      Seq(
+      agentBuilder(
         AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "dummy", input = "{}")), StopReason.ToolUse),
         AgentResponse("", Seq(ToolCall(id = "call_2", toolName = "dummy", input = "{}")), StopReason.ToolUse),
         AgentResponse("", Seq(ToolCall(id = "call_3", toolName = "dummy", input = "{}")), StopReason.ToolUse),
         AgentResponse("", Seq(ToolCall(id = "call_4", toolName = "dummy", input = "{}")), StopReason.ToolUse),
         AgentResponse("", Seq(ToolCall(id = "call_5", toolName = "dummy", input = "{}")), StopReason.ToolUse)
-      ),
-      tools = Seq(dummyTool)
+      ).maxIterations(5).tools(dummyTool)
     )
 
     result.finishReason shouldBe FinishReason.MaxIterations
@@ -88,7 +82,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "complete the loop when the response has no tool calls and empty text" in {
-    val result = runLoop(Seq(AgentResponse("", Seq.empty, StopReason.EndTurn)))
+    val result = runLoop(agentBuilder(AgentResponse("", Seq.empty, StopReason.EndTurn)))
 
     result.finishReason shouldBe FinishReason.NaturalStop
     result.finalAnswer shouldBe ""
@@ -98,7 +92,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
 
   it should "execute multiple tool calls in one iteration" in {
     val result = runLoop(
-      Seq(
+      agentBuilder(
         AgentResponse(
           "",
           Seq(
@@ -108,8 +102,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
           StopReason.ToolUse
         ),
         AgentResponse("Done", Seq.empty, StopReason.EndTurn)
-      ),
-      tools = Seq(calculatorTool)
+      ).tools(calculatorTool)
     )
 
     result.iterations shouldBe 2
@@ -131,7 +124,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
     }
 
     val result = runLoop(
-      Seq(
+      agentBuilder(
         AgentResponse(
           "",
           Seq(
@@ -140,8 +133,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
           StopReason.ToolUse
         ),
         AgentResponse("Recovered", Seq.empty, StopReason.EndTurn)
-      ),
-      tools = Seq(errorTool)
+      ).tools(errorTool)
     )
 
     result.iterations shouldBe 2
@@ -154,7 +146,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
 
   it should "handle unknown tool gracefully" in {
     val result = runLoop(
-      Seq(
+      agentBuilder(
         AgentResponse(
           "",
           Seq(
@@ -174,7 +166,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
 
   it should "build tool call records correctly" in {
     val result = runLoop(
-      Seq(
+      agentBuilder(
         AgentResponse(
           "",
           Seq(
@@ -183,8 +175,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
           StopReason.ToolUse
         ),
         AgentResponse("Done", Seq.empty, StopReason.EndTurn)
-      ),
-      tools = Seq(calculatorTool)
+      ).tools(calculatorTool)
     )
 
     result.toolCalls should have size 1
@@ -204,16 +195,13 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       "Dummy tool"
     )((_: DummyInput) => "dummy result")
 
-    val config = AgentConfig[Identity](maxIterations = 3, userTools = Seq(dummyTool))
-    val (loop, stubBackend) = createLoop(
+    val stubBackend = new StubAgentBackend(
       Seq(
         AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "dummy", input = "{}")), StopReason.ToolUse),
         AgentResponse("Done", Seq.empty, StopReason.EndTurn)
-      ),
-      config
+      )
     )
-
-    loop.run("Test")(backend)
+    runLoop(AgentBuilder[Identity](_ => stubBackend)(IdentityMonad).tools(dummyTool))
 
     stubBackend.receivedHistories should have size 2
     val firstHistory = stubBackend.receivedHistories.head
@@ -228,7 +216,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       "Custom tool"
     )((_: DummyInput) => "result")
 
-    val config = AgentConfig[Identity](userTools = Seq(customTool))
+    val config = agentBuilder().tools(customTool).config
 
     config.userTools should have size 1
     config.userTools.head.name shouldBe "custom"
@@ -240,17 +228,13 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       "Dummy tool"
     )((_: DummyInput) => "final tool result")
 
-    val config = AgentConfig[Identity](maxIterations = 3, userTools = Seq(dummyTool))
-    val (loop, _) = createLoop(
-      Seq(
+    val result = runLoop(
+      agentBuilder(
         AgentResponse("First response", Seq(ToolCall(id = "call_1", toolName = "dummy", input = "{}")), StopReason.ToolUse),
         AgentResponse("Second response", Seq(ToolCall(id = "call_2", toolName = "dummy", input = "{}")), StopReason.ToolUse),
         AgentResponse("Third response", Seq(ToolCall(id = "call_3", toolName = "dummy", input = "{}")), StopReason.ToolUse)
-      ),
-      config
+      ).maxIterations(3).tools(dummyTool)
     )
-
-    val result = loop.run("Test")(backend)
 
     result.finishReason shouldBe FinishReason.MaxIterations
     result.finalAnswer shouldBe "final tool result"
@@ -265,19 +249,12 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       throw new java.io.IOException("Network error")
     }
 
-    val config = AgentConfig[Identity](
-      maxIterations = 3,
-      userTools = Seq(ioTool),
-      exceptionHandler = ExceptionHandler.default
-    )
-
-    val (loop, _) = createLoop(
-      Seq(AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "io_tool", input = "{}")), StopReason.ToolUse)),
-      config
-    )
-
     assertThrows[java.io.IOException] {
-      loop.run("Test")(backend)
+      runLoop(
+        agentBuilder(
+          AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "io_tool", input = "{}")), StopReason.ToolUse)
+        ).tools(ioTool).exceptionHandler(ExceptionHandler.default)
+      )
     }
   }
 
@@ -289,19 +266,12 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       throw new InterruptedException("Thread interrupted")
     }
 
-    val config = AgentConfig[Identity](
-      maxIterations = 3,
-      userTools = Seq(interruptedTool),
-      exceptionHandler = ExceptionHandler.default
-    )
-
-    val (loop, _) = createLoop(
-      Seq(AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "interrupted_tool", input = "{}")), StopReason.ToolUse)),
-      config
-    )
-
     assertThrows[InterruptedException] {
-      loop.run("Test")(backend)
+      runLoop(
+        agentBuilder(
+          AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "interrupted_tool", input = "{}")), StopReason.ToolUse)
+        ).tools(interruptedTool).exceptionHandler(ExceptionHandler.default)
+      )
     }
   }
 
@@ -313,21 +283,12 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       throw new java.io.IOException("Network error")
     }
 
-    val config = AgentConfig[Identity](
-      maxIterations = 3,
-      userTools = Seq(ioTool),
-      exceptionHandler = ExceptionHandler.sendAllToLLM
-    )
-
-    val (loop, _) = createLoop(
-      Seq(
+    val result = runLoop(
+      agentBuilder(
         AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "io_tool", input = "{}")), StopReason.ToolUse),
         AgentResponse("Recovered", Seq.empty, StopReason.EndTurn)
-      ),
-      config
+      ).tools(ioTool).exceptionHandler(ExceptionHandler.sendAllToLLM)
     )
-
-    val result = loop.run("Test")(backend)
 
     result.toolCalls.head.output should include("Error executing tool 'io_tool'")
     result.toolCalls.head.output should include("Network error")
@@ -342,19 +303,12 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       throw new RuntimeException("Any error")
     }
 
-    val config = AgentConfig[Identity](
-      maxIterations = 3,
-      userTools = Seq(errorTool),
-      exceptionHandler = ExceptionHandler.propagateAll
-    )
-
-    val (loop, _) = createLoop(
-      Seq(AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "error_tool", input = "{}")), StopReason.ToolUse)),
-      config
-    )
-
     assertThrows[RuntimeException] {
-      loop.run("Test")(backend)
+      runLoop(
+        agentBuilder(
+          AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "error_tool", input = "{}")), StopReason.ToolUse)
+        ).tools(errorTool).exceptionHandler(ExceptionHandler.propagateAll)
+      )
     }
   }
 
@@ -366,21 +320,13 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       s"Got: ${input.value}"
     }
 
-    val config = AgentConfig[Identity](
-      maxIterations = 3,
-      userTools = Seq(numberTool)
-    )
-
-    val (loop, _) = createLoop(
-      Seq(
+    val result = runLoop(
+      agentBuilder(
         // Invalid input - string instead of int
         AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "number", input = """{"value":"not_a_number"}""")), StopReason.ToolUse),
         AgentResponse("Fixed", Seq.empty, StopReason.EndTurn)
-      ),
-      config
+      ).tools(numberTool)
     )
-
-    val result = loop.run("Test")(backend)
 
     result.toolCalls.head.output should include("Invalid arguments for tool 'number'")
     result.toolCalls.head.output should include("Please check the tool definition")
@@ -388,20 +334,12 @@ class AgentSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "handle malformed JSON" in {
-    val config = AgentConfig[Identity](
-      maxIterations = 3,
-      userTools = Seq(calculatorTool)
-    )
-
-    val (loop, _) = createLoop(
-      Seq(
+    val result = runLoop(
+      agentBuilder(
         AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "calculator", input = """{"a":not valid json}""")), StopReason.ToolUse),
         AgentResponse("Fixed", Seq.empty, StopReason.EndTurn)
-      ),
-      config
+      ).tools(calculatorTool)
     )
-
-    val result = loop.run("Test")(backend)
 
     result.toolCalls.head.output should include("Invalid arguments")
     result.finishReason shouldBe FinishReason.NaturalStop
@@ -427,21 +365,12 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       throw new IllegalArgumentException("Bad argument")
     }
 
-    val config = AgentConfig[Identity](
-      maxIterations = 3,
-      userTools = Seq(errorTool),
-      exceptionHandler = customHandler
-    )
-
-    val (loop, _) = createLoop(
-      Seq(
+    val result = runLoop(
+      agentBuilder(
         AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "error_tool", input = "{}")), StopReason.ToolUse),
         AgentResponse("Done", Seq.empty, StopReason.EndTurn)
-      ),
-      config
+      ).tools(errorTool).exceptionHandler(customHandler)
     )
-
-    val result = loop.run("Test")(backend)
 
     result.toolCalls.head.output shouldBe "CUSTOM ERROR in error_tool: IllegalArgumentException"
   }
@@ -453,19 +382,9 @@ class AgentSpec extends AnyFlatSpec with Matchers {
   }
 
   "Agent with responseSchema" should "round-trip the typed payload through the final answer" in {
-    val cfg = AgentConfig[Identity](
-      maxIterations = 3,
-      responseSchema = Some(ResponseSchema.derived[WeatherSummary]())
-    )
-
-    val (loop, _) = createLoop(
-      Seq(
-        AgentResponse("""{"city":"Krakow","temp_c":12.0,"conditions":"sunny"}""", Seq.empty, StopReason.EndTurn)
-      ),
-      cfg
-    )
-
-    val result = loop.run("What's the weather?")(backend)
+    val result = agentBuilder(
+      AgentResponse("""{"city":"Krakow","temp_c":12.0,"conditions":"sunny"}""", Seq.empty, StopReason.EndTurn)
+    ).deriveResponseSchema[WeatherSummary].build.run("What's the weather?")(backend)
 
     result.finishReason shouldBe FinishReason.NaturalStop: Unit
     val parsed = SnakePickle.read[WeatherSummary](result.finalAnswer)
@@ -473,19 +392,9 @@ class AgentSpec extends AnyFlatSpec with Matchers {
   }
 
   "Agent.runAs[T]" should "return Right(T) when the model emits a well-formed structured payload" in {
-    val cfg = AgentConfig[Identity](
-      maxIterations = 3,
-      responseSchema = Some(ResponseSchema.derived[WeatherSummary]())
-    )
-
-    val (loop, _) = createLoop(
-      Seq(
-        AgentResponse("""{"city":"Krakow","temp_c":12.0,"conditions":"sunny"}""", Seq.empty, StopReason.EndTurn)
-      ),
-      cfg
-    )
-
-    val result = loop.runAs[WeatherSummary]("What's the weather?")(backend)
+    val result = agentBuilder(
+      AgentResponse("""{"city":"Krakow","temp_c":12.0,"conditions":"sunny"}""", Seq.empty, StopReason.EndTurn)
+    ).deriveResponseSchema[WeatherSummary].build.runAs[WeatherSummary]("What's the weather?")(backend)
 
     result.finishReason shouldBe FinishReason.NaturalStop: Unit
     result.iterations shouldBe 1: Unit
@@ -493,19 +402,9 @@ class AgentSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "return Left(AgentParseError) preserving the trace when the answer can't be parsed as T" in {
-    val cfg = AgentConfig[Identity](
-      maxIterations = 3,
-      responseSchema = Some(ResponseSchema.derived[WeatherSummary]())
-    )
-
-    val (loop, _) = createLoop(
-      Seq(
-        AgentResponse("""{"wrong":"shape"}""", Seq.empty, StopReason.EndTurn)
-      ),
-      cfg
-    )
-
-    val result = loop.runAs[WeatherSummary]("What's the weather?")(backend)
+    val result = agentBuilder(
+      AgentResponse("""{"wrong":"shape"}""", Seq.empty, StopReason.EndTurn)
+    ).deriveResponseSchema[WeatherSummary].build.runAs[WeatherSummary]("What's the weather?")(backend)
 
     result.iterations shouldBe 1: Unit
     result.finishReason shouldBe FinishReason.NaturalStop: Unit
@@ -521,20 +420,12 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       "Dummy tool"
     )((_: DummyInput) => "not json")
 
-    val cfg = AgentConfig[Identity](
-      maxIterations = 1,
-      userTools = Seq(dummyTool),
-      responseSchema = Some(ResponseSchema.derived[WeatherSummary]())
-    )
-
-    val (loop, _) = createLoop(
-      Seq(
-        AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "dummy", input = "{}")), StopReason.ToolUse)
-      ),
-      cfg
-    )
-
-    val result = loop.runAs[WeatherSummary]("What's the weather?")(backend)
+    val result = agentBuilder(
+      AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "dummy", input = "{}")), StopReason.ToolUse)
+    ).tools(dummyTool)
+      .deriveResponseSchema[WeatherSummary]
+      .build
+      .runAs[WeatherSummary]("What's the weather?")(backend)
 
     result.finishReason shouldBe FinishReason.MaxIterations: Unit
     result.finalAnswer.isLeft shouldBe true: Unit
@@ -542,7 +433,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
   }
 
   "Agent finish reason" should "be TokenLimit when the final answer is cut off by the token limit" in {
-    val result = runLoop(Seq(AgentResponse("partial answer", Seq.empty, StopReason.MaxTokens)))
+    val result = runLoop(agentBuilder(AgentResponse("partial answer", Seq.empty, StopReason.MaxTokens)))
 
     result.finishReason shouldBe FinishReason.TokenLimit
     result.finalAnswer shouldBe "partial answer"
@@ -551,18 +442,9 @@ class AgentSpec extends AnyFlatSpec with Matchers {
 
   "Agent with hooks" should "invoke afterToolCall once per tool call" in {
     val results = scala.collection.mutable.ListBuffer.empty[Any]
-    val config = AgentConfig[Identity](
-      maxIterations = 5,
-      userTools = Seq(calculatorTool),
-      exceptionHandler = ExceptionHandler.sendAllToLLM
-    ).hookBeforeToolCall { (c: ToolCall) =>
-      results += c; ()
-    }.hookAfterToolCall { (r: ToolCallRecord) =>
-      results += r; ()
-    }
 
-    val (loop, _) = createLoop(
-      Seq(
+    runLoop(
+      agentBuilder(
         AgentResponse(
           "",
           Seq(
@@ -573,11 +455,15 @@ class AgentSpec extends AnyFlatSpec with Matchers {
           StopReason.ToolUse
         ),
         AgentResponse("Done", Seq.empty, StopReason.EndTurn)
-      ),
-      config
+      ).tools(calculatorTool)
+        .exceptionHandler(ExceptionHandler.sendAllToLLM)
+        .hookBeforeToolCall { (c: ToolCall) =>
+          results += c; ()
+        }
+        .hookAfterToolCall { (r: ToolCallRecord) =>
+          results += r; ()
+        }
     )
-
-    loop.run("Test")(backend)
 
     results should contain inOrderOnly (
       ToolCall("call_1", "calculator", """{"a":5,"b":10}"""),
@@ -587,5 +473,38 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       ToolCall("call_3", "non_existing_tool", """{"a":3,"b":7}"""),
       ToolCallRecord("call_3", "non_existing_tool", """{"a":3,"b":7}""", "Tool not found: non_existing_tool", 1)
     )
+  }
+
+  "AgentBuilder" should "accumulate configuration into the built config" in {
+    val before: ToolCall => Identity[Unit] = _ => ()
+    val after: ToolCallRecord => Identity[Unit] = _ => ()
+
+    val config = agentBuilder()
+      .maxIterations(7)
+      .systemPrompt("custom")
+      .tools(calculatorTool)
+      .exceptionHandler(ExceptionHandler.sendAllToLLM)
+      .hookBeforeToolCall(before)
+      .hookAfterToolCall(after)
+      .config
+
+    config.maxIterations shouldBe 7
+    config.systemPrompt.value shouldBe "custom"
+    config.userTools should contain only calculatorTool
+    config.exceptionHandler shouldBe ExceptionHandler.sendAllToLLM
+    config.beforeToolCall.value shouldBe before
+    config.afterToolCall.value shouldBe after
+  }
+
+  it should "derive the default system prompt from the final maxIterations" in {
+    val systemPrompt = agentBuilder().maxIterations(42).config.systemPrompt
+
+    systemPrompt.value should include("42")
+  }
+
+  it should "derive a response schema carrying the given description" in {
+    val responseSchema = agentBuilder().deriveResponseSchema[WeatherSummary]("the weather report").config.responseSchema
+
+    responseSchema.value.description shouldBe Some("the weather report")
   }
 }

--- a/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
@@ -521,7 +521,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       "Dummy tool"
     )((_: DummyInput) => "not json")
 
-    val cfg = AgentConfig(
+    val cfg = AgentConfig[Identity](
       maxIterations = 1,
       userTools = Seq(dummyTool),
       responseSchema = Some(ResponseSchema.derived[WeatherSummary]())
@@ -550,15 +550,16 @@ class AgentSpec extends AnyFlatSpec with Matchers {
   }
 
   "Agent with hooks" should "invoke afterToolCall once per tool call" in {
-    val results = scala.collection.mutable.ListBuffer.empty[String]
+    val results = scala.collection.mutable.ListBuffer.empty[Any]
     val config = AgentConfig[Identity](
       maxIterations = 5,
       userTools = Seq(calculatorTool),
-      afterToolCall = Some { (r: ToolCallRecord) =>
-        results += r.output.takeWhile(_ != '\n'); ()
-      },
       exceptionHandler = ExceptionHandler.sendAllToLLM
-    )
+    ).hookBeforeToolCall { (c: ToolCall) =>
+      results += c; ()
+    }.hookAfterToolCall { (r: ToolCallRecord) =>
+      results += r; ()
+    }
 
     val (loop, _) = createLoop(
       Seq(
@@ -579,9 +580,12 @@ class AgentSpec extends AnyFlatSpec with Matchers {
     loop.run("Test")(backend)
 
     results should contain inOrderOnly (
-      "Result: 15.0",
-      "Failed to parse arguments for tool 'calculator': $['a']",
-      "Tool not found: non_existing_tool"
+      ToolCall("call_1", "calculator", """{"a":5,"b":10}"""),
+      ToolCallRecord("call_1", "calculator", """{"a":5,"b":10}""", "Result: 15.0", 1),
+      ToolCall("call_2", "calculator", """{"a":"bad","b":"input"}"""),
+      ToolCallRecord("call_2", "calculator", """{"a":"bad","b":"input"}""", "Failed to parse arguments for tool 'calculator': $['a']", 1),
+      ToolCall("call_3", "non_existing_tool", """{"a":3,"b":7}"""),
+      ToolCallRecord("call_3", "non_existing_tool", """{"a":3,"b":7}""", "Tool not found: non_existing_tool", 1)
     )
   }
 }

--- a/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
@@ -45,14 +45,14 @@ class AgentSpec extends AnyFlatSpec with Matchers {
     s"Result: ${input.a + input.b}"
   }
 
-  private def createLoop(responses: Seq[AgentResponse], config: AgentConfig): (Agent[Identity], StubAgentBackend) = {
+  private def createLoop(responses: Seq[AgentResponse], config: AgentConfig[Identity]): (Agent[Identity], StubAgentBackend) = {
     val stubBackend = new StubAgentBackend(responses)
     val loop = new Agent[Identity](stubBackend, config)(IdentityMonad)
     (loop, stubBackend)
   }
 
   private def runLoop(responses: Seq[AgentResponse], tools: Seq[AgentTool[_]] = Seq.empty): AgentResult[String] = {
-    val testConfig = AgentConfig(maxIterations = 5, userTools = tools)
+    val testConfig = AgentConfig[Identity](maxIterations = 5, userTools = tools)
     val (loop, _) = createLoop(responses, testConfig)
     loop.run("Test")(backend)
   }
@@ -204,7 +204,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       "Dummy tool"
     )((_: DummyInput) => "dummy result")
 
-    val config = AgentConfig(maxIterations = 3, userTools = Seq(dummyTool))
+    val config = AgentConfig[Identity](maxIterations = 3, userTools = Seq(dummyTool))
     val (loop, stubBackend) = createLoop(
       Seq(
         AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "dummy", input = "{}")), StopReason.ToolUse),
@@ -228,7 +228,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       "Custom tool"
     )((_: DummyInput) => "result")
 
-    val config = AgentConfig(userTools = Seq(customTool))
+    val config = AgentConfig[Identity](userTools = Seq(customTool))
 
     config.userTools should have size 1
     config.userTools.head.name shouldBe "custom"
@@ -240,7 +240,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       "Dummy tool"
     )((_: DummyInput) => "final tool result")
 
-    val config = AgentConfig(maxIterations = 3, userTools = Seq(dummyTool))
+    val config = AgentConfig[Identity](maxIterations = 3, userTools = Seq(dummyTool))
     val (loop, _) = createLoop(
       Seq(
         AgentResponse("First response", Seq(ToolCall(id = "call_1", toolName = "dummy", input = "{}")), StopReason.ToolUse),
@@ -265,7 +265,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       throw new java.io.IOException("Network error")
     }
 
-    val config = AgentConfig(
+    val config = AgentConfig[Identity](
       maxIterations = 3,
       userTools = Seq(ioTool),
       exceptionHandler = ExceptionHandler.default
@@ -289,7 +289,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       throw new InterruptedException("Thread interrupted")
     }
 
-    val config = AgentConfig(
+    val config = AgentConfig[Identity](
       maxIterations = 3,
       userTools = Seq(interruptedTool),
       exceptionHandler = ExceptionHandler.default
@@ -313,7 +313,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       throw new java.io.IOException("Network error")
     }
 
-    val config = AgentConfig(
+    val config = AgentConfig[Identity](
       maxIterations = 3,
       userTools = Seq(ioTool),
       exceptionHandler = ExceptionHandler.sendAllToLLM
@@ -342,7 +342,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       throw new RuntimeException("Any error")
     }
 
-    val config = AgentConfig(
+    val config = AgentConfig[Identity](
       maxIterations = 3,
       userTools = Seq(errorTool),
       exceptionHandler = ExceptionHandler.propagateAll
@@ -366,7 +366,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       s"Got: ${input.value}"
     }
 
-    val config = AgentConfig(
+    val config = AgentConfig[Identity](
       maxIterations = 3,
       userTools = Seq(numberTool)
     )
@@ -388,7 +388,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "handle malformed JSON" in {
-    val config = AgentConfig(
+    val config = AgentConfig[Identity](
       maxIterations = 3,
       userTools = Seq(calculatorTool)
     )
@@ -427,7 +427,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
       throw new IllegalArgumentException("Bad argument")
     }
 
-    val config = AgentConfig(
+    val config = AgentConfig[Identity](
       maxIterations = 3,
       userTools = Seq(errorTool),
       exceptionHandler = customHandler
@@ -453,7 +453,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
   }
 
   "Agent with responseSchema" should "round-trip the typed payload through the final answer" in {
-    val cfg = AgentConfig(
+    val cfg = AgentConfig[Identity](
       maxIterations = 3,
       responseSchema = Some(ResponseSchema.derived[WeatherSummary]())
     )
@@ -473,7 +473,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
   }
 
   "Agent.runAs[T]" should "return Right(T) when the model emits a well-formed structured payload" in {
-    val cfg = AgentConfig(
+    val cfg = AgentConfig[Identity](
       maxIterations = 3,
       responseSchema = Some(ResponseSchema.derived[WeatherSummary]())
     )
@@ -493,7 +493,7 @@ class AgentSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "return Left(AgentParseError) preserving the trace when the answer can't be parsed as T" in {
-    val cfg = AgentConfig(
+    val cfg = AgentConfig[Identity](
       maxIterations = 3,
       responseSchema = Some(ResponseSchema.derived[WeatherSummary]())
     )
@@ -547,5 +547,41 @@ class AgentSpec extends AnyFlatSpec with Matchers {
     result.finishReason shouldBe FinishReason.TokenLimit
     result.finalAnswer shouldBe "partial answer"
     result.iterations shouldBe 1
+  }
+
+  "Agent with hooks" should "invoke afterToolCall once per tool call" in {
+    val results = scala.collection.mutable.ListBuffer.empty[String]
+    val config = AgentConfig[Identity](
+      maxIterations = 5,
+      userTools = Seq(calculatorTool),
+      afterToolCall = Some { (r: ToolCallRecord) =>
+        results += r.output.takeWhile(_ != '\n'); ()
+      },
+      exceptionHandler = ExceptionHandler.sendAllToLLM
+    )
+
+    val (loop, _) = createLoop(
+      Seq(
+        AgentResponse(
+          "",
+          Seq(
+            ToolCall(id = "call_1", toolName = "calculator", input = """{"a":5,"b":10}"""),
+            ToolCall(id = "call_2", toolName = "calculator", input = """{"a":"bad","b":"input"}"""),
+            ToolCall(id = "call_3", toolName = "non_existing_tool", input = """{"a":3,"b":7}""")
+          ),
+          StopReason.ToolUse
+        ),
+        AgentResponse("Done", Seq.empty, StopReason.EndTurn)
+      ),
+      config
+    )
+
+    loop.run("Test")(backend)
+
+    results should contain inOrderOnly (
+      "Result: 15.0",
+      "Failed to parse arguments for tool 'calculator': $['a']",
+      "Tool not found: non_existing_tool"
+    )
   }
 }

--- a/core/src/test/scala/sttp/ai/core/agent/ConversationHistorySpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/ConversationHistorySpec.scala
@@ -70,7 +70,7 @@ class ConversationHistorySpec extends AnyFlatSpec with Matchers {
 
   "addToolResult" should "add tool result to history" in {
     val history = ConversationHistory.empty
-      .addToolResult("call_1", "calculator", "Result: 42")
+      .addToolResult(ToolCallRecord("call_1", "calculator", "{}", "Result: 42", 1))
 
     history.entries should have size 1
     history.entries.head shouldBe ConversationEntry.ToolResult("call_1", "calculator", "Result: 42")
@@ -80,7 +80,7 @@ class ConversationHistorySpec extends AnyFlatSpec with Matchers {
     val toolCall = ToolCall(id = "call_1", toolName = "calc", input = """{"x":"5"}""")
     val history = ConversationHistory.empty
       .addAssistantResponse("Calculating", Seq(toolCall))
-      .addToolResult("call_1", "calc", "5")
+      .addToolResult(ToolCallRecord("call_1", "calc", """{"x":"5"}""", "5", 1))
 
     history.entries should have size 2
     history.entries(0) shouldBe a[ConversationEntry.AssistantResponse]
@@ -123,8 +123,8 @@ class ConversationHistorySpec extends AnyFlatSpec with Matchers {
     val history = ConversationHistory
       .withInitialPrompt("Calculate 5+10 and get weather")
       .addAssistantResponse("I'll help with that", Seq(toolCall1, toolCall2))
-      .addToolResult("call_1", "calc", "15")
-      .addToolResult("call_2", "weather", "Sunny, 22C")
+      .addToolResult(ToolCallRecord("call_1", "calc", """{"x":"5"}""", "15", 1))
+      .addToolResult(ToolCallRecord("call_2", "weather", """{"city":"Paris"}""", "Sunny, 22C", 1))
       .addIterationMarker(2, 5)
       .addAssistantResponse("The result is 15 and it's sunny in Paris", Seq.empty)
 

--- a/examples/src/main/scala/examples/AgentLoopExample.scala
+++ b/examples/src/main/scala/examples/AgentLoopExample.scala
@@ -5,6 +5,7 @@ import sttp.ai.core.json.SnakePickle
 import sttp.ai.openai.OpenAI
 import sttp.ai.openai.agent.OpenAIAgent
 import sttp.client4.DefaultSyncBackend
+import sttp.shared.Identity
 import sttp.tapir.Schema
 
 object AgentLoopExample extends App {
@@ -39,7 +40,7 @@ object AgentLoopExample extends App {
   val tools = Seq(weatherTool, calculatorTool)
 
   val openai = OpenAI.fromEnv
-  private val config = AgentConfig(
+  private val config = AgentConfig[Identity](
     maxIterations = 8,
     userTools = tools
   )

--- a/examples/src/main/scala/examples/AgentLoopExample.scala
+++ b/examples/src/main/scala/examples/AgentLoopExample.scala
@@ -5,7 +5,6 @@ import sttp.ai.core.json.SnakePickle
 import sttp.ai.openai.OpenAI
 import sttp.ai.openai.agent.OpenAIAgent
 import sttp.client4.DefaultSyncBackend
-import sttp.shared.Identity
 import sttp.tapir.Schema
 
 object AgentLoopExample extends App {
@@ -40,10 +39,6 @@ object AgentLoopExample extends App {
   val tools = Seq(weatherTool, calculatorTool)
 
   val openai = OpenAI.fromEnv
-  private val config = AgentConfig[Identity](
-    maxIterations = 8,
-    userTools = tools
-  )
 
   println("=== Agent Loop Example ===\n")
 
@@ -53,7 +48,11 @@ object AgentLoopExample extends App {
 
   val backend = DefaultSyncBackend()
   try {
-    val agent = OpenAIAgent.synchronous(openai, "gpt-4o-mini", config)
+    val agent = OpenAIAgent
+      .synchronous(openai, "gpt-4o-mini")
+      .maxIterations(8)
+      .tools(tools)
+      .build
 
     val result = agent.run(prompt)(backend)
 

--- a/examples/src/main/scala/examples/TypedAgentLoopExample.scala
+++ b/examples/src/main/scala/examples/TypedAgentLoopExample.scala
@@ -5,7 +5,6 @@ import sttp.ai.core.json.SnakePickle
 import sttp.ai.openai.OpenAI
 import sttp.ai.openai.agent.OpenAIAgent
 import sttp.client4.DefaultSyncBackend
-import sttp.shared.Identity
 import sttp.tapir.Schema
 
 object TypedAgentLoopExample extends App {
@@ -32,16 +31,15 @@ object TypedAgentLoopExample extends App {
     s"${input.a} ${input.operation} ${input.b} = $result"
   }
 
-  val cfg = AgentConfig[Identity](
-    maxIterations = 8,
-    userTools = Seq(weatherTool, calculatorTool),
-    responseSchema = Some(ResponseSchema.derived[TripSummary]())
-  )
-
   val openai = OpenAI.fromEnv
   val backend = DefaultSyncBackend()
   try {
-    val agent = OpenAIAgent.synchronous(openai, "gpt-4o-mini", cfg)
+    val agent = OpenAIAgent
+      .synchronous(openai, "gpt-4o-mini")
+      .maxIterations(8)
+      .tools(weatherTool, calculatorTool)
+      .deriveResponseSchema[TripSummary]
+      .build
     val prompt = "What's the weather in Paris? Also, what is 15 multiplied by 23? Provide a complete answer."
 
     agent.runAs[TripSummary](prompt)(backend).finalAnswer match {

--- a/examples/src/main/scala/examples/TypedAgentLoopExample.scala
+++ b/examples/src/main/scala/examples/TypedAgentLoopExample.scala
@@ -5,6 +5,7 @@ import sttp.ai.core.json.SnakePickle
 import sttp.ai.openai.OpenAI
 import sttp.ai.openai.agent.OpenAIAgent
 import sttp.client4.DefaultSyncBackend
+import sttp.shared.Identity
 import sttp.tapir.Schema
 
 object TypedAgentLoopExample extends App {
@@ -31,7 +32,7 @@ object TypedAgentLoopExample extends App {
     s"${input.a} ${input.operation} ${input.b} = $result"
   }
 
-  val cfg = AgentConfig(
+  val cfg = AgentConfig[Identity](
     maxIterations = 8,
     userTools = Seq(weatherTool, calculatorTool),
     responseSchema = Some(ResponseSchema.derived[TripSummary]())

--- a/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
+++ b/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
@@ -137,45 +137,26 @@ private[openai] class OpenAIAgentBackend[F[_]](
 }
 
 object OpenAIAgent {
-  def apply[F[_]](
-      apiKey: String,
-      modelName: String,
-      config: AgentConfig[F]
-  )(implicit monad: sttp.monad.MonadError[F]): Agent[F] = {
-    val backend = new OpenAIAgentBackend[F](
-      new OpenAI(apiKey),
-      modelName,
-      config.userTools,
-      config.systemPrompt,
-      config.responseSchema
-    )
-    Agent(backend, config)
-  }
 
-  def apply[F[_]](
+  def builder[F[_]](
       openAI: OpenAI,
-      modelName: String,
-      config: AgentConfig[F]
-  )(implicit monad: sttp.monad.MonadError[F]): Agent[F] = {
-    val backend = new OpenAIAgentBackend[F](
-      openAI,
-      modelName,
-      config.userTools,
-      config.systemPrompt,
-      config.responseSchema
-    )
-    Agent(backend, config)
-  }
+      modelName: String
+  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
+    AgentBuilder[F](config => new OpenAIAgentBackend[F](openAI, modelName, config.userTools, config.systemPrompt, config.responseSchema))
 
-  def synchronous(
+  def builder[F[_]](
       apiKey: String,
-      modelName: String,
-      config: AgentConfig[Identity]
-  ): Agent[Identity] = apply(apiKey, modelName, config)(IdentityMonad)
+      modelName: String
+  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
+    builder(new OpenAI(apiKey), modelName)
 
   def synchronous(
       openAI: OpenAI,
-      modelName: String,
-      config: AgentConfig[Identity]
-  ): Agent[Identity] = apply(openAI, modelName, config)(IdentityMonad)
+      modelName: String
+  ): AgentBuilder[Identity] = builder[Identity](openAI, modelName)(IdentityMonad)
+
+  def synchronous(
+      apiKey: String,
+      modelName: String
+  ): AgentBuilder[Identity] = builder[Identity](apiKey, modelName)(IdentityMonad)
 }

--- a/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
+++ b/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
@@ -140,7 +140,7 @@ object OpenAIAgent {
   def apply[F[_]](
       apiKey: String,
       modelName: String,
-      config: AgentConfig
+      config: AgentConfig[F]
   )(implicit monad: sttp.monad.MonadError[F]): Agent[F] = {
     val backend = new OpenAIAgentBackend[F](
       new OpenAI(apiKey),
@@ -155,7 +155,7 @@ object OpenAIAgent {
   def apply[F[_]](
       openAI: OpenAI,
       modelName: String,
-      config: AgentConfig
+      config: AgentConfig[F]
   )(implicit monad: sttp.monad.MonadError[F]): Agent[F] = {
     val backend = new OpenAIAgentBackend[F](
       openAI,
@@ -170,12 +170,12 @@ object OpenAIAgent {
   def synchronous(
       apiKey: String,
       modelName: String,
-      config: AgentConfig
+      config: AgentConfig[Identity]
   ): Agent[Identity] = apply(apiKey, modelName, config)(IdentityMonad)
 
   def synchronous(
       openAI: OpenAI,
       modelName: String,
-      config: AgentConfig
+      config: AgentConfig[Identity]
   ): Agent[Identity] = apply(openAI, modelName, config)(IdentityMonad)
 }

--- a/openai/src/test/scala/sttp/ai/openai/integration/OpenAIAgentIntegrationSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/integration/OpenAIAgentIntegrationSpec.scala
@@ -31,11 +31,11 @@ class OpenAIAgentIntegrationSpec extends AgentIntegrationSpecBase {
       responseSchema: ResponseSchema[T]
   ): Agent[Identity] = {
     val openai = OpenAI.fromEnv
-    val agentConfig = AgentConfig[Identity](
-      maxIterations = maxIterations,
-      userTools = tools,
-      responseSchema = Some(responseSchema)
-    )
-    OpenAIAgent.synchronous(openai, "gpt-4o-mini", agentConfig)
+    OpenAIAgent
+      .synchronous(openai, "gpt-4o-mini")
+      .maxIterations(maxIterations)
+      .tools(tools)
+      .responseSchema(responseSchema)
+      .build
   }
 }

--- a/openai/src/test/scala/sttp/ai/openai/integration/OpenAIAgentIntegrationSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/integration/OpenAIAgentIntegrationSpec.scala
@@ -14,7 +14,7 @@ class OpenAIAgentIntegrationSpec extends AgentIntegrationSpecBase {
 
   override def createAgent(maxIterations: Int, tools: Seq[AgentTool[_]]): Agent[Identity] = {
     val openai = OpenAI.fromEnv
-    val agentConfig = AgentConfig(maxIterations = maxIterations, userTools = tools)
+    val agentConfig = AgentConfig[Identity](maxIterations = maxIterations, userTools = tools)
     val agentBackend = new OpenAIAgentBackend[Identity](
       openai,
       "gpt-4o-mini",
@@ -31,7 +31,7 @@ class OpenAIAgentIntegrationSpec extends AgentIntegrationSpecBase {
       responseSchema: ResponseSchema[T]
   ): Agent[Identity] = {
     val openai = OpenAI.fromEnv
-    val agentConfig = AgentConfig(
+    val agentConfig = AgentConfig[Identity](
       maxIterations = maxIterations,
       userTools = tools,
       responseSchema = Some(responseSchema)


### PR DESCRIPTION
Configurable and effectful `beforeToolCall` and `afterToolCall` hooks. These can be used for example for logging. This change pushes the `F` parameter into new places. 