### PR TITLE
docs: clarify max_tokens vs max_completion_tokens for GPT-5/reasoning models

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ object Main:
     */
 ```
 
+> **Token limits on GPT-5 / reasoning models:** newer OpenAI reasoning models (GPT-5, o1, o3, ...) reject the `max_tokens`
+> parameter with `Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.`
+> For these models leave `maxTokens = None` and set `maxCompletionTokens`:
+>
+> ```scala
+> val chatRequestBody = ChatBody(
+>   model = ChatCompletionModel.GPT5,
+>   messages = bodyMessages,
+>   maxCompletionTokens = Some(1000)
+> )
+> ```
+
 ## Claude API
 
 This module provides **native support for Anthropic's Claude API** within the sttp-openai library. Unlike OpenAI compatibility layers, this provides direct access to Claude's unique features and API structure.

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestBody.scala
@@ -50,7 +50,9 @@ object ChatRequestBody {
     * @param logitBias
     *   Modify the likelihood of specified tokens appearing in the completion.
     * @param maxTokens
-    *   The maximum number of tokens to generate in the chat completion.
+    *   The maximum number of tokens to generate in the chat completion. Note: newer reasoning models (GPT-5, o1, o3, ...) reject
+    *   `max_tokens` and return "Unsupported parameter: 'max_tokens'...". For those models leave this as `None` and set
+    *   `maxCompletionTokens` instead.
     * @param n
     *   How many chat completion choices to generate for each input message.
     * @param presencePenalty
@@ -95,7 +97,7 @@ object ChatRequestBody {
     *   log probability. logprobs must be set to true if this parameter is used.
     * @param maxCompletionTokens
     *   An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning
-    *   tokens.
+    *   tokens. Use this instead of `maxTokens` for reasoning models (GPT-5, o1, o3, ...), which reject `max_tokens`.
     * @param modalities
     *   Output types that you would like the model to generate for this request. Most models are capable of generating text, which is the
     *   default: ["text"]. The gpt-4o-audio-preview model can also be used to generate audio. To request that this model generate both text


### PR DESCRIPTION
Reasoning models (GPT-5, o1, o3, ...) reject `max_tokens` and require `max_completion_tokens`. Cross-reference the two ChatBody scaladoc params and add a README callout with a GPT-5 example. Closes #490.