### PR TITLE
Update docs on release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,6 @@ lazy val root = (project in file("."))
     publish / skip := true,
     name := "sttp-ai",
     scalaVersion := scala2.head,
-    // during a release, also regenerate the mdoc output (tracked in generated-docs/out),
-    // so that the versions in the published docs match the released one
     updateDocs := Def.taskDyn {
       val files = UpdateVersionInDocs(sLog.value, organization.value, version.value)
       Def.task {

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import Dependencies.*
-import com.softwaremill.Publish.ossPublishSettings
+import com.softwaremill.Publish.{ossPublishSettings, updateDocs}
 import com.softwaremill.SbtSoftwareMillCommon.commonSmlBuildSettings
+import com.softwaremill.UpdateVersionInDocs
 
 val scala2 = List("2.13.18")
 val scala3 = List("3.3.8")
@@ -17,7 +18,20 @@ lazy val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
 
 lazy val root = (project in file("."))
   .settings(commonSettings: _*)
-  .settings(publish / skip := true, name := "sttp-ai", scalaVersion := scala2.head)
+  .settings(
+    publish / skip := true,
+    name := "sttp-ai",
+    scalaVersion := scala2.head,
+    // during a release, also regenerate the mdoc output (tracked in generated-docs/out),
+    // so that the versions in the published docs match the released one
+    updateDocs := Def.taskDyn {
+      val files = UpdateVersionInDocs(sLog.value, organization.value, version.value)
+      Def.task {
+        (docs.jvm(scala3.head) / mdoc).toTask("").value
+        files ++ Seq(file("generated-docs/out"))
+      }
+    }.value
+  )
   .aggregate(allAgregates: _*)
 
 lazy val allAgregates = core.projectRefs ++

--- a/generated-docs/out/README.md
+++ b/generated-docs/out/README.md
@@ -36,6 +36,6 @@ Commit both `docs/` (the source) and `generated-docs/out/` (the mdoc output) —
 
 ## Notes
 
-- `0.5.1` and other mdoc variables are **not** substituted in the local watch mode. For a fully-rendered preview, run `sbt "docs3/mdoc"` from the repo root and serve `generated-docs/out/` instead.
+- `0.5.2` and other mdoc variables are **not** substituted in the local watch mode. For a fully-rendered preview, run `sbt "docs3/mdoc"` from the repo root and serve `generated-docs/out/` instead.
 - Scala code snippets are verified by `sbt compileDocumentation` (also runs in CI).
 - `adr/`, `plans/`, and `superpowers/` in this directory are internal project docs — they are excluded from the published site.

--- a/generated-docs/out/agents/quickstart.md
+++ b/generated-docs/out/agents/quickstart.md
@@ -14,7 +14,7 @@ Framework for building autonomous AI agents that iteratively solve tasks using t
 ## Quick Start
 
 ```scala
-//> using dep com.softwaremill.sttp.ai::openai:0.5.1
+//> using dep com.softwaremill.sttp.ai::openai:0.5.2
 
 import sttp.ai.core.agent.*
 import sttp.ai.openai.OpenAI

--- a/generated-docs/out/agents/tools.md
+++ b/generated-docs/out/agents/tools.md
@@ -48,7 +48,7 @@ Set `responseSchema` on `AgentConfig` and use `runAs[T]` to receive a parsed Sca
 On parse failure the iteration trace is preserved: `finalAnswer` is `Left(AgentParseError)` rather than a thrown exception.
 
 ```scala
-//> using dep com.softwaremill.sttp.ai::openai:0.5.1
+//> using dep com.softwaremill.sttp.ai::openai:0.5.2
 
 import sttp.ai.core.agent.*
 import sttp.ai.openai.OpenAI

--- a/generated-docs/out/claude/basics.md
+++ b/generated-docs/out/claude/basics.md
@@ -20,7 +20,7 @@ This module provides **native support for Anthropic's Claude API** within the st
 ## Basic Usage (Claude)
 
 ```scala
-//> using dep com.softwaremill.sttp.ai::claude:0.5.1
+//> using dep com.softwaremill.sttp.ai::claude:0.5.2
 
 import sttp.ai.claude.*
 import sttp.ai.claude.config.ClaudeConfig

--- a/generated-docs/out/claude/structured-outputs.md
+++ b/generated-docs/out/claude/structured-outputs.md
@@ -12,7 +12,7 @@ Claude's structured output feature (currently in beta) allows you to enforce tha
 For the shortest path, use `ClaudeSyncClient.createMessageAs[T]` — the response schema is derived from `T` via Tapir, set on the request automatically, and the model's response is parsed back into `T` via circe.
 
 ```scala
-//> using dep com.softwaremill.sttp.ai::claude:0.5.1
+//> using dep com.softwaremill.sttp.ai::claude:0.5.2
 
 import sttp.ai.claude.ClaudeSyncClient
 import sttp.ai.claude.models.Message
@@ -43,7 +43,7 @@ object Main:
 ## Basic Structured Output Example
 
 ```scala
-//> using dep com.softwaremill.sttp.ai::claude:0.5.1
+//> using dep com.softwaremill.sttp.ai::claude:0.5.2
 //> using dep com.softwaremill.sttp.tapir::tapir-core:1.11.7
 
 import sttp.ai.claude.*

--- a/generated-docs/out/openai/basics.md
+++ b/generated-docs/out/openai/basics.md
@@ -7,7 +7,7 @@ Examples are runnable using [scala-cli](https://scala-cli.virtuslab.org).
 ## Basic Usage (OpenAI)
 
 ```scala
-//> using dep com.softwaremill.sttp.ai::openai:0.5.1
+//> using dep com.softwaremill.sttp.ai::openai:0.5.2
 
 import sttp.ai.openai.OpenAISyncClient
 import sttp.ai.openai.requests.completions.chat.ChatRequestResponseData.ChatResponse

--- a/generated-docs/out/openai/compatible-apis.md
+++ b/generated-docs/out/openai/compatible-apis.md
@@ -5,7 +5,7 @@
 Ollama with sync backend:
 
 ```scala
-//> using dep com.softwaremill.sttp.ai::openai:0.5.1
+//> using dep com.softwaremill.sttp.ai::openai:0.5.2
 
 import sttp.model.Uri.*
 import sttp.ai.openai.OpenAISyncClient
@@ -59,7 +59,7 @@ object Main:
 Grok with cats-effect based backend:
 
 ```scala
-//> using dep com.softwaremill.sttp.ai::openai:0.5.1
+//> using dep com.softwaremill.sttp.ai::openai:0.5.2
 //> using dep com.softwaremill.sttp.client4::cats:4.0.0-M17
 
 import cats.effect.IO
@@ -135,7 +135,7 @@ Example below uses `HttpClientCatsBackend` as a backend, make sure to [add it to
 or use backend of your choice.
 
 ```scala
-//> using dep com.softwaremill.sttp.ai::openai:0.5.1
+//> using dep com.softwaremill.sttp.ai::openai:0.5.2
 //> using dep com.softwaremill.sttp.client4::cats:4.0.0-M17
 
 import cats.effect.IO

--- a/generated-docs/out/openai/streaming.md
+++ b/generated-docs/out/openai/streaming.md
@@ -9,7 +9,7 @@ For example, to use `fs2` add the following dependency & import:
 
 ```scala
 // sbt dependency
-"com.softwaremill.sttp.ai" %% "fs2" % "0.5.1"
+"com.softwaremill.sttp.ai" %% "fs2" % "0.5.2"
 
 // import 
 import sttp.ai.openai.streaming.fs2.*
@@ -18,7 +18,7 @@ import sttp.ai.openai.streaming.fs2.*
 Example below uses `HttpClientFs2Backend` as a backend:
 
 ```scala
-//> using dep com.softwaremill.sttp.ai::fs2:0.5.1
+//> using dep com.softwaremill.sttp.ai::fs2:0.5.2
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -99,7 +99,7 @@ To use direct-style streaming (requires Scala 3) add the following dependency & 
 
 ```scala
 // sbt dependency
-"com.softwaremill.sttp.ai" %% "ox" % "0.5.1"
+"com.softwaremill.sttp.ai" %% "ox" % "0.5.2"
 
 // import 
 import sttp.ai.openai.streaming.ox.*
@@ -108,7 +108,7 @@ import sttp.ai.openai.streaming.ox.*
 Example code:
 
 ```scala
-//> using dep com.softwaremill.sttp.ai::ox:0.5.1
+//> using dep com.softwaremill.sttp.ai::ox:0.5.2
 
 import ox.*
 import ox.either.orThrow

--- a/generated-docs/out/openai/structured-outputs.md
+++ b/generated-docs/out/openai/structured-outputs.md
@@ -3,7 +3,7 @@
 [OpenAI's Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs/introduction) constrain the model to produce JSON matching a given JSON Schema. The simplest way to use them is `OpenAISyncClient.createChatCompletionAs[T]` — the response schema is derived from a Scala case class via Tapir, set as `responseFormat` automatically, and the model's response is parsed back into `T` via circe:
 
 ```scala
-//> using dep com.softwaremill.sttp.ai::openai:0.5.1
+//> using dep com.softwaremill.sttp.ai::openai:0.5.2
 
 import sttp.ai.openai.OpenAISyncClient
 import sttp.ai.openai.requests.completions.chat.ChatRequestBody.{ChatBody, ChatCompletionModel}
@@ -35,7 +35,7 @@ object Main:
 If you need finer control — a hand-built schema, custom parsing, or a non-Tapir schema source — use `ResponseFormat.JsonSchema` directly. The example below produces a JSON object:
 
 ```scala
-//> using dep com.softwaremill.sttp.ai::openai:0.5.1
+//> using dep com.softwaremill.sttp.ai::openai:0.5.2
 
 import scala.collection.immutable.ListMap
 import sttp.apispec.{Schema, SchemaType}
@@ -161,7 +161,7 @@ Another helpful feature is adding possibility to create `Message.Tool` object pa
 With all this in mind please remember that it is still required to deserialized arguments, which are sent back by Assistant to call our function.
 
 ```scala
-//> using dep com.softwaremill.sttp.ai::openai:0.5.1
+//> using dep com.softwaremill.sttp.ai::openai:0.5.2
 
 import sttp.ai.openai.OpenAISyncClient
 import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatBody

--- a/generated-docs/out/quickstart.md
+++ b/generated-docs/out/quickstart.md
@@ -5,7 +5,7 @@
 Add the following dependency:
 
 ```sbt
-"com.softwaremill.sttp.ai" %% "openai" % "0.5.1"
+"com.softwaremill.sttp.ai" %% "openai" % "0.5.2"
 ```
 
 ## For Claude (Anthropic) API
@@ -13,14 +13,14 @@ Add the following dependency:
 Add the following dependency:
 
 ```sbt
-"com.softwaremill.sttp.ai" %% "claude" % "0.5.1"
+"com.softwaremill.sttp.ai" %% "claude" % "0.5.2"
 
 // For streaming support, add one or more:
-"com.softwaremill.sttp.ai" %% "claude-streaming-fs2" % "0.5.1"    // cats-effect/fs2
-"com.softwaremill.sttp.ai" %% "claude-streaming-zio" % "0.5.1"    // ZIO
-"com.softwaremill.sttp.ai" %% "claude-streaming-akka" % "0.5.1"   // Akka Streams (Scala 2.13 only)
-"com.softwaremill.sttp.ai" %% "claude-streaming-pekko" % "0.5.1"  // Pekko Streams
-"com.softwaremill.sttp.ai" %% "claude-streaming-ox" % "0.5.1"    // Ox direct-style (Scala 3 only)
+"com.softwaremill.sttp.ai" %% "claude-streaming-fs2" % "0.5.2"    // cats-effect/fs2
+"com.softwaremill.sttp.ai" %% "claude-streaming-zio" % "0.5.2"    // ZIO
+"com.softwaremill.sttp.ai" %% "claude-streaming-akka" % "0.5.2"   // Akka Streams (Scala 2.13 only)
+"com.softwaremill.sttp.ai" %% "claude-streaming-pekko" % "0.5.2"  // Pekko Streams
+"com.softwaremill.sttp.ai" %% "claude-streaming-ox" % "0.5.2"    // Ox direct-style (Scala 3 only)
 ```
 
 sttp-openai is available for Scala 2.13 and Scala 3


### PR DESCRIPTION
## Regenerate mdoc docs on release
Docs published from `generated-docs/out` kept stale versions after a release - `README.md` said `0.5.2` while `generated-docs/out/quickstart.md` still said `0.5.1`.                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                                           ### Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
  - `updateDocs` now also re-runs mdoc and commits `generated-docs/out` during a release, so versions in the published docs always match the released one.                                                                                                                                                                                                                                                                                                                                                                       
  - Regenerated the docs for `0.5.2`, fixing the currently stale `0.5.1` references.