### PR TITLE
Label Scala Steward PRs that update scala-cli dep directives

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,6 +7,8 @@ labels:
       - "project/plugins.sbt"
       - "project/build.properties"
       - "project/Dependencies.scala"
+      # sbt-built sources only: CI compiles these, so green build = safe to merge
+      - "examples/src/main/scala/.*\\.scala"
   - label: "dependency"
     authors: ["softwaremill-ci"]
     files:
@@ -14,3 +16,6 @@ labels:
       - "project/plugins.sbt"
       - "project/build.properties"
       - "project/Dependencies.scala"
+      - "examples/src/main/scala/.*\\.scala"
+      # scala-cli scripts are not compiled by CI, so no automerge for these
+      - "model_update_scripts/.*\\.scala"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,8 +7,9 @@ labels:
       - "project/plugins.sbt"
       - "project/build.properties"
       - "project/Dependencies.scala"
-      # sbt-built sources only: CI compiles these, so green build = safe to merge
+      # CI verifies the scala-cli dep directives in these via verify*CompileUsingScalaCli
       - "examples/src/main/scala/.*\\.scala"
+      - "model_update_scripts/.*\\.scala"
       # scalafmt-core updates: CI's scalafmtCheckAll blocks merge on formatting drift
       - "\\.scalafmt\\.conf"
   - label: "dependency"
@@ -19,6 +20,5 @@ labels:
       - "project/build.properties"
       - "project/Dependencies.scala"
       - "examples/src/main/scala/.*\\.scala"
-      - "\\.scalafmt\\.conf"
-      # scala-cli scripts are not compiled by CI, so no automerge for these
       - "model_update_scripts/.*\\.scala"
+      - "\\.scalafmt\\.conf"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,10 +7,8 @@ labels:
       - "project/plugins.sbt"
       - "project/build.properties"
       - "project/Dependencies.scala"
-      # CI verifies the scala-cli dep directives in these via verify*CompileUsingScalaCli
       - "examples/src/main/scala/.*\\.scala"
       - "model_update_scripts/.*\\.scala"
