### PR TITLE
fix: remove ivy2Local directive from examples to unbreak Scala Steward

### DIFF
--- a/examples/src/main/scala/examples/ClaudeBasicExample.scala
+++ b/examples/src/main/scala/examples/ClaudeBasicExample.scala
@@ -1,4 +1,3 @@
-//> using repository ivy2Local
 //> using dep com.softwaremill.sttp.ai::claude:0.4.0
 //> using dep ch.qos.logback:logback-classic:1.5.19
 

--- a/examples/src/main/scala/examples/ClaudeImageAnalysisExample.scala
+++ b/examples/src/main/scala/examples/ClaudeImageAnalysisExample.scala
@@ -1,4 +1,3 @@
-//> using repository ivy2Local
 //> using dep com.softwaremill.sttp.ai::claude:0.4.0
 //> using dep ch.qos.logback:logback-classic:1.5.19
 

--- a/examples/src/main/scala/examples/ClaudeStructuredOutputExample.scala
+++ b/examples/src/main/scala/examples/ClaudeStructuredOutputExample.scala
@@ -1,4 +1,3 @@
-//> using repository ivy2Local
 //> using dep com.softwaremill.sttp.ai::claude:0.4.0
 //> using dep ch.qos.logback:logback-classic:1.5.19
 

--- a/examples/src/main/scala/examples/ClaudeToolCallingExample.scala
+++ b/examples/src/main/scala/examples/ClaudeToolCallingExample.scala
@@ -1,4 +1,3 @@
-//> using repository ivy2Local
 //> using dep com.softwaremill.sttp.ai::claude:0.4.0
 //> using dep ch.qos.logback:logback-classic:1.5.19
 

--- a/examples/src/main/scala/examples/OpenAIStructuredOutputExample.scala
+++ b/examples/src/main/scala/examples/OpenAIStructuredOutputExample.scala
@@ -1,4 +1,3 @@
-//> using repository ivy2Local
 //> using dep com.softwaremill.sttp.ai::openai:0.4.0
 //> using dep ch.qos.logback:logback-classic:1.5.19
 


### PR DESCRIPTION
Scala Steward detects the //> using dep directives and exports the repo with 'scala-cli export --sbt'. The ivy2Local repository directive makes that export emit 'Resolver.url(...) artifacts ...' resolvers, which no longer compile since scala-cli 1.15.0 switched the export default to sbt 2. The directive is unnecessary for the committed examples, which reference released artifacts.