### PR TITLE
Preserve base-URI query parameters and harden error handling for OpenAI-compatible APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ metals.sbt
 
 # Claude Code
 .claude/settings.local.json
+
+.orca
+.devcontainer

--- a/openai/src/main/scala/sttp/ai/openai/OpenAI.scala
+++ b/openai/src/main/scala/sttp/ai/openai/OpenAI.scala
@@ -1628,31 +1628,34 @@ object OpenAI {
 }
 
 private class OpenAIUris(val baseUri: Uri) {
-  private val imageBase: Uri = uri"$baseUri/images"
-  private val audioBase: Uri = uri"$baseUri/audio/"
+  // Endpoint URIs are built by appending path segments to baseUri (via addPath) rather than string-interpolating the segments
+  // after $baseUri. This keeps any query string present on baseUri (e.g. Azure's ?api-version=...) attached after the full path,
+  // instead of producing .../?api-version=.../chat/completions.
+  private val imageBase: Uri = baseUri.addPath("images")
+  private val audioBase: Uri = baseUri.addPath("audio")
 
-  val ChatCompletions: Uri = uri"$baseUri/chat/completions"
-  val Completions: Uri = uri"$baseUri/completions"
+  val ChatCompletions: Uri = baseUri.addPath("chat", "completions")
+  val Completions: Uri = baseUri.addPath("completions")
   val CreateImage: Uri = imageBase.addPath("generations")
-  val Embeddings: Uri = uri"$baseUri/embeddings"
+  val Embeddings: Uri = baseUri.addPath("embeddings")
   val EditImage: Uri = imageBase.addPath("edits")
-  val Files: Uri = uri"$baseUri/files"
-  val Models: Uri = uri"$baseUri/models"
-  val Moderations: Uri = uri"$baseUri/moderations"
-  val FineTuningJobs: Uri = uri"$baseUri/fine_tuning/jobs"
-  val Batches: Uri = uri"$baseUri/batches"
-  val Uploads: Uri = uri"$baseUri/uploads"
-  val AdminApiKeys: Uri = uri"$baseUri/organization/admin_api_keys"
+  val Files: Uri = baseUri.addPath("files")
+  val Models: Uri = baseUri.addPath("models")
+  val Moderations: Uri = baseUri.addPath("moderations")
+  val FineTuningJobs: Uri = baseUri.addPath("fine_tuning", "jobs")
+  val Batches: Uri = baseUri.addPath("batches")
+  val Uploads: Uri = baseUri.addPath("uploads")
+  val AdminApiKeys: Uri = baseUri.addPath("organization", "admin_api_keys")
   val Transcriptions: Uri = audioBase.addPath("transcriptions")
   val Translations: Uri = audioBase.addPath("translations")
   val Speech: Uri = audioBase.addPath("speech")
   val VariationsImage: Uri = imageBase.addPath("variations")
-  val Responses: Uri = uri"$baseUri/responses"
+  val Responses: Uri = baseUri.addPath("responses")
 
-  val Assistants: Uri = uri"$baseUri/assistants"
-  val Threads: Uri = uri"$baseUri/threads"
-  val ThreadsRuns: Uri = uri"$baseUri/threads/runs"
-  val VectorStores: Uri = uri"$baseUri/vector_stores"
+  val Assistants: Uri = baseUri.addPath("assistants")
+  val Threads: Uri = baseUri.addPath("threads")
+  val ThreadsRuns: Uri = baseUri.addPath("threads", "runs")
+  val VectorStores: Uri = baseUri.addPath("vector_stores")
 
   def upload(uploadId: String): Uri = Uploads.addPath(uploadId)
   def uploadParts(uploadId: String): Uri = upload(uploadId).addPath("parts")

--- a/openai/src/main/scala/sttp/ai/openai/json/SttpUpickleApiExtension.scala
+++ b/openai/src/main/scala/sttp/ai/openai/json/SttpUpickleApiExtension.scala
@@ -57,14 +57,27 @@ object SttpUpickleApiExtension extends SttpUpickleApi with ResponseHandlers[Open
       }
       .showAs("either(as error, as string)")
 
+  /** Max number of characters of a raw error body kept as the fallback message when it can't be parsed as a standard OpenAI error. */
+  private val MaxRawErrorBodyLength = 500
+
   private def httpToOpenAIError(he: UnexpectedStatusCode[String]): OpenAIException = {
+    // Fallback for bodies that aren't the standard {"error": {...}} OpenAI shape (e.g. Azure's {"statusCode":...,"message":...},
+    // a non-object JSON root, or non-JSON): expose a truncated raw body and the status code rather than throwing.
+    val fallback = (Some(he.body.take(MaxRawErrorBodyLength)), None, None, Some(he.response.code.toString))
+
     val (message, tpe, param, code) =
-      try {
-        val errorMessageBody = upickleApi.read[ujson.Value](he.body).apply("error")
-        val error = upickleApi.read[Error](errorMessageBody)
-        (error.message, error.`type`, error.param, error.code)
-      } catch {
-        case _: ujson.ParseException => (None, None, None, None)
+      try
+        upickleApi
+          .read[ujson.Value](he.body)
+          .objOpt
+          .flatMap(_.get("error")) match {
+          case Some(errorNode) =>
+            val error = upickleApi.read[Error](errorNode)
+            (error.message, error.`type`, error.param, error.code)
+          case None => fallback
+        }
+      catch {
+        case _: Exception => fallback
       }
 
     he.response.code match {

--- a/openai/src/test/scala/sttp/ai/openai/openai/OpenAIUrisSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/OpenAIUrisSpec.scala
@@ -1,0 +1,37 @@
+package sttp.ai.openai
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.client4._
+import sttp.model.Uri
+
+class OpenAIUrisSpec extends AnyFlatSpec with Matchers {
+  private val azureBase: Uri = uri"https://x.openai.azure.com/openai/deployments/y?api-version=2024-10-21"
+  private val plainBase: Uri = uri"https://api.openai.com/v1"
+
+  "OpenAIUris with a base URI carrying a query string" should "keep the query after the path on every endpoint" in {
+    val uris = new OpenAIUris(azureBase)
+
+    uris.ChatCompletions.toString shouldBe
+      "https://x.openai.azure.com/openai/deployments/y/chat/completions?api-version=2024-10-21": Unit
+    uris.Embeddings.toString shouldBe
+      "https://x.openai.azure.com/openai/deployments/y/embeddings?api-version=2024-10-21": Unit
+    uris.Models.toString shouldBe
+      "https://x.openai.azure.com/openai/deployments/y/models?api-version=2024-10-21": Unit
+    uris.Transcriptions.toString shouldBe
+      "https://x.openai.azure.com/openai/deployments/y/audio/transcriptions?api-version=2024-10-21": Unit
+    uris.CreateImage.toString shouldBe
+      "https://x.openai.azure.com/openai/deployments/y/images/generations?api-version=2024-10-21": Unit
+
+    uris.ChatCompletions.params.get("api-version") shouldBe Some("2024-10-21")
+  }
+
+  "OpenAIUris with a plain base URI" should "build endpoint paths without a query" in {
+    val uris = new OpenAIUris(plainBase)
+
+    uris.ChatCompletions.toString shouldBe "https://api.openai.com/v1/chat/completions": Unit
+    uris.Embeddings.toString shouldBe "https://api.openai.com/v1/embeddings": Unit
+    uris.Models.toString shouldBe "https://api.openai.com/v1/models": Unit
+    uris.Transcriptions.toString shouldBe "https://api.openai.com/v1/audio/transcriptions"
+  }
+}

--- a/openai/src/test/scala/sttp/ai/openai/openai/client/SyncClientSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/client/SyncClientSpec.scala
@@ -3,6 +3,7 @@ package sttp.ai.openai.client
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.client4.ResponseException.UnexpectedStatusCode
 import sttp.client4._
 import sttp.client4.testing.ResponseStub
 import sttp.model.StatusCode
@@ -37,6 +38,103 @@ class SyncClientSpec extends AnyFlatSpec with Matchers with EitherValues {
       caught.param shouldBe expectedError.param: Unit
       caught.`type` shouldBe expectedError.`type`
     }
+
+  "Service response with an Azure-style error body" should "fall back to the raw body and status code" in {
+    // given
+    val azureBody = """{"statusCode":404,"message":"Resource not found"}"""
+    val syncBackendStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondAdjust(azureBody, NotFound)
+    val syncClient = OpenAISyncClient(authToken = "test-token", backend = syncBackendStub)
+
+    // when
+    val caught = intercept[OpenAIException](syncClient.getModels)
+
+    // then
+    caught.getClass shouldBe classOf[OpenAIException.InvalidRequestException]: Unit
+    caught.message shouldBe Some(azureBody): Unit
+    caught.code shouldBe Some(NotFound.code.toString): Unit
+    caught.param shouldBe None: Unit
+    caught.`type` shouldBe None: Unit
+    caught.cause.getClass shouldBe classOf[UnexpectedStatusCode[String]]
+  }
+
+  "Service response with a non-object JSON root" should "fall back to the raw body and status code" in {
+    // given
+    val arrayBody = """["unexpected","array"]"""
+    val syncBackendStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondAdjust(arrayBody, BadRequest)
+    val syncClient = OpenAISyncClient(authToken = "test-token", backend = syncBackendStub)
+
+    // when
+    val caught = intercept[OpenAIException](syncClient.getModels)
+
+    // then
+    caught.getClass shouldBe classOf[OpenAIException.InvalidRequestException]: Unit
+    caught.message shouldBe Some(arrayBody): Unit
+    caught.code shouldBe Some(BadRequest.code.toString): Unit
+    caught.param shouldBe None: Unit
+    caught.`type` shouldBe None
+  }
+
+  "Service response with a malformed non-JSON body" should "fall back to the raw body and status code" in {
+    // given
+    val malformedBody = "not even json <html>500</html>"
+    val syncBackendStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondAdjust(malformedBody, ServiceUnavailable)
+    val syncClient = OpenAISyncClient(authToken = "test-token", backend = syncBackendStub)
+
+    // when
+    val caught = intercept[OpenAIException](syncClient.getModels)
+
+    // then
+    caught.getClass shouldBe classOf[OpenAIException.ServiceUnavailableException]: Unit
+    caught.message shouldBe Some(malformedBody): Unit
+    caught.code shouldBe Some(ServiceUnavailable.code.toString)
+  }
+
+  "Service response with an error body longer than the max" should "truncate the fallback message" in {
+    // given
+    val longBody = "x" * 600
+    val syncBackendStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondAdjust(longBody, BadRequest)
+    val syncClient = OpenAISyncClient(authToken = "test-token", backend = syncBackendStub)
+
+    // when
+    val caught = intercept[OpenAIException](syncClient.getModels)
+
+    // then
+    caught.message.map(_.length) shouldBe Some(500): Unit
+    caught.message shouldBe Some(longBody.take(500))
+  }
+
+  "Service response with a present but malformed error node" should "fall back to the raw body and status code" in {
+    // given
+    val malformedErrorBody = """{"error":"unstructured string"}"""
+    val syncBackendStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondAdjust(malformedErrorBody, BadRequest)
+    val syncClient = OpenAISyncClient(authToken = "test-token", backend = syncBackendStub)
+
+    // when
+    val caught = intercept[OpenAIException](syncClient.getModels)
+
+    // then
+    caught.getClass shouldBe classOf[OpenAIException.InvalidRequestException]: Unit
+    caught.message shouldBe Some(malformedErrorBody): Unit
+    caught.code shouldBe Some(BadRequest.code.toString): Unit
+    caught.param shouldBe None: Unit
+    caught.`type` shouldBe None
+  }
+
+  "Service response with the standard OpenAI error body" should "still map to the right subclass with parsed fields" in {
+    // given
+    val syncBackendStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondAdjust(ErrorFixture.errorResponse, Unauthorized)
+    val syncClient = OpenAISyncClient(authToken = "test-token", backend = syncBackendStub)
+
+    // when
+    val caught = intercept[OpenAIException](syncClient.getModels)
+
+    // then
+    caught.getClass shouldBe classOf[OpenAIException.AuthenticationException]: Unit
+    caught.message shouldBe Some("Some error message."): Unit
+    caught.`type` shouldBe Some("error_type"): Unit
+    caught.param shouldBe None: Unit
+    caught.code shouldBe Some("invalid_api_key")
+  }
 
   "Fetching models with successful response" should "return properly deserialized list of available models" in {
     // given


### PR DESCRIPTION
This change addresses compatibility with OpenAI-compatible APIs like Azure that include query parameters in the base URL (e.g., `?api-version=...`). Previously, endpoint paths were constructed via string interpolation, which would place query parameters in the middle of the URL rather than at the end.

**URI Construction**: All endpoint URIs now use `baseUri.addPath()` instead of string interpolation. This ensures that any query parameters present on the base URI remain at the end of the final URL, after all path segments are appended. Azure deployments, which require `?api-version=...` in all requests, now work correctly.

**Error Handling**: The error parsing logic is now more robust against non-standard error responses. It handles Azure-style errors, non-object JSON roots, malformed JSON, and invalid error node structures by falling back to exposing the raw error body (truncated to 500 characters) and HTTP status code. Standard OpenAI error responses continue to parse and map to the correct exception subclasses.

**Tests**: Added comprehensive test coverage for URI construction with Azure-style base URIs and new test cases for each error response variant.