### PR TITLE
Update dependencies and sbt plugins to latest versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val examples = (projectMatrix in file("examples"))
   .settings(
     libraryDependencies ++= Seq(
       "com.softwaremill.sttp.tapir" %% "tapir-netty-server-sync" % V.tapir,
-      "ch.qos.logback" % "logback-classic" % "1.5.6"
+      "ch.qos.logback" % "logback-classic" % "1.5.35"
     ) ++ Libraries.sttpClientOx,
     publish / skip := true
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,16 +4,16 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport.*
 object Dependencies {
 
   object V {
-    val scalaTest = "3.2.19"
-    val scalaTestCats = "1.7.0"
+    val scalaTest = "3.2.20"
+    val scalaTestCats = "1.8.0"
 
     val sttpApispec = "0.11.10"
-    val sttpClient = "4.0.18"
-    val pekkoStreams = "1.2.1"
-    val akkaStreams = "2.6.20"
-    val tapir = "1.13.8"
-    val circe = "0.14.14"
-    val circeGenericExtras = "0.14.4"
+    val sttpClient = "4.0.25"
+    val pekkoStreams = "1.6.0"
+    val akkaStreams = "2.6.20" // last Apache-2.0 licensed Akka release; 2.7+ is under the BSL
+    val tapir = "1.13.23"
+    val circe = "0.14.16"
+    val circeGenericExtras = "0.14.4" // 0.14.5 is only available as RC
   }
 
   object Libraries {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.7
+sbt.version=1.12.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-val sbtSoftwareMillVersion = "2.1.1"
+val sbtSoftwareMillVersion = "2.1.2"
 addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill-common" % sbtSoftwareMillVersion)
 addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill-publish" % sbtSoftwareMillVersion)
 addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.11.0")
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.7.2")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.9")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.9.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")


### PR DESCRIPTION
Routine dependency and plugin maintenance.

## Dependencies
| Dependency | From | To |
|---|---|---|
| sttp-client4 | 4.0.18 | 4.0.25 |
| tapir | 1.13.8 | 1.13.23 |
| circe | 0.14.14 | 0.14.16 |
| pekko-stream | 1.2.1 | 1.6.0 |
| scalatest | 3.2.19 | 3.2.20 |
| cats-effect-testing-scalatest | 1.7.0 | 1.8.0 |
| logback-classic | 1.5.6 | 1.5.35 |

## Plugins / build
| Item | From | To |
|---|---|---|
| sbt | 1.11.7 | 1.12.13 |
| sbt-softwaremill | 2.1.1 | 2.1.2 |
| sbt-mdoc | 2.7.2 | 2.9.0 |
| sbt-scala-native | 0.5.9 | 0.5.12 |

## Deliberately held back
- **akka-stream** stays at `2.6.20` — Akka 2.7+ switched from Apache-2.0 to the BSL license; 2.6.20 is the last Apache-licensed release.
- **sbt** kept on latest `1.x` rather than `2.0.0` (major migration).
- **circe-generic-extras** stays at `0.14.4` — newer is RC only.
- **circe** stays on `0.14.x` — `0.15.0` is a milestone only.
- **Scala versions** (2.13.18 / 3.3.6 LTS) untouched.

## Verification
- `sbt compile` — succeeds (pre-existing warnings only)
- `sbt test` — all 89 unit tests pass
- `sbt scalafmtCheckAll` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)