-      # scalafmt-core updates: CI's scalafmtCheckAll blocks merge on formatting drift
       - "\\.scalafmt\\.conf"
   - label: "dependency"
     authors: ["softwaremill-ci"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,6 +9,8 @@ labels:
       - "project/Dependencies.scala"
       # sbt-built sources only: CI compiles these, so green build = safe to merge
       - "examples/src/main/scala/.*\\.scala"
+      # scalafmt-core updates: CI's scalafmtCheckAll blocks merge on formatting drift
+      - "\\.scalafmt\\.conf"
   - label: "dependency"
     authors: ["softwaremill-ci"]
     files:
@@ -17,5 +19,6 @@ labels:
       - "project/build.properties"
       - "project/Dependencies.scala"
       - "examples/src/main/scala/.*\\.scala"
+      - "\\.scalafmt\\.conf"
       # scala-cli scripts are not compiled by CI, so no automerge for these
       - "model_update_scripts/.*\\.scala"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
         java-version: '21'
         cache: 'sbt'
     - uses: sbt/setup-sbt@66fb4376e81982c7d92a4074170846fff88e2e30 # v1, specifically v1.5.0
+    - name: Install scala-cli
+      uses: VirtusLab/scala-cli-setup@d320e01a605bf27128a5657575382668f83ef34e # main, specifically v1.14.0
+      with:
+        jvm: '' # needed because scala-cli-setup otherwise forces the installation of their default JVM (17)
     - name: Install native dependencies
       run: |
         sudo apt-get update
@@ -35,6 +39,10 @@ jobs:
       run: sbt -v compile
     - name: Compile documentation
       run: sbt -v compileDocumentation
+    - name: Verify that examples compile using Scala CLI
+      run: sbt -v verifyExamplesCompileUsingScalaCli
+    - name: Verify that model update scripts compile using Scala CLI
+      run: sbt -v verifyModelUpdateScriptsCompileUsingScalaCli
     - name: Test
       run: sbt -v test
     - uses: actions/upload-artifact@v7  # upload test results

--- a/build.sbt
+++ b/build.sbt
@@ -152,6 +152,16 @@ val compileDocumentation: TaskKey[Unit] = taskKey[Unit]("Compiles docs module th
 compileDocumentation :=
   (docs.jvm(scala3.head) / mdoc).toTask(" --out target/sttp-ai-docs").value
 
+// verify the scala-cli `//> using dep` directives, which are not covered by the sbt build
+val verifyExamplesCompileUsingScalaCli: TaskKey[Unit] = taskKey[Unit]("Verify that each example compiles using Scala CLI")
+verifyExamplesCompileUsingScalaCli :=
+  VerifyExamplesCompileUsingScalaCli(sLog.value, (examples.jvm(scala3.head) / sourceDirectory).value)
+
+val verifyModelUpdateScriptsCompileUsingScalaCli: TaskKey[Unit] =
+  taskKey[Unit]("Verify that each model update script compiles using Scala CLI")
+verifyModelUpdateScriptsCompileUsingScalaCli :=
+  VerifyExamplesCompileUsingScalaCli(sLog.value, file("model_update_scripts"))
+
 lazy val docs = (projectMatrix in file("generated-docs")) // important: it must not be docs/
   .enablePlugins(MdocPlugin)
   .settings(commonSettings)
@@ -165,11 +175,16 @@ lazy val docs = (projectMatrix in file("generated-docs")) // important: it must 
     mdocExtraArguments := Seq(
       "--clean-target",
       "--disable-using-directives",
-      "--exclude", ".venv",
-      "--exclude", "_build",
-      "--exclude", "adr",
-      "--exclude", "plans",
-      "--exclude", "superpowers"
+      "--exclude",
+      ".venv",
+      "--exclude",
+      "_build",
+      "--exclude",
+      "adr",
+      "--exclude",
+      "plans",
+      "--exclude",
+      "superpowers"
     ),
     publishArtifact := false,
     name := "docs",

--- a/examples/src/main/scala/examples/AgentLoopExample.scala
+++ b/examples/src/main/scala/examples/AgentLoopExample.scala
@@ -1,3 +1,6 @@
+//> using dep com.softwaremill.sttp.ai::openai:0.5.2
+//> using dep ch.qos.logback:logback-classic:1.5.38
+
 package examples
 
 import sttp.ai.core.agent.*

--- a/examples/src/main/scala/examples/ChatProxy.scala
+++ b/examples/src/main/scala/examples/ChatProxy.scala
@@ -1,7 +1,7 @@
-//> using dep com.softwaremill.sttp.ai::ox:0.4.0
-//> using dep com.softwaremill.sttp.tapir::tapir-netty-server-sync:1.11.48
-//> using dep com.softwaremill.sttp.client4::ox:4.0.12
-//> using dep ch.qos.logback:logback-classic:1.5.19
+//> using dep com.softwaremill.sttp.ai::ox:0.5.2
+//> using dep com.softwaremill.sttp.tapir::tapir-netty-server-sync:1.13.28
+//> using dep com.softwaremill.sttp.client4::ox:4.0.26
+//> using dep ch.qos.logback:logback-classic:1.5.38
 
 // remember to set the OPENAI_API_KEY env variable!
 // run with: OPENAI_API_KEY=... scala-cli run ChatProxy.scala

--- a/examples/src/main/scala/examples/ClaudeBasicExample.scala
+++ b/examples/src/main/scala/examples/ClaudeBasicExample.scala
@@ -1,5 +1,5 @@
-//> using dep com.softwaremill.sttp.ai::claude:0.4.0
-//> using dep ch.qos.logback:logback-classic:1.5.19
+//> using dep com.softwaremill.sttp.ai::claude:0.5.2
+//> using dep ch.qos.logback:logback-classic:1.5.38
 
 // remember to set the ANTHROPIC_API_KEY env variable!
 // run with: ANTHROPIC_API_KEY=... scala-cli run ClaudeBasicExample.scala

--- a/examples/src/main/scala/examples/ClaudeImageAnalysisExample.scala
+++ b/examples/src/main/scala/examples/ClaudeImageAnalysisExample.scala
@@ -1,5 +1,5 @@
-//> using dep com.softwaremill.sttp.ai::claude:0.4.0
-//> using dep ch.qos.logback:logback-classic:1.5.19
+//> using dep com.softwaremill.sttp.ai::claude:0.5.2
+//> using dep ch.qos.logback:logback-classic:1.5.38
 
 // remember to set the ANTHROPIC_API_KEY env variable!
 // run with: ANTHROPIC_API_KEY=... scala-cli run ClaudeImageAnalysisExample.scala

--- a/examples/src/main/scala/examples/ClaudeStructuredOutputExample.scala
+++ b/examples/src/main/scala/examples/ClaudeStructuredOutputExample.scala
@@ -1,5 +1,5 @@
-//> using dep com.softwaremill.sttp.ai::claude:0.4.0
-//> using dep ch.qos.logback:logback-classic:1.5.19
+//> using dep com.softwaremill.sttp.ai::claude:0.5.2
+//> using dep ch.qos.logback:logback-classic:1.5.38
 
 // remember to set the ANTHROPIC_API_KEY env variable!
 // run with: ANTHROPIC_API_KEY=... scala-cli run ClaudeStructuredOutputExample.scala

--- a/examples/src/main/scala/examples/ClaudeToolCallingExample.scala
+++ b/examples/src/main/scala/examples/ClaudeToolCallingExample.scala
@@ -1,5 +1,5 @@
-//> using dep com.softwaremill.sttp.ai::claude:0.4.0
-//> using dep ch.qos.logback:logback-classic:1.5.19
+//> using dep com.softwaremill.sttp.ai::claude:0.5.2
+//> using dep ch.qos.logback:logback-classic:1.5.38
 
 // remember to set the ANTHROPIC_API_KEY env variable!
 // run with: ANTHROPIC_API_KEY=... scala-cli run ClaudeToolCallingExample.scala

--- a/examples/src/main/scala/examples/OpenAIStructuredOutputExample.scala
+++ b/examples/src/main/scala/examples/OpenAIStructuredOutputExample.scala
@@ -1,5 +1,5 @@
-//> using dep com.softwaremill.sttp.ai::openai:0.4.0
-//> using dep ch.qos.logback:logback-classic:1.5.19
+//> using dep com.softwaremill.sttp.ai::openai:0.5.2
+//> using dep ch.qos.logback:logback-classic:1.5.38
 
 // remember to set the OPENAI_API_KEY env variable!
 // run with: OPENAI_API_KEY=... scala-cli run OpenAIStructuredOutputExample.scala

--- a/examples/src/main/scala/examples/StrictStructuredFunctionCallingExample.scala
+++ b/examples/src/main/scala/examples/StrictStructuredFunctionCallingExample.scala
@@ -1,3 +1,6 @@
+//> using dep com.softwaremill.sttp.ai::openai:0.5.2
+//> using dep ch.qos.logback:logback-classic:1.5.38
+
 package examples
 
 /** Manual playground for the strict structured outputs for function calling feature (`strict = true`).

--- a/examples/src/main/scala/examples/TypedAgentLoopExample.scala
+++ b/examples/src/main/scala/examples/TypedAgentLoopExample.scala
@@ -1,3 +1,6 @@
+//> using dep com.softwaremill.sttp.ai::openai:0.5.2
+//> using dep ch.qos.logback:logback-classic:1.5.38
+
 package examples
 
 import sttp.ai.core.agent.*

--- a/project/FileUtils.scala
+++ b/project/FileUtils.scala
@@ -1,0 +1,22 @@
+import java.io.File
+import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
+import java.nio.file.attribute.BasicFileAttributes
+
+object FileUtils {
+  def listScalaFiles(basePath: File): Seq[Path] = {
+    val dirPath = basePath.toPath
+    var result = Vector.empty[Path]
+
+    val fileVisitor = new SimpleFileVisitor[Path] {
+      override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        if (file.toString.endsWith(".scala")) {
+          result = result :+ file
+        }
+        FileVisitResult.CONTINUE
+      }
+    }
+
+    Files.walkFileTree(dirPath, fileVisitor)
+    result
+  }
+}

--- a/project/VerifyExamplesCompileUsingScalaCli.scala
+++ b/project/VerifyExamplesCompileUsingScalaCli.scala
@@ -1,0 +1,22 @@
+import java.io.File
+import sbt.Logger
+import scala.sys.process.{Process, ProcessLogger}
+
+object VerifyExamplesCompileUsingScalaCli {
+  def apply(log: Logger, examplesSrcPath: File): Unit = {
+    val examples = FileUtils.listScalaFiles(examplesSrcPath)
+    log.info(s"Found ${examples.size} examples")
+
+    for (example <- examples) {
+      log.info(s"Compiling: $example")
+      val errorOutput = new StringBuilder
+      val logger = ProcessLogger((o: String) => (), (e: String) => errorOutput.append(e + "\n"))
+      try {
+        val result = Process(List("scala-cli", "compile", example.toFile.getAbsolutePath), examplesSrcPath).!(logger)
+        if (result != 0) {
+          throw new Exception(s"""Compiling $example failed.\n$errorOutput""".stripMargin)
+        }
+      } finally Process(List("scala-cli", "clean", example.toFile.getAbsolutePath), examplesSrcPath).!
+    }
+  }
+}


### PR DESCRIPTION
Steward PRs touching only examples/ or model_update_scripts/ got no labels, so they never auto-merged. Add examples (sbt-built, CI-verified) to both labels; model_update_scripts (not compiled by CI) gets only the dependency label.