### PR TITLE
Mcp backend schema compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -161,7 +161,7 @@ lazy val mcp = (projectMatrix in file("mcp"))
       Libraries.logbackTest
     )
   )
-  .dependsOn(core % "compile->compile;test->test")
+  .dependsOn(core % "compile->compile;test->test", openai % "test->compile", claude % "test->compile")
 
 lazy val examples = (projectMatrix in file("examples"))
   .jvmPlatform(

--- a/claude/src/main/scala/sttp/ai/claude/ClaudeClient.scala
+++ b/claude/src/main/scala/sttp/ai/claude/ClaudeClient.scala
@@ -168,7 +168,7 @@ class ClaudeClientImpl(config: ClaudeConfig) extends ClaudeClient with ResponseH
       requestJson.asObject
         .flatMap(_("tools"))
         .flatMap(_.asArray)
-        .map(_.map(_.asObject.flatMap(_("input_schema"))))
+        .map(_.map(_.asObject.flatMap(_("input_schema")).filter(!_.isNull)))
 
     val cleaned = requestJson.deepDropNullValues
 

--- a/claude/src/main/scala/sttp/ai/claude/ClaudeClient.scala
+++ b/claude/src/main/scala/sttp/ai/claude/ClaudeClient.scala
@@ -9,7 +9,7 @@ import sttp.ai.core.http.ResponseHandlers
 import sttp.capabilities.Streams
 import sttp.client4._
 import sttp.model.{ResponseMetadata, Uri}
-import io.circe.Decoder
+import io.circe.{Decoder, Json}
 import io.circe.parser.decode
 import io.circe.syntax._
 import sttp.ai.claude.json.ClaudeDerivedCodecs._
@@ -117,7 +117,7 @@ class ClaudeClientImpl(config: ClaudeConfig) extends ClaudeClient with ResponseH
   override def createMessage(request: MessageRequest): Request[Either[ClaudeException, MessageResponse]] =
     claudeAuthRequestForMessage(request)
       .post(claudeUris.Messages)
-      .body(request.asJson.deepDropNullValues.noSpaces)
+      .body(serializeMessageRequest(request))
       .response(asJson_parseErrors[MessageResponse])
 
   override def listModels(): Request[Either[ClaudeException, ModelsResponse]] =
@@ -133,7 +133,7 @@ class ClaudeClientImpl(config: ClaudeConfig) extends ClaudeClient with ResponseH
 
     claudeAuthRequestForMessage(streamingRequest)
       .post(claudeUris.Messages)
-      .body(streamingRequest.asJson.deepDropNullValues.noSpaces)
+      .body(serializeMessageRequest(streamingRequest))
       .response(asStreamUnsafe_parseErrors(streams))
   }
 
@@ -142,8 +142,51 @@ class ClaudeClientImpl(config: ClaudeConfig) extends ClaudeClient with ResponseH
 
     claudeAuthRequestForMessage(streamingRequest)
       .post(claudeUris.Messages)
-      .body(streamingRequest.asJson.deepDropNullValues.noSpaces)
+      .body(serializeMessageRequest(streamingRequest))
       .response(asInputStreamUnsafe_parseErrors)
+  }
+
+  /** Serializes a `MessageRequest` to the JSON body sent on the wire.
+    *
+    * `deepDropNullValues` is applied to strip unset-`Option` fields (e.g. `temperature: null`), but it also strips null VALUES nested
+    * inside array elements, not just absent object fields. That corrupts tool schemas that legitimately contain JSON `null` (e.g.
+    * `"enum": ["low", "high", null]`, `"default": null`) as passed through faithfully by [[sttp.ai.claude.models.Tool.CustomRaw]].
+    *
+    * To keep those schemas byte-faithful while still dropping unset-field nulls everywhere else: capture each tool's `input_schema` from
+    * the pre-drop encoding, run `deepDropNullValues` as before, then splice the untouched `input_schema` values back into the cleaned JSON
+    * (tools are index-aligned, since `deepDropNullValues` never removes object elements from an array, only null values). Tools without an
+    * `input_schema` (i.e. `web_search`) are left alone.
+    */
+  private def serializeMessageRequest(request: MessageRequest): String =
+    dropNullsPreservingInputSchemas(request.asJson).noSpaces
+
+  /** See [[serializeMessageRequest]] for why this exists: applies `deepDropNullValues` to the whole request, then restores each tool's
+    * pre-drop `input_schema` verbatim (only `tools[*]` that had an `input_schema` to begin with are touched).
+    */
+  private def dropNullsPreservingInputSchemas(requestJson: Json): Json = {
+    val originalInputSchemas: Option[Vector[Option[Json]]] =
+      requestJson.asObject
+        .flatMap(_("tools"))
+        .flatMap(_.asArray)
+        .map(_.map(_.asObject.flatMap(_("input_schema"))))
+
+    val cleaned = requestJson.deepDropNullValues
+
+    originalInputSchemas match {
+      case Some(schemas) =>
+        cleaned.mapObject { obj =>
+          obj("tools").flatMap(_.asArray) match {
+            case Some(cleanedTools) =>
+              val restoredTools = cleanedTools.zip(schemas).map {
+                case (toolJson, Some(inputSchema)) => toolJson.mapObject(_.add("input_schema", inputSchema))
+                case (toolJson, None)              => toolJson
+              }
+              obj.add("tools", Json.fromValues(restoredTools))
+            case None => obj
+          }
+        }
+      case None => cleaned
+    }
   }
 }
 

--- a/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
+++ b/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
@@ -32,12 +32,17 @@ private[claude] class ClaudeAgentBackend[F[_]](
       inputSchema = ensureObjectType(tool.rawJsonSchema)
     )
 
-  /** Anthropic requires `input_schema.type == "object"`; MCP allows schemas that omit it (e.g. `{}` for no-argument tools). */
+  /** Anthropic requires `input_schema.type == "object"`; MCP allows schemas that omit it (e.g. `{}` for no-argument tools), and also allows
+    * the JSON Schema/MCP boolean form `true` (meaning "any input is valid") which Anthropic would reject outright. Both are normalized to a
+    * minimal object schema; any other schema is passed through unchanged.
+    */
   private def ensureObjectType(schema: Json): Json =
-    schema.asObject match {
-      case Some(obj) if !obj.contains("type") => Json.fromJsonObject(obj.add("type", Json.fromString("object")))
-      case _                                  => schema
-    }
+    if (schema.isBoolean) Json.obj("type" -> Json.fromString("object"))
+    else
+      schema.asObject match {
+        case Some(obj) if !obj.contains("type") => Json.fromJsonObject(obj.add("type", Json.fromString("object")))
+        case _                                  => schema
+      }
 
   private def buildMessages(history: ConversationHistory): Seq[Message] =
     history.entries.flatMap {

--- a/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
+++ b/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
@@ -5,10 +5,8 @@ import sttp.ai.claude.config.ClaudeConfig
 import sttp.ai.claude.models.{ContentBlock, Message, OutputConfig, OutputFormat, Tool}
 import sttp.ai.claude.requests.MessageRequest
 import sttp.ai.core.agent._
-import sttp.apispec.circe._
 import sttp.client4.Backend
 import io.circe.Json
-import io.circe.syntax._
 import io.circe.parser.{parse => parseJson}
 import sttp.shared.Identity
 import sttp.monad.IdentityMonad
@@ -31,8 +29,15 @@ private[claude] class ClaudeAgentBackend[F[_]](
     Tool.CustomRaw(
       name = tool.name,
       description = tool.description,
-      inputSchema = tool.jsonSchema.asJson.deepDropNullValues
+      inputSchema = ensureObjectType(tool.rawJsonSchema)
     )
+
+  /** Anthropic requires `input_schema.type == "object"`; MCP allows schemas that omit it (e.g. `{}` for no-argument tools). */
+  private def ensureObjectType(schema: Json): Json =
+    schema.asObject match {
+      case Some(obj) if !obj.contains("type") => Json.fromJsonObject(obj.add("type", Json.fromString("object")))
+      case _                                  => schema
+    }
 
   private def buildMessages(history: ConversationHistory): Seq[Message] =
     history.entries.flatMap {

--- a/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
+++ b/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
@@ -2,7 +2,7 @@ package sttp.ai.claude.agent
 
 import sttp.ai.claude.ClaudeClient
 import sttp.ai.claude.config.ClaudeConfig
-import sttp.ai.claude.models.{ContentBlock, Message, OutputConfig, OutputFormat, PropertySchema, Tool, ToolInputSchema}
+import sttp.ai.claude.models.{ContentBlock, Message, OutputConfig, OutputFormat, Tool}
 import sttp.ai.claude.requests.MessageRequest
 import sttp.ai.core.agent._
 import sttp.apispec.circe._
@@ -22,46 +22,17 @@ private[claude] class ClaudeAgentBackend[F[_]](
 )(implicit monad: sttp.monad.MonadError[F])
     extends AgentBackend[F] {
 
-  private val convertedTools: Seq[Tool] = tools.map(convertTool)
+  private[claude] val convertedTools: Seq[Tool] = tools.map(convertTool)
 
   private val outputConfig: Option[OutputConfig] =
     responseSchema.map(rs => OutputConfig(format = Some(OutputFormat.JsonSchema(rs.schema))))
 
-  private def convertTool(tool: AgentTool[F, _]): Tool = {
-    val schemaCursor = tool.jsonSchema.asJson.hcursor
-
-    val properties = schemaCursor
-      .downField("properties")
-      .focus
-      .flatMap(_.asObject)
-      .map { propsObj =>
-        propsObj.toMap.map { case (name, propSchema) =>
-          val c = propSchema.hcursor
-          val propType = c.get[String]("type").toOption.getOrElse("string")
-          val propDescription = c.get[String]("description").toOption
-          val propEnum = c.downField("enum").as[List[String]].toOption
-
-          name -> PropertySchema(
-            `type` = propType,
-            description = propDescription,
-            `enum` = propEnum
-          )
-        }
-      }
-      .getOrElse(Map.empty)
-
-    val required = schemaCursor.downField("required").as[List[String]].toOption
-
-    Tool(
+  private def convertTool(tool: AgentTool[F, _]): Tool =
+    Tool.CustomRaw(
       name = tool.name,
       description = tool.description,
-      inputSchema = ToolInputSchema(
-        `type` = "object",
-        properties = properties,
-        required = required
-      )
+      inputSchema = tool.jsonSchema.asJson.deepDropNullValues
     )
-  }
 
   private def buildMessages(history: ConversationHistory): Seq[Message] =
     history.entries.flatMap {

--- a/claude/src/main/scala/sttp/ai/claude/json/ClaudeManualCodecs.scala
+++ b/claude/src/main/scala/sttp/ai/claude/json/ClaudeManualCodecs.scala
@@ -79,7 +79,8 @@ object ClaudeManualCodecs {
         }
       }
 
-  // `name`/`description` missing is a genuine decode failure either way, so surface Custom's error rather than CustomRaw's.
+  // `name`/`description` missing is a genuine decode failure either way; `orElse` surfaces the second decoder's (this one's) error, not
+  // Custom's, so it's `decodeCustomRaw`'s own field-level failure that's reported to the caller.
   private def decodeCustomRaw(c: io.circe.HCursor): Decoder.Result[Tool.CustomRaw] =
     for {
       name <- c.get[String]("name")

--- a/claude/src/main/scala/sttp/ai/claude/json/ClaudeManualCodecs.scala
+++ b/claude/src/main/scala/sttp/ai/claude/json/ClaudeManualCodecs.scala
@@ -93,13 +93,21 @@ object ClaudeManualCodecs {
     Decoder.instance(c =>
       c.get[String]("type").toOption match {
         case Some(Tool.WebSearch.ToolType) => c.as[Tool.WebSearch]
-        // Flat schemas decode as Custom (historical behavior); schemas Custom cannot represent
-        // (e.g. `{"type":"object"}` without `properties`, or union types) fall back to CustomRaw.
+        // Flat schemas decode as Custom (historical behavior). But because derived decoders ignore unknown JSON fields, JSON with
+        // structure `Custom` can't represent (nested objects, array item types, extra keys, ...) still decodes "successfully" as
+        // `Custom` -- that extra structure is silently dropped, not preserved. Only JSON that makes `Custom`'s decode outright FAIL
+        // (e.g. a property-less object, since `properties` is a required field; or union types) falls back to `CustomRaw`. Caveat:
+        // a decode -> re-encode round trip through this codec is therefore lossy whenever the original schema had structure `Custom`
+        // can't express, even though the decode step itself reports no error.
         case _ => c.as[Tool.Custom].orElse(decodeCustomRaw(c))
       }
     ),
     Encoder.instance {
-      case x: Tool.Custom    => encodeCustomTool(x.name, x.description, x.inputSchema.asJson, x.cacheControl)
+      // `.deepDropNullValues` here: `ToolInputSchema`/`PropertySchema` are derived codecs that emit `null` for every unset `Option`
+      // field (`required`, `description`, `enum`, ...). A typed `ToolInputSchema` cannot contain a JSON `null` that's anything other
+      // than such an artifact, so it's always safe to drop them -- unlike `CustomRaw`, whose raw JSON may contain legitimate nulls
+      // (e.g. `"enum": ["low", "high", null]`) that must be preserved verbatim.
+      case x: Tool.Custom    => encodeCustomTool(x.name, x.description, x.inputSchema.asJson.deepDropNullValues, x.cacheControl)
       case x: Tool.CustomRaw => encodeCustomTool(x.name, x.description, x.inputSchema, x.cacheControl)
       case x: Tool.WebSearch =>
         x.asJson

--- a/claude/src/main/scala/sttp/ai/claude/json/ClaudeManualCodecs.scala
+++ b/claude/src/main/scala/sttp/ai/claude/json/ClaudeManualCodecs.scala
@@ -65,40 +65,41 @@ object ClaudeManualCodecs {
     }
   )
 
+  private def encodeCustomTool(name: String, description: String, inputSchema: Json, cacheControl: Option[CacheControl]): Json =
+    Json
+      .obj(
+        "name" := name,
+        "description" := description,
+        "input_schema" := inputSchema
+      )
+      .mapObject { obj =>
+        cacheControl match {
+          case Some(cc) => obj.add("cache_control", cc.asJson)
+          case None     => obj
+        }
+      }
+
+  // `name`/`description` missing is a genuine decode failure either way, so surface Custom's error rather than CustomRaw's.
+  private def decodeCustomRaw(c: io.circe.HCursor): Decoder.Result[Tool.CustomRaw] =
+    for {
+      name <- c.get[String]("name")
+      description <- c.get[String]("description")
+      inputSchema <- c.getOrElse[Json]("input_schema")(Json.obj())
+      cacheControl <- c.get[Option[CacheControl]]("cache_control")
+    } yield Tool.CustomRaw(name, description, inputSchema, cacheControl)
+
   implicit val toolCodec: Codec[Tool] = Codec.from(
     Decoder.instance(c =>
       c.get[String]("type").toOption match {
         case Some(Tool.WebSearch.ToolType) => c.as[Tool.WebSearch]
-        case _                             => c.as[Tool.Custom]
+        // Flat schemas decode as Custom (historical behavior); schemas Custom cannot represent
+        // (e.g. `{"type":"object"}` without `properties`, or union types) fall back to CustomRaw.
+        case _ => c.as[Tool.Custom].orElse(decodeCustomRaw(c))
       }
     ),
     Encoder.instance {
-      case x: Tool.Custom =>
-        Json
-          .obj(
-            "name" := x.name,
-            "description" := x.description,
-            "input_schema" := x.inputSchema
-          )
-          .mapObject { obj =>
-            x.cacheControl match {
-              case Some(cc) => obj.add("cache_control", cc.asJson)
-              case None     => obj
-            }
-          }
-      case x: Tool.CustomRaw =>
-        Json
-          .obj(
-            "name" := x.name,
-            "description" := x.description,
-            "input_schema" := x.inputSchema
-          )
-          .mapObject { obj =>
-            x.cacheControl match {
-              case Some(cc) => obj.add("cache_control", cc.asJson)
-              case None     => obj
-            }
-          }
+      case x: Tool.Custom    => encodeCustomTool(x.name, x.description, x.inputSchema.asJson, x.cacheControl)
+      case x: Tool.CustomRaw => encodeCustomTool(x.name, x.description, x.inputSchema, x.cacheControl)
       case x: Tool.WebSearch =>
         x.asJson
           .mapObject(_.add("type", Json.fromString(Tool.WebSearch.ToolType)).add("name", Json.fromString(Tool.WebSearch.ToolName)))

--- a/claude/src/main/scala/sttp/ai/claude/json/ClaudeManualCodecs.scala
+++ b/claude/src/main/scala/sttp/ai/claude/json/ClaudeManualCodecs.scala
@@ -86,6 +86,19 @@ object ClaudeManualCodecs {
               case None     => obj
             }
           }
+      case x: Tool.CustomRaw =>
+        Json
+          .obj(
+            "name" := x.name,
+            "description" := x.description,
+            "input_schema" := x.inputSchema
+          )
+          .mapObject { obj =>
+            x.cacheControl match {
+              case Some(cc) => obj.add("cache_control", cc.asJson)
+              case None     => obj
+            }
+          }
       case x: Tool.WebSearch =>
         x.asJson
           .mapObject(_.add("type", Json.fromString(Tool.WebSearch.ToolType)).add("name", Json.fromString(Tool.WebSearch.ToolName)))

--- a/claude/src/main/scala/sttp/ai/claude/models/Tool.scala
+++ b/claude/src/main/scala/sttp/ai/claude/models/Tool.scala
@@ -75,6 +75,16 @@ object Tool {
       cacheControl: Option[CacheControl] = None
   ) extends Tool
 
+  /** A tool whose input schema is supplied as raw JSON Schema, passed to the API verbatim. Use this when the schema has structure that
+    * [[ToolInputSchema]] cannot express (nested objects, array item types, etc.) — e.g. schemas loaded from MCP servers.
+    */
+  case class CustomRaw(
+      name: String,
+      description: String,
+      inputSchema: io.circe.Json,
+      cacheControl: Option[CacheControl] = None
+  ) extends Tool
+
   case class WebSearch(
       maxUses: Option[Int] = None,
       allowedDomains: Option[List[String]] = None,
@@ -89,6 +99,9 @@ object Tool {
 
     val default: WebSearch = WebSearch()
   }
+
+  def custom(name: String, description: String, inputSchema: io.circe.Json): CustomRaw =
+    CustomRaw(name, description, inputSchema)
 
   def apply(name: String, description: String, inputSchema: ToolInputSchema): Custom =
     Custom(name, description, inputSchema)

--- a/claude/src/main/scala/sttp/ai/claude/models/Tool.scala
+++ b/claude/src/main/scala/sttp/ai/claude/models/Tool.scala
@@ -100,7 +100,7 @@ object Tool {
     val default: WebSearch = WebSearch()
   }
 
-  def custom(name: String, description: String, inputSchema: io.circe.Json): CustomRaw =
+  def customRaw(name: String, description: String, inputSchema: io.circe.Json): CustomRaw =
     CustomRaw(name, description, inputSchema)
 
   def apply(name: String, description: String, inputSchema: ToolInputSchema): Custom =

--- a/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
@@ -1,5 +1,6 @@
 package sttp.ai.claude.agent
 
+import io.circe.Json
 import io.circe.parser.parse
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
@@ -38,6 +39,43 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
         nested.downField("properties").downField("lat").downField("type").as[String] shouldBe Right("number")
         raw.inputSchema.hcursor.downField("required").as[List[String]] shouldBe Right(List("title", "location"))
       case other => fail(s"expected Tool.CustomRaw, got $other")
+    }
+  }
+
+  it should "default an empty schema's input_schema to type object (Anthropic requires input_schema.type)" in {
+    val schema = parse("{}").value.as[Schema](sttp.apispec.circe.schemaDecoder).value
+    val tool = AgentTool.dynamic("no-arg-tool", "Takes no arguments", schema)(_ => "ok")
+
+    val client = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
+    val backend = new ClaudeAgentBackend[Identity](client, "claude-haiku-4-5-20251001", Seq(tool), None, None)(IdentityMonad)
+
+    backend.convertedTools.head match {
+      case raw: Tool.CustomRaw =>
+        raw.inputSchema shouldBe parse("""{"type":"object"}""").value
+      case other => fail(s"expected Tool.CustomRaw, got $other")
+    }
+  }
+
+  it should "pass an overridden rawJsonSchema through byte-identical, including null-valued fields" in {
+    val originalSchema = parse(
+      """{"type":"object","properties":{"level":{"enum":["low","high",null],"default":null}}}"""
+    ).value
+
+    val tool = new AgentTool[Identity, Map[String, Json]] {
+      override def name: String = "raw-passthrough-tool"
+      override def description: String = "Uses a raw schema with null-valued fields"
+      override def jsonSchema: Schema = parse("""{"type":"object"}""").value.as[Schema](sttp.apispec.circe.schemaDecoder).value
+      override def codec: io.circe.Codec[Map[String, Json]] = io.circe.Codec.implied
+      override def execute(input: Map[String, Json]): Identity[String] = "ok"
+      override def rawJsonSchema: Json = originalSchema
+    }
+
+    val client = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
+    val backend = new ClaudeAgentBackend[Identity](client, "claude-haiku-4-5-20251001", Seq(tool), None, None)(IdentityMonad)
+
+    backend.convertedTools.head match {
+      case raw: Tool.CustomRaw => raw.inputSchema shouldBe originalSchema
+      case other               => fail(s"expected Tool.CustomRaw, got $other")
     }
   }
 }

--- a/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
@@ -1,0 +1,43 @@
+package sttp.ai.claude.agent
+
+import io.circe.parser.parse
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.claude.ClaudeClient
+import sttp.ai.claude.config.ClaudeConfig
+import sttp.ai.claude.models.Tool
+import sttp.ai.core.agent.AgentTool
+import sttp.apispec.Schema
+import sttp.monad.IdentityMonad
+import sttp.shared.Identity
+
+class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  private val rawSchema =
+    """{"type":"object",
+      |"properties":{
+      |  "title":{"type":"string"},
+      |  "location":{"type":"object","properties":{"lat":{"type":"number"},"lng":{"type":"number"}},"required":["lat","lng"]}
+      |},
+      |"required":["title","location"]}""".stripMargin
+
+  "ClaudeAgentBackend" should "pass the full tool schema through, preserving nested structure" in {
+    val schema = parse(rawSchema).value.as[Schema](sttp.apispec.circe.schemaDecoder).value
+    val tool = AgentTool.dynamic("create-event", "Creates an event", schema)(_ => "ok")
+
+    val client = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
+    val backend = new ClaudeAgentBackend[Identity](client, "claude-haiku-4-5-20251001", Seq(tool), None, None)(IdentityMonad)
+
+    backend.convertedTools.head match {
+      case raw: Tool.CustomRaw =>
+        raw.name shouldBe "create-event"
+        raw.description shouldBe "Creates an event"
+        val nested = raw.inputSchema.hcursor.downField("properties").downField("location")
+        nested.downField("type").as[String] shouldBe Right("object")
+        nested.downField("properties").downField("lat").downField("type").as[String] shouldBe Right("number")
+        raw.inputSchema.hcursor.downField("required").as[List[String]] shouldBe Right(List("title", "location"))
+      case other => fail(s"expected Tool.CustomRaw, got $other")
+    }
+  }
+}

--- a/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
@@ -78,4 +78,23 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
       case other               => fail(s"expected Tool.CustomRaw, got $other")
     }
   }
+
+  it should "replace a JSON Schema boolean schema (MCP's `true` = \"any input\") with a minimal object schema" in {
+    val tool = new AgentTool[Identity, Map[String, Json]] {
+      override def name: String = "any-input-tool"
+      override def description: String = "Accepts any input"
+      override def jsonSchema: Schema = parse("""{"type":"object"}""").value.as[Schema](sttp.apispec.circe.schemaDecoder).value
+      override def codec: io.circe.Codec[Map[String, Json]] = io.circe.Codec.implied
+      override def execute(input: Map[String, Json]): Identity[String] = "ok"
+      override def rawJsonSchema: Json = Json.True
+    }
+
+    val client = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
+    val backend = new ClaudeAgentBackend[Identity](client, "claude-haiku-4-5-20251001", Seq(tool), None, None)(IdentityMonad)
+
+    backend.convertedTools.head match {
+      case raw: Tool.CustomRaw => raw.inputSchema shouldBe parse("""{"type":"object"}""").value
+      case other               => fail(s"expected Tool.CustomRaw, got $other")
+    }
+  }
 }

--- a/claude/src/test/scala/sttp/ai/claude/models/ToolCustomRawSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/models/ToolCustomRawSpec.scala
@@ -5,6 +5,7 @@ import io.circe.syntax._
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.ai.claude.json.ClaudeDerivedCodecs._
 import sttp.ai.claude.json.ClaudeManualCodecs._
 
 class ToolCustomRawSpec extends AnyFlatSpec with Matchers with EitherValues {
@@ -19,7 +20,7 @@ class ToolCustomRawSpec extends AnyFlatSpec with Matchers with EitherValues {
   ).value
 
   "Tool.CustomRaw" should "encode with the raw input schema passed through verbatim" in {
-    val tool: Tool = Tool.custom("create-event", "Creates an event", nestedSchema)
+    val tool: Tool = Tool.customRaw("create-event", "Creates an event", nestedSchema)
     val expected = parse(
       s"""{"name":"create-event","description":"Creates an event","input_schema":${nestedSchema.noSpaces}}"""
     ).value
@@ -32,5 +33,35 @@ class ToolCustomRawSpec extends AnyFlatSpec with Matchers with EitherValues {
       s"""{"name":"t","description":"d","input_schema":${nestedSchema.noSpaces},"cache_control":{"ttl":null,"type":"ephemeral"}}"""
     ).value
     (tool.asJson: io.circe.Json) shouldBe expected
+  }
+
+  it should "encode Custom and CustomRaw with equivalent content identically (encoder dedup regression guard)" in {
+    val inputSchema = ToolInputSchema.forObject(Map("q" -> PropertySchema.string("query")))
+    val custom: Tool = Tool.Custom("t", "d", inputSchema, cacheControl = Some(CacheControl.Ephemeral()))
+    val customRaw: Tool = Tool.CustomRaw("t", "d", inputSchema.asJson, cacheControl = Some(CacheControl.Ephemeral()))
+    (custom.asJson: io.circe.Json) shouldBe (customRaw.asJson: io.circe.Json)
+  }
+
+  "Tool decoder" should "decode a flat schema as Tool.Custom (historical behavior preserved)" in {
+    val json = parse(
+      """{"name":"t","description":"d","input_schema":{"type":"object","properties":{"q":{"type":"string"}}}}"""
+    ).value
+    json.as[Tool].value shouldBe a[Tool.Custom]
+  }
+
+  it should "fall back to Tool.CustomRaw for an object schema without properties (Custom cannot represent it)" in {
+    val json = parse(
+      """{"name":"t","description":"d","input_schema":{"type":"object"}}"""
+    ).value
+    val schema = parse("""{"type":"object"}""").value
+    json.as[Tool].value shouldBe Tool.CustomRaw("t", "d", schema)
+  }
+
+  it should "fall back to Tool.CustomRaw for a union type property (Custom cannot represent it)" in {
+    val json = parse(
+      """{"name":"t","description":"d","input_schema":{"type":"object","properties":{"a":{"type":["string","null"]}}}}"""
+    ).value
+    val schema = parse("""{"type":"object","properties":{"a":{"type":["string","null"]}}}""").value
+    json.as[Tool].value shouldBe Tool.CustomRaw("t", "d", schema)
   }
 }

--- a/claude/src/test/scala/sttp/ai/claude/models/ToolCustomRawSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/models/ToolCustomRawSpec.scala
@@ -28,6 +28,9 @@ class ToolCustomRawSpec extends AnyFlatSpec with Matchers with EitherValues {
 
   it should "include cache_control when set" in {
     val tool: Tool = Tool.CustomRaw("t", "d", nestedSchema, cacheControl = Some(CacheControl.Ephemeral()))
-    tool.asJson.hcursor.downField("cache_control").succeeded shouldBe true
+    val expected = parse(
+      s"""{"name":"t","description":"d","input_schema":${nestedSchema.noSpaces},"cache_control":{"ttl":null,"type":"ephemeral"}}"""
+    ).value
+    (tool.asJson: io.circe.Json) shouldBe expected
   }
 }

--- a/claude/src/test/scala/sttp/ai/claude/models/ToolCustomRawSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/models/ToolCustomRawSpec.scala
@@ -1,0 +1,33 @@
+package sttp.ai.claude.models
+
+import io.circe.parser.parse
+import io.circe.syntax._
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.claude.json.ClaudeManualCodecs._
+
+class ToolCustomRawSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  private val nestedSchema = parse(
+    """{"type":"object",
+      |"properties":{
+      |  "title":{"type":"string"},
+      |  "location":{"type":"object","properties":{"lat":{"type":"number"},"lng":{"type":"number"}},"required":["lat","lng"]}
+      |},
+      |"required":["title","location"]}""".stripMargin
+  ).value
+
+  "Tool.CustomRaw" should "encode with the raw input schema passed through verbatim" in {
+    val tool: Tool = Tool.custom("create-event", "Creates an event", nestedSchema)
+    val expected = parse(
+      s"""{"name":"create-event","description":"Creates an event","input_schema":${nestedSchema.noSpaces}}"""
+    ).value
+    (tool.asJson: io.circe.Json) shouldBe expected
+  }
+
+  it should "include cache_control when set" in {
+    val tool: Tool = Tool.CustomRaw("t", "d", nestedSchema, cacheControl = Some(CacheControl.Ephemeral()))
+    tool.asJson.hcursor.downField("cache_control").succeeded shouldBe true
+  }
+}

--- a/claude/src/test/scala/sttp/ai/claude/models/ToolCustomRawSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/models/ToolCustomRawSpec.scala
@@ -35,11 +35,17 @@ class ToolCustomRawSpec extends AnyFlatSpec with Matchers with EitherValues {
     (tool.asJson: io.circe.Json) shouldBe expected
   }
 
-  it should "encode Custom and CustomRaw with equivalent content identically (encoder dedup regression guard)" in {
+  it should "drop Custom's derived-codec null artifacts (required/enum) while CustomRaw with the identical JSON keeps them (encoder dedup regression guard)" in {
     val inputSchema = ToolInputSchema.forObject(Map("q" -> PropertySchema.string("query")))
     val custom: Tool = Tool.Custom("t", "d", inputSchema, cacheControl = Some(CacheControl.Ephemeral()))
-    val customRaw: Tool = Tool.CustomRaw("t", "d", inputSchema.asJson, cacheControl = Some(CacheControl.Ephemeral()))
-    (custom.asJson: io.circe.Json) shouldBe (customRaw.asJson: io.circe.Json)
+    // `inputSchema.asJson` contains `"required":null`/`"enum":null` for the unset `Option`s: `Custom`'s encoder drops them (a typed
+    // `ToolInputSchema` can't legitimately contain those nulls), while `CustomRaw`'s encoder passes the identical JSON through verbatim.
+    val customRawWithNulls: Tool = Tool.CustomRaw("t", "d", inputSchema.asJson, cacheControl = Some(CacheControl.Ephemeral()))
+    val customRawWithoutNulls: Tool =
+      Tool.CustomRaw("t", "d", inputSchema.asJson.deepDropNullValues, cacheControl = Some(CacheControl.Ephemeral()))
+
+    (custom.asJson: io.circe.Json) should not be (customRawWithNulls.asJson: io.circe.Json)
+    (custom.asJson: io.circe.Json) shouldBe (customRawWithoutNulls.asJson: io.circe.Json)
   }
 
   "Tool decoder" should "decode a flat schema as Tool.Custom (historical behavior preserved)" in {

--- a/claude/src/test/scala/sttp/ai/claude/unit/ClaudeClientSerializationSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/unit/ClaudeClientSerializationSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.ai.claude.ClaudeClient
 import sttp.ai.claude.config.ClaudeConfig
-import sttp.ai.claude.models.{Message, Tool}
+import sttp.ai.claude.models.{Message, PropertySchema, Tool, ToolInputSchema}
 import sttp.ai.claude.requests.MessageRequest
 import sttp.client4.StringBody
 
@@ -46,5 +46,35 @@ class ClaudeClientSerializationSpec extends AnyFlatSpec with Matchers with Eithe
     json.hcursor.downField("top_p").succeeded shouldBe false
     json.hcursor.downField("system").succeeded shouldBe false
     json.hcursor.downField("output_config").succeeded shouldBe false
+  }
+
+  it should "drop the derived-codec's null-valued fields (required/description/enum) from a Custom tool's input_schema" in {
+    val client = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
+    val tool: Tool = Tool.Custom(
+      name = "get_weather",
+      description = "Gets the weather",
+      // `required = None` and `PropertySchema(description = None, enum = None)` are unset `Option`s: the derived codec renders them as
+      // `"required":null`/`"description":null`/`"enum":null`, which would be invalid JSON Schema if sent verbatim.
+      inputSchema = ToolInputSchema(
+        `type` = "object",
+        properties = Map("location" -> PropertySchema(`type` = "string", description = None, `enum` = None)),
+        required = None
+      )
+    )
+    val request = MessageRequest
+      .simple("claude-haiku-4-5-20251001", List(Message.user("hi")), 100)
+      .copy(tools = Some(List(tool)))
+
+    val body = requestBodyOf(client, request)
+    body should not include "\"required\":null"
+    body should not include "\"description\":null"
+    body should not include "\"enum\":null"
+
+    val json = parse(body).value
+    val inputSchema = json.hcursor.downField("tools").downArray.get[Json]("input_schema").value
+    inputSchema.asObject.exists(_.contains("required")) shouldBe false
+    val locationProperty = inputSchema.hcursor.downField("properties").downField("location")
+    locationProperty.downField("description").succeeded shouldBe false
+    locationProperty.downField("enum").succeeded shouldBe false
   }
 }

--- a/claude/src/test/scala/sttp/ai/claude/unit/ClaudeClientSerializationSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/unit/ClaudeClientSerializationSpec.scala
@@ -1,0 +1,50 @@
+package sttp.ai.claude.unit
+
+import io.circe.Json
+import io.circe.parser.parse
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.claude.ClaudeClient
+import sttp.ai.claude.config.ClaudeConfig
+import sttp.ai.claude.models.{Message, Tool}
+import sttp.ai.claude.requests.MessageRequest
+import sttp.client4.StringBody
+
+/** Regression coverage for the null-drop-vs-schema-fidelity fix in [[ClaudeClient]]: `deepDropNullValues` is applied to the whole request
+  * at send time (to omit unset `Option` fields), but it also strips null VALUES nested inside JSON arrays, which corrupts tool schemas that
+  * legitimately contain `null` (e.g. `enum` values, `default: null`). The client must preserve `input_schema` verbatim while still dropping
+  * unset-field nulls everywhere else.
+  */
+class ClaudeClientSerializationSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  private val schemaWithNulls: Json = parse(
+    """{"type":"object","properties":{"effort":{"type":"string","enum":["low","high",null],"default":null}},"required":["effort"]}"""
+  ).value
+
+  private def requestBodyOf(client: ClaudeClient, request: MessageRequest): String =
+    client.createMessage(request).body match {
+      case StringBody(s, _, _) => s
+      case other               => fail(s"expected a StringBody request body, got $other")
+    }
+
+  "ClaudeClient.createMessage" should "retain nulls inside a CustomRaw tool's input_schema while dropping unset-field nulls elsewhere" in {
+    val client = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
+    val tool: Tool = Tool.customRaw("set_effort", "Sets reasoning effort", schemaWithNulls)
+    // temperature/topP/topK/stopSequences/system/outputConfig/cacheControl are all left as their `None` default, so their JSON `null`s
+    // should be dropped from the serialized body -- unlike the nulls legitimately present inside the tool's input_schema.
+    val request = MessageRequest
+      .simple("claude-haiku-4-5-20251001", List(Message.user("hi")), 100)
+      .copy(tools = Some(List(tool)))
+
+    val json = parse(requestBodyOf(client, request)).value
+
+    val inputSchema = json.hcursor.downField("tools").downArray.get[Json]("input_schema").value
+    inputSchema shouldBe schemaWithNulls
+
+    json.hcursor.downField("temperature").succeeded shouldBe false
+    json.hcursor.downField("top_p").succeeded shouldBe false
+    json.hcursor.downField("system").succeeded shouldBe false
+    json.hcursor.downField("output_config").succeeded shouldBe false
+  }
+}

--- a/core/src/main/scala/sttp/ai/core/agent/AgentTool.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentTool.scala
@@ -12,6 +12,12 @@ trait AgentTool[F[_], T] {
   def jsonSchema: Schema
   def codec: Codec[T]
   def execute(input: T): F[String]
+
+  /** The tool's input schema as raw JSON. Defaults to the encoding of [[jsonSchema]]; implementations that obtained the schema as JSON in
+    * the first place (e.g. tools loaded from MCP servers) should override this with the original document, so backends can pass it through
+    * without a lossy round-trip.
+    */
+  def rawJsonSchema: Json = sttp.apispec.circe.encoderSchema(jsonSchema).deepDropNullValues
 }
 
 object AgentTool {

--- a/core/src/test/scala/sttp/ai/core/agent/AgentToolSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentToolSpec.scala
@@ -1,0 +1,43 @@
+package sttp.ai.core.agent
+
+import io.circe.Codec
+import io.circe.generic.semiauto.deriveCodec
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.tapir.Schema
+
+class AgentToolSpec extends AnyFlatSpec with Matchers with OptionValues {
+
+  case class CalculatorInput(a: Double, b: Double)
+  implicit val calculatorInputCodec: Codec[CalculatorInput] = deriveCodec
+  implicit val calculatorInputSchema: Schema[CalculatorInput] = Schema.derived
+
+  private val calculatorTool = AgentTool.fromFunction(
+    "calculator",
+    "Calculate"
+  ) { (input: CalculatorInput) =>
+    s"Result: ${input.a + input.b}"
+  }
+
+  behavior of "AgentTool.rawJsonSchema"
+
+  it should "default to the faithful, null-free encoding of jsonSchema" in {
+    val raw = calculatorTool.rawJsonSchema
+    val expected = sttp.apispec.circe.encoderSchema(calculatorTool.jsonSchema).deepDropNullValues
+    raw shouldBe expected
+
+    val cursor = raw.hcursor.downField("properties")
+    cursor.keys.value.toSet shouldBe Set("a", "b")
+
+    def hasNoNulls(json: io.circe.Json): Boolean = json.fold(
+      jsonNull = false,
+      jsonBoolean = _ => true,
+      jsonNumber = _ => true,
+      jsonString = _ => true,
+      jsonArray = _.forall(hasNoNulls),
+      jsonObject = _.values.forall(hasNoNulls)
+    )
+    hasNoNulls(raw) shouldBe true
+  }
+}

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -14,6 +14,10 @@ val agent = OpenAIAgent
   .build
 ```
 
+The OpenAI factories additionally accept a `strictTools` flag (default `true`): when `true`, tool schemas are
+normalized for OpenAI's strict function calling (`additionalProperties: false`, all properties required, optional
+properties nullable); when `false`, tools are registered as non-strict with their original schemas.
+
 ## Hooks
 
 The loop can invoke optional effectful hooks around each tool call. Both run inside the agent loop, so an error in either hook interrupts the run.

--- a/docs/agents/mcp.md
+++ b/docs/agents/mcp.md
@@ -66,9 +66,10 @@ Notes:
 
 * The OpenAI agent backend registers tools with `strict: true` function calling by default. Schemas are automatically
   normalized to strict-mode rules: `additionalProperties: false` is set on objects, all properties are listed as
-  `required`, and originally-optional properties are made nullable (the model passes `null` instead of omitting them —
-  your MCP server should treat `null` as "not provided"). If a schema uses JSON Schema features strict mode cannot
-  accept, the API rejects it at request time — pass `strictTools = false` to the builder as an escape hatch:
+  `required`, and originally-optional properties are made nullable (the model passes `null` instead of omitting them;
+  those nulls are stripped client-side before the tool call reaches the MCP server — see below). If a schema uses JSON
+  Schema features strict mode cannot accept, the API rejects it at request time — pass `strictTools = false` to the
+  builder as an escape hatch:
 
   ```scala
   OpenAIAgent.synchronous(OpenAI.fromEnv, "gpt-4o-mini", strictTools = false)

--- a/docs/agents/mcp.md
+++ b/docs/agents/mcp.md
@@ -74,4 +74,6 @@ Notes:
   OpenAIAgent.synchronous(OpenAI.fromEnv, "gpt-4o-mini", strictTools = false)
   ```
 
-* The Claude agent backend passes tool schemas to the API verbatim, including nested structure — no caveats.
+* The Claude agent backend passes the full tool schema structure to the API — nested objects, arrays, enums, and
+  required lists are preserved (JSON Schema keywords outside the OpenAPI-style schema model are dropped during
+  conversion).

--- a/docs/agents/mcp.md
+++ b/docs/agents/mcp.md
@@ -64,13 +64,14 @@ Notes:
 
 ## Backend caveats
 
-The LLM backends impose their own constraints on tool schemas, which arbitrary MCP servers may not satisfy:
+* The OpenAI agent backend registers tools with `strict: true` function calling by default. Schemas are automatically
+  normalized to strict-mode rules: `additionalProperties: false` is set on objects, all properties are listed as
+  `required`, and originally-optional properties are made nullable (the model passes `null` instead of omitting them —
+  your MCP server should treat `null` as "not provided"). If a schema uses JSON Schema features strict mode cannot
+  accept, the API rejects it at request time — pass `strictTools = false` to the builder as an escape hatch:
 
-* The OpenAI agent backend registers tools with `strict: true` function calling, which requires every object in the
-  schema to set `additionalProperties: false` and list all properties as `required`. MCP tools whose schemas don't
-  conform are rejected by the OpenAI API at request time.
-* The Claude agent backend converts tool schemas to a flat property list, so nested object structure in an MCP tool's
-  input schema is not conveyed to the model.
+  ```scala
+  OpenAIAgent.synchronous(OpenAI.fromEnv, "gpt-4o-mini", strictTools = false)
+  ```
 
-If you hit either limitation with a particular MCP server, consider wrapping the problematic tool manually with
-`AgentTool.fromFunction` for now.
+* The Claude agent backend passes tool schemas to the API verbatim, including nested structure — no caveats.

--- a/docs/agents/mcp.md
+++ b/docs/agents/mcp.md
@@ -74,6 +74,13 @@ Notes:
   OpenAIAgent.synchronous(OpenAI.fromEnv, "gpt-4o-mini", strictTools = false)
   ```
 
-* The Claude agent backend passes the full tool schema structure to the API — nested objects, arrays, enums, and
-  required lists are preserved (JSON Schema keywords outside the OpenAPI-style schema model are dropped during
-  conversion).
+* Before an argument map reaches the MCP server's `tools/call`, top-level arguments that are JSON `null` are dropped
+  if the server's original schema does not list that parameter as `required` — i.e. "optional-by-absence" — so the
+  server sees the parameter as simply missing rather than explicitly `null`. Nulls for parameters the server *does*
+  list as `required` (e.g. a required-but-nullable property, as strict-mode normalization produces) are left in place
+  and forwarded as-is.
+
+* The Claude agent backend passes the server's original tool schema JSON through untouched — nested objects, arrays,
+  enums, `required` lists, and any other JSON Schema keywords are all forwarded as received. The only modification is
+  adding a top-level `"type": "object"` when the schema omits it (Anthropic requires `input_schema.type == "object"`,
+  but MCP allows tools to omit `type`, e.g. `{}` for a no-argument tool).

--- a/docs/openai/structured-outputs.md
+++ b/docs/openai/structured-outputs.md
@@ -283,3 +283,8 @@ object Main:
       )
       */
 ```
+
+> **Note:** when a schema is normalized for strict mode, properties that are optional in the source schema (absent
+> from its `required` list) are encoded as nullable — the model returns `null` for them instead of inventing a value.
+> If you decode structured outputs into classes with non-`Option` fields, mark optional fields as `Option` or list
+> them as required in your schema.

--- a/docs/openai/structured-outputs.md
+++ b/docs/openai/structured-outputs.md
@@ -284,7 +284,9 @@ object Main:
       */
 ```
 
-> **Note:** when a schema is normalized for strict mode, properties that are optional in the source schema (absent
-> from its `required` list) are encoded as nullable — the model returns `null` for them instead of inventing a value.
-> If you decode structured outputs into classes with non-`Option` fields, mark optional fields as `Option` or list
-> them as required in your schema.
+> **Note:** normalization is applied only when `strict = true` is requested; otherwise the schema is encoded
+> faithfully, unchanged. When a schema *is* normalized for strict mode, `additionalProperties: false` is set on every
+> object, all properties are listed as `required`, and properties that were optional in the source schema (absent
+> from its original `required` list) are made nullable — the model returns `null` for them instead of inventing a
+> value. If you decode structured outputs into classes with non-`Option` fields, mark optional fields as `Option` or
+> list them as required in your schema.

--- a/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
+++ b/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
@@ -22,10 +22,17 @@ object McpTools {
     *
     * The caller owns the client: it must stay open while the agent runs, and must be closed by the caller afterwards.
     *
-    * Tool calls are executed remotely via `tools/call`. Results are rendered as text: text content blocks are joined with newlines, other
-    * content blocks are rendered as compact JSON, and an empty content list falls back to the tool's structured content. Results marked as
-    * errors by the server are prefixed with `"Tool execution failed: "` and returned to the LLM as regular tool output. Transport-level
-    * failures surface as exceptions and are subject to the agent's configured `ExceptionHandler`.
+    * The server's original input schema `Json` is preserved verbatim and exposed via `rawJsonSchema`, so backends that consume it can pass
+    * it through to the model without the lossy round-trip of re-encoding the decoded [[sttp.apispec.Schema]] (which stringifies `null` enum
+    * members and drops null array elements/defaults).
+    *
+    * Tool calls are executed remotely via `tools/call`. Before calling, arguments whose value is JSON `null` are stripped unless the
+    * corresponding parameter is listed in the tool's original top-level `required` array: this accommodates backends (e.g. OpenAI strict
+    * mode) that normalize optional parameters into explicit `null`s, which schema-validating MCP servers may otherwise reject. Nulls for
+    * genuinely required-but-nullable parameters are preserved. Results are rendered as text: text content blocks are joined with newlines,
+    * other content blocks are rendered as compact JSON, and an empty content list falls back to the tool's structured content. Results
+    * marked as errors by the server are prefixed with `"Tool execution failed: "` and returned to the LLM as regular tool output.
+    * Transport-level failures surface as exceptions and are subject to the agent's configured `ExceptionHandler`.
     *
     * @param namePrefix
     *   When defined, tools are exposed to the LLM as `s"${prefix}_${name}"`, to avoid collisions with manually defined tools or tools
@@ -58,8 +65,19 @@ object McpTools {
     }
     val exposedName = namePrefix.fold(definition.name)(prefix => s"${prefix}_${definition.name}")
     val description = definition.description.orElse(definition.title).getOrElse(definition.name)
-    AgentTool.dynamicF(exposedName, description, schema) { input =>
-      client.callTool(definition.name, Json.fromFields(input)).map(renderResult)
+    val requiredParams =
+      definition.inputSchema.hcursor.downField("required").as[List[String]].toOption.getOrElse(Nil).toSet
+    val delegate = AgentTool.dynamicF(exposedName, description, schema) { input =>
+      val filtered = input.filterNot { case (k, v) => v.isNull && !requiredParams(k) }
+      client.callTool(definition.name, Json.fromFields(filtered)).map(renderResult)
+    }
+    new AgentTool[F, Map[String, Json]] {
+      override def name: String = delegate.name
+      override def description: String = delegate.description
+      override def jsonSchema: Schema = delegate.jsonSchema
+      override def codec: io.circe.Codec[Map[String, Json]] = delegate.codec
+      override def execute(input: Map[String, Json]): F[String] = delegate.execute(input)
+      override def rawJsonSchema: Json = definition.inputSchema
     }
   }
 

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
@@ -117,4 +117,39 @@ class McpToolsSpec extends AnyFlatSpec with Matchers {
     val client = new StubMcpClient(pages = Seq(ListToolsResponse(tools = List(toolDef("add")))))
     McpTools.fromClient(client).head.name shouldBe "add"
   }
+
+  it should "expose the server's original schema verbatim via rawJsonSchema, byte-equal, while jsonSchema still decodes" in {
+    val lossySchema = Json.obj(
+      "type" -> Json.fromString("object"),
+      "properties" -> Json.obj(
+        "level" -> Json.obj(
+          "type" -> Json.fromString("string"),
+          "enum" -> Json.arr(Json.fromString("low"), Json.fromString("high"), Json.Null),
+          "default" -> Json.Null
+        )
+      )
+    )
+    val client = new StubMcpClient(pages = Seq(ListToolsResponse(tools = List(toolDef("levelled", schema = lossySchema)))))
+    val tool = McpTools.fromClient(client).head
+    tool.rawJsonSchema shouldBe lossySchema
+    noException should be thrownBy tool.jsonSchema
+  }
+
+  it should "strip null-valued arguments for optional parameters but keep them for required ones" in {
+    val schema = Json.obj(
+      "type" -> Json.fromString("object"),
+      "properties" -> Json.obj(
+        "a" -> Json.obj("type" -> Json.fromString("string")),
+        "b" -> Json.obj("type" -> Json.fromString("string"))
+      ),
+      "required" -> Json.arr(Json.fromString("a"))
+    )
+    val client = new StubMcpClient(
+      pages = Seq(ListToolsResponse(tools = List(toolDef("f", schema = schema)))),
+      callResults = Map("f" -> CallToolResult(List(ToolContent.Text(text = "ok"))))
+    )
+    val tool = McpTools.fromClient(client).head
+    tool.execute(Map("a" -> Json.Null, "b" -> Json.Null, "c" -> Json.fromString("x"))) shouldBe "ok"
+    client.recordedCalls shouldBe Vector("f" -> Json.obj("a" -> Json.Null, "c" -> Json.fromString("x")))
+  }
 }

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/integration/McpAgentIntegrationSpec.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/integration/McpAgentIntegrationSpec.scala
@@ -1,0 +1,80 @@
+package sttp.ai.core.agent.mcp.integration
+
+import chimp.client.McpClient
+import chimp.client.transport.ClientHttpTransport
+import chimp.protocol.Implementation
+import chimp.server.{tool, McpServer, ToolResult}
+import io.circe.Codec
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ox.supervised
+import sttp.ai.claude.agent.ClaudeAgent
+import sttp.ai.claude.config.ClaudeConfig
+import sttp.ai.core.agent.mcp.McpTools
+import sttp.ai.core.agent.{AgentBuilder, AgentResult, AgentTool}
+import sttp.ai.openai.OpenAI
+import sttp.ai.openai.agent.OpenAIAgent
+import sttp.client4.DefaultSyncBackend
+import sttp.model.Uri.UriContext
+import sttp.monad.{IdentityMonad, MonadError}
+import sttp.shared.Identity
+import sttp.tapir.Schema
+import sttp.tapir.server.netty.sync.NettySyncServer
+
+/** Agent-level integration tests: an LLM drives tools loaded from a real (in-process) MCP server whose tool input has a nested object and
+  * an optional parameter — the two schema shapes that previously degraded per backend. Each test self-cancels without its API key.
+  */
+class McpAgentIntegrationSpec extends AnyFlatSpec with Matchers {
+
+  private given MonadError[Identity] = IdentityMonad
+
+  case class Location(lat: Double, lng: Double) derives Codec, Schema
+  case class CreateEventInput(title: String, location: Location, priority: Option[String]) derives Codec, Schema
+
+  private def withMcpAgentRun(builderFor: Seq[AgentTool[Identity, ?]] => AgentBuilder[Identity])(
+      check: AgentResult[String] => Assertion
+  ): Assertion =
+    supervised {
+      val createEvent = tool("create-event")
+        .description("Creates an event with a title at the given location; priority is optional")
+        .input[CreateEventInput]
+        .handle(in =>
+          ToolResult.text(s"Created '${in.title}' at (${in.location.lat}, ${in.location.lng}), priority=${in.priority.getOrElse("normal")}")
+        )
+      val binding = NettySyncServer().port(0).addEndpoint(McpServer(tools = List(createEvent)).endpoint(List("mcp"))).start()
+      try {
+        val backend = DefaultSyncBackend()
+        try {
+          val transport = ClientHttpTransport[Identity](backend, uri"http://localhost:${binding.port}/mcp")
+          val client = McpClient[Identity](transport, Implementation("sttp-ai-mcp-it", "0.0.1"))
+          try {
+            val tools = McpTools.fromClient(client)
+            val agent = builderFor(tools).maxIterations(5).build
+            val result = agent.run(
+              "Create an event titled 'Standup' at latitude 1.5 and longitude 2.5. Do not set a priority. Then report the tool's answer."
+            )(backend)
+            check(result)
+          } finally client.close()
+        } finally backend.close()
+      } finally binding.stop()
+    }
+
+  private def assertToolExecuted(result: AgentResult[String]): Assertion = {
+    result.toolCalls.map(_.toolName) should contain("create-event")
+    val output = result.toolCalls.filter(_.toolName == "create-event").map(_.output).mkString("\n")
+    output should include("Standup")
+    output should include("1.5")
+    output should include("2.5")
+  }
+
+  "an OpenAI agent" should "call an MCP tool with a nested and optional-parameter schema (strict mode)" in {
+    if (sys.env.get("OPENAI_API_KEY").forall(_.isEmpty)) cancel("OPENAI_API_KEY not defined - skipping integration test")
+    withMcpAgentRun(tools => OpenAIAgent.synchronous(OpenAI.fromEnv, "gpt-4o-mini").tools(tools))(assertToolExecuted)
+  }
+
+  "a Claude agent" should "call an MCP tool with a nested and optional-parameter schema" in {
+    if (sys.env.get("ANTHROPIC_API_KEY").forall(_.isEmpty)) cancel("ANTHROPIC_API_KEY not defined - skipping integration test")
+    withMcpAgentRun(tools => ClaudeAgent.synchronous(ClaudeConfig.fromEnv, "claude-haiku-4-5-20251001").tools(tools))(assertToolExecuted)
+  }
+}

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/integration/McpAgentIntegrationSpec.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/integration/McpAgentIntegrationSpec.scala
@@ -22,15 +22,16 @@ import sttp.shared.Identity
 import sttp.tapir.Schema
 import sttp.tapir.server.netty.sync.NettySyncServer
 
-/** Agent-level integration tests: an LLM drives tools loaded from a real (in-process) MCP server whose tool input has a nested object and
-  * an optional parameter — the two schema shapes that previously degraded per backend. Each test self-cancels without its API key.
+/** Agent-level integration tests: an LLM drives tools loaded from a real (in-process) MCP server whose tool input has an optional nested
+  * object and an optional scalar parameter — including the `type:["object","null"]` shape produced for optional objects under OpenAI
+  * strict-mode normalization — the schema shapes that previously degraded per backend. Each test self-cancels without its API key.
   */
 class McpAgentIntegrationSpec extends AnyFlatSpec with Matchers {
 
   private given MonadError[Identity] = IdentityMonad
 
   case class Location(lat: Double, lng: Double) derives Codec, Schema
-  case class CreateEventInput(title: String, location: Location, priority: Option[String]) derives Codec, Schema
+  case class CreateEventInput(title: String, location: Option[Location], priority: Option[String]) derives Codec, Schema
 
   private def withMcpAgentRun(builderFor: Seq[AgentTool[Identity, ?]] => AgentBuilder[Identity])(
       check: AgentResult[String] => Assertion
@@ -40,7 +41,10 @@ class McpAgentIntegrationSpec extends AnyFlatSpec with Matchers {
         .description("Creates an event with a title at the given location; priority is optional")
         .input[CreateEventInput]
         .handle(in =>
-          ToolResult.text(s"Created '${in.title}' at (${in.location.lat}, ${in.location.lng}), priority=${in.priority.getOrElse("normal")}")
+          ToolResult.text(
+            s"Created '${in.title}' at ${in.location.map(l => s"(${l.lat}, ${l.lng})").getOrElse("nowhere")}, priority=${in.priority
+                .getOrElse("normal")}"
+          )
         )
       val binding = NettySyncServer().port(0).addEndpoint(McpServer(tools = List(createEvent)).endpoint(List("mcp"))).start()
       try {
@@ -68,12 +72,12 @@ class McpAgentIntegrationSpec extends AnyFlatSpec with Matchers {
     output should include("2.5")
   }
 
-  "an OpenAI agent" should "call an MCP tool with a nested and optional-parameter schema (strict mode)" in {
+  "an OpenAI agent" should "call an MCP tool with an optional nested-object and optional-scalar schema (strict mode)" in {
     if (sys.env.get("OPENAI_API_KEY").forall(_.isEmpty)) cancel("OPENAI_API_KEY not defined - skipping integration test")
     withMcpAgentRun(tools => OpenAIAgent.synchronous(OpenAI.fromEnv, "gpt-4o-mini").tools(tools))(assertToolExecuted)
   }
 
-  "a Claude agent" should "call an MCP tool with a nested and optional-parameter schema" in {
+  "a Claude agent" should "call an MCP tool with an optional nested-object and optional-scalar schema" in {
     if (sys.env.get("ANTHROPIC_API_KEY").forall(_.isEmpty)) cancel("ANTHROPIC_API_KEY not defined - skipping integration test")
     withMcpAgentRun(tools => ClaudeAgent.synchronous(ClaudeConfig.fromEnv, "claude-haiku-4-5-20251001").tools(tools))(assertToolExecuted)
   }

--- a/openai/src/main/scala-2/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
+++ b/openai/src/main/scala-2/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
@@ -136,9 +136,8 @@ object OpenAIDerivedCodecs {
   implicit val chatStreamOptionsEncoder: Encoder[ChatRequestBody.StreamOptions] = deriveConfiguredEncoder
   implicit val updateChatCompletionRequestBodyEncoder: Encoder[ChatRequestBody.UpdateChatCompletionRequestBody] = deriveConfiguredEncoder
 
-  // chat ResponseFormat (encode-only): OpenAI tagged form via deriveAdtEncoder. Text / JsonObject -> {"type":"..."}, JsonSchema ->
-  // {"type":"json_schema","json_schema":{name, strict, schema, description}}.
-  implicit val chatResponseFormatEncoder: Encoder[ChatRequestBody.ResponseFormat] = deriveAdtEncoder
+  // chatResponseFormatEncoder: Encoder[ChatRequestBody.ResponseFormat] -- hand-written in OpenAIManualCodecs so the `json_schema` case can
+  // gate strict-mode schema normalization on the actual `strict` flag; see that file for rationale.
 
   // message Tool: OpenAI tagged form via deriveAdt*. function -> {"type":"function","function":{...}}, custom -> {"type":"custom","custom":{...}}.
   // The default `strict: false` on a function tool is omitted (matches the previous uPickle default-omission); an explicit `true` is kept.
@@ -601,7 +600,8 @@ object OpenAIDerivedCodecs {
       case _                                              => o
     }
   })
-  implicit val rrFormatEncoder: Encoder[RRB.Format] = deriveConfiguredEncoder
+  // rrFormatEncoder: Encoder[RRB.Format] -- hand-written in OpenAIManualCodecs (responsesRequestFormatEncoder) so the `json_schema` case
+  // can gate strict-mode normalization on the actual `strict` flag; see that file for rationale.
   implicit val rrPromptConfigEncoder: Encoder[RRB.PromptConfig] = deriveConfiguredEncoder
   implicit val rrReasoningConfigEncoder: Encoder[RRB.ReasoningConfig] = deriveConfiguredEncoder
   implicit val rrTextConfigEncoder: Encoder[RRB.TextConfig] = deriveConfiguredEncoder

--- a/openai/src/main/scala-3/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
+++ b/openai/src/main/scala-3/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
@@ -137,7 +137,8 @@ object OpenAIDerivedCodecs {
   implicit val chatStreamOptionsEncoder: Encoder[ChatRequestBody.StreamOptions] = ConfiguredEncoder.derived
   implicit val updateChatCompletionRequestBodyEncoder: Encoder[ChatRequestBody.UpdateChatCompletionRequestBody] = ConfiguredEncoder.derived
 
-  implicit val chatResponseFormatEncoder: Encoder[ChatRequestBody.ResponseFormat] = deriveAdtEncoder[ChatRequestBody.ResponseFormat]
+  // chatResponseFormatEncoder: Encoder[ChatRequestBody.ResponseFormat] -- hand-written in OpenAIManualCodecs so the `json_schema` case can
+  // gate strict-mode schema normalization on the actual `strict` flag; see that file for rationale.
   implicit val msgCustomFormatCodec: Codec[MsgTool.Custom.Format] = ConfiguredCodec.derived
   implicit val msgToolEncoder: Encoder[MsgTool] = {
     import sttp.ai.core.json.CirceHelpers.omitFalse
@@ -564,7 +565,8 @@ object OpenAIDerivedCodecs {
         case _                                              => o
       }
     })
-  implicit val rrFormatEncoder: Encoder[RRB.Format] = ConfiguredEncoder.derived
+  // rrFormatEncoder: Encoder[RRB.Format] -- hand-written in OpenAIManualCodecs (responsesRequestFormatEncoder) so the `json_schema` case
+  // can gate strict-mode normalization on the actual `strict` flag; see that file for rationale.
   implicit val rrPromptConfigEncoder: Encoder[RRB.PromptConfig] = ConfiguredEncoder.derived
   implicit val rrReasoningConfigEncoder: Encoder[RRB.ReasoningConfig] = ConfiguredEncoder.derived
   implicit val rrTextConfigEncoder: Encoder[RRB.TextConfig] = ConfiguredEncoder.derived

--- a/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
+++ b/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
@@ -14,11 +14,12 @@ private[openai] class OpenAIAgentBackend[F[_]](
     modelName: String,
     val tools: Seq[AgentTool[F, _]],
     val systemPrompt: Option[String],
-    responseSchema: Option[ResponseSchema[_]]
+    responseSchema: Option[ResponseSchema[_]],
+    strictTools: Boolean = true
 )(implicit monad: sttp.monad.MonadError[F])
     extends AgentBackend[F] {
 
-  private val convertedTools: Seq[Tool.Function] = tools.map(convertTool)
+  private[openai] val convertedTools: Seq[Tool.Function] = tools.map(convertTool)
 
   private val responseFormat: Option[ResponseFormat] = responseSchema.map { rs =>
     ResponseFormat.JsonSchema(
@@ -30,14 +31,15 @@ private[openai] class OpenAIAgentBackend[F[_]](
   }
 
   private def convertTool(tool: AgentTool[F, _]): Tool.Function = {
-    val schema = tool.jsonSchema
-    val schemaJson = SchemaSupport.schemaCodec(schema)
+    val schemaJson =
+      if (strictTools) SchemaSupport.schemaCodec(tool.jsonSchema)
+      else sttp.apispec.circe.encoderSchema(tool.jsonSchema).deepDropNullValues
 
     Tool.Function(
       name = tool.name,
       description = Some(tool.description),
       parameters = Some(schemaJson.asObject.map(_.toMap).getOrElse(Map.empty)),
-      strict = Some(true)
+      strict = Some(strictTools)
     )
   }
 
@@ -158,4 +160,32 @@ object OpenAIAgent {
       apiKey: String,
       modelName: String
   ): AgentBuilder[Identity] = builder[Identity](apiKey, modelName)(IdentityMonad)
+
+  def builder[F[_]](
+      openAI: OpenAI,
+      modelName: String,
+      strictTools: Boolean
+  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
+    AgentBuilder[F](config =>
+      new OpenAIAgentBackend[F](openAI, modelName, config.userTools, config.systemPrompt, config.responseSchema, strictTools)
+    )
+
+  def builder[F[_]](
+      apiKey: String,
+      modelName: String,
+      strictTools: Boolean
+  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
+    builder(new OpenAI(apiKey), modelName, strictTools)
+
+  def synchronous(
+      openAI: OpenAI,
+      modelName: String,
+      strictTools: Boolean
+  ): AgentBuilder[Identity] = builder[Identity](openAI, modelName, strictTools)(IdentityMonad)
+
+  def synchronous(
+      apiKey: String,
+      modelName: String,
+      strictTools: Boolean
+  ): AgentBuilder[Identity] = builder[Identity](apiKey, modelName, strictTools)(IdentityMonad)
 }

--- a/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
+++ b/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
@@ -32,8 +32,8 @@ private[openai] class OpenAIAgentBackend[F[_]](
 
   private def convertTool(tool: AgentTool[F, _]): Tool.Function = {
     val schemaJson =
-      if (strictTools) SchemaSupport.schemaCodec(tool.jsonSchema)
-      else sttp.apispec.circe.encoderSchema(tool.jsonSchema).deepDropNullValues
+      if (strictTools) SchemaSupport.normalizeForStrict(tool.rawJsonSchema)
+      else tool.rawJsonSchema
 
     Tool.Function(
       name = tool.name,
@@ -143,23 +143,23 @@ object OpenAIAgent {
       openAI: OpenAI,
       modelName: String
   )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
-    AgentBuilder[F](config => new OpenAIAgentBackend[F](openAI, modelName, config.userTools, config.systemPrompt, config.responseSchema))
+    builder(openAI, modelName, strictTools = true)
 
   def builder[F[_]](
       apiKey: String,
       modelName: String
   )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
-    builder(new OpenAI(apiKey), modelName)
+    builder(apiKey, modelName, strictTools = true)
 
   def synchronous(
       openAI: OpenAI,
       modelName: String
-  ): AgentBuilder[Identity] = builder[Identity](openAI, modelName)(IdentityMonad)
+  ): AgentBuilder[Identity] = synchronous(openAI, modelName, strictTools = true)
 
   def synchronous(
       apiKey: String,
       modelName: String
-  ): AgentBuilder[Identity] = builder[Identity](apiKey, modelName)(IdentityMonad)
+  ): AgentBuilder[Identity] = synchronous(apiKey, modelName, strictTools = true)
 
   def builder[F[_]](
       openAI: OpenAI,

--- a/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
+++ b/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
@@ -15,7 +15,7 @@ private[openai] class OpenAIAgentBackend[F[_]](
     val tools: Seq[AgentTool[F, _]],
     val systemPrompt: Option[String],
     responseSchema: Option[ResponseSchema[_]],
-    strictTools: Boolean = true
+    strictTools: Boolean
 )(implicit monad: sttp.monad.MonadError[F])
     extends AgentBackend[F] {
 

--- a/openai/src/main/scala/sttp/ai/openai/json/OpenAIJson.scala
+++ b/openai/src/main/scala/sttp/ai/openai/json/OpenAIJson.scala
@@ -4,7 +4,7 @@ import sttp.client4.ResponseException.UnexpectedStatusCode
 import sttp.client4._
 import sttp.model.ResponseMetadata
 import sttp.model.StatusCode._
-import io.circe.{parser, Decoder, Encoder}
+import io.circe.{parser, Decoder, Encoder, Json}
 import io.circe.syntax._
 import io.circe.generic.semiauto.deriveDecoder
 import sttp.model.MediaType
@@ -44,7 +44,75 @@ object OpenAIJson extends ResponseHandlers[OpenAIException, Decoder] {
 
   /** Serializes a value to a JSON request body, omitting `None`/null fields */
   def asJson[B: Encoder](b: B): StringBody =
-    StringBody(b.asJson.deepDropNullValues.noSpaces, "utf-8", MediaType.ApplicationJson)
+    StringBody(dropNullsPreservingSchemas(b.asJson).noSpaces, "utf-8", MediaType.ApplicationJson)
+
+  /** `deepDropNullValues` is applied to the whole request body to strip unset-`Option` fields (e.g. `user: null`), but it also strips null
+    * VALUES nested inside array elements, not just absent object fields. That corrupts tool schemas and response-format schemas that
+    * legitimately contain JSON `null` (e.g. `"enum": ["low", "high", null]`, produced by strict-mode nullability normalization via
+    * `SchemaSupport.normalizeForStrict`/`addNullToEnum`).
+    *
+    * To keep those schemas byte-faithful while still dropping unset-field nulls everywhere else: capture `tools[*].function.parameters` and
+    * `response_format.json_schema.schema` from the pre-drop encoding, run `deepDropNullValues` as before, then splice the untouched values
+    * back into the cleaned JSON. This is a safe no-op for the (large majority of) request bodies that have neither field.
+    */
+  private def dropNullsPreservingSchemas(bodyJson: Json): Json = {
+    val originalToolParameters: Option[Vector[Option[Json]]] =
+      bodyJson.asObject
+        .flatMap(_("tools"))
+        .flatMap(_.asArray)
+        .map(_.map(_.asObject.flatMap(_("function")).flatMap(_.asObject).flatMap(_("parameters"))))
+
+    val originalResponseFormatSchema: Option[Json] =
+      bodyJson.asObject
+        .flatMap(_("response_format"))
+        .flatMap(_.asObject)
+        .flatMap(_("json_schema"))
+        .flatMap(_.asObject)
+        .flatMap(_("schema"))
+
+    val cleaned = bodyJson.deepDropNullValues
+
+    val withToolsRestored = originalToolParameters match {
+      case Some(originalParameters) =>
+        cleaned.mapObject { obj =>
+          obj("tools").flatMap(_.asArray) match {
+            case Some(cleanedTools) =>
+              val restoredTools = cleanedTools.zip(originalParameters).map {
+                case (toolJson, Some(parameters)) =>
+                  toolJson.mapObject { toolObj =>
+                    toolObj("function").flatMap(_.asObject) match {
+                      case Some(functionObj) => toolObj.add("function", Json.fromJsonObject(functionObj.add("parameters", parameters)))
+                      case None              => toolObj
+                    }
+                  }
+                case (toolJson, None) => toolJson
+              }
+              obj.add("tools", Json.fromValues(restoredTools))
+            case None => obj
+          }
+        }
+      case None => cleaned
+    }
+
+    originalResponseFormatSchema match {
+      case Some(schema) =>
+        withToolsRestored.mapObject { obj =>
+          obj("response_format").flatMap(_.asObject) match {
+            case Some(responseFormatObj) =>
+              responseFormatObj("json_schema").flatMap(_.asObject) match {
+                case Some(jsonSchemaObj) =>
+                  obj.add(
+                    "response_format",
+                    Json.fromJsonObject(responseFormatObj.add("json_schema", Json.fromJsonObject(jsonSchemaObj.add("schema", schema))))
+                  )
+                case None => obj
+              }
+            case None => obj
+          }
+        }
+      case None => withToolsRestored
+    }
+  }
 
   def asStringEither: ResponseAs[Either[OpenAIException, String]] =
     asStringAlways

--- a/openai/src/main/scala/sttp/ai/openai/json/OpenAIJson.scala
+++ b/openai/src/main/scala/sttp/ai/openai/json/OpenAIJson.scala
@@ -51,16 +51,25 @@ object OpenAIJson extends ResponseHandlers[OpenAIException, Decoder] {
     * legitimately contain JSON `null` (e.g. `"enum": ["low", "high", null]`, produced by strict-mode nullability normalization via
     * `SchemaSupport.normalizeForStrict`/`addNullToEnum`).
     *
-    * To keep those schemas byte-faithful while still dropping unset-field nulls everywhere else: capture `tools[*].function.parameters` and
-    * `response_format.json_schema.schema` from the pre-drop encoding, run `deepDropNullValues` as before, then splice the untouched values
-    * back into the cleaned JSON. This is a safe no-op for the (large majority of) request bodies that have neither field.
+    * To keep those schemas byte-faithful while still dropping unset-field nulls everywhere else: capture the schema-bearing fields from the
+    * pre-drop encoding, run `deepDropNullValues` as before, then splice the untouched values back into the cleaned JSON. This covers both
+    * chat completions (`tools[*].function.parameters`, `response_format.json_schema.schema`) and the Responses API, which encodes the same
+    * kind of data at different paths: function tools are flat (`tools[*].parameters`, no nested `function` wrapper) and the structured
+    * output schema lives at `text.format.schema`. Capture sites use `.filter(!_.isNull)` because a field that's present with a JSON `null`
+    * value (e.g. `Tool.Function(parameters = None)`) is itself an unset-`Option` artifact that must stay dropped, not spliced back in. This
+    * is a safe no-op for the (large majority of) request bodies that have none of these fields.
     */
   private def dropNullsPreservingSchemas(bodyJson: Json): Json = {
-    val originalToolParameters: Option[Vector[Option[Json]]] =
+    val originalToolParameters: Option[Vector[(Option[Json], Option[Json])]] =
       bodyJson.asObject
         .flatMap(_("tools"))
         .flatMap(_.asArray)
-        .map(_.map(_.asObject.flatMap(_("function")).flatMap(_.asObject).flatMap(_("parameters"))))
+        .map(_.map { toolJson =>
+          val toolObj = toolJson.asObject
+          val nestedFunctionParameters = toolObj.flatMap(_("function")).flatMap(_.asObject).flatMap(_("parameters")).filter(!_.isNull)
+          val flatParameters = toolObj.flatMap(_("parameters")).filter(!_.isNull)
+          (nestedFunctionParameters, flatParameters)
+        })
 
     val originalResponseFormatSchema: Option[Json] =
       bodyJson.asObject
@@ -69,6 +78,16 @@ object OpenAIJson extends ResponseHandlers[OpenAIException, Decoder] {
         .flatMap(_("json_schema"))
         .flatMap(_.asObject)
         .flatMap(_("schema"))
+        .filter(!_.isNull)
+
+    val originalTextFormatSchema: Option[Json] =
+      bodyJson.asObject
+        .flatMap(_("text"))
+        .flatMap(_.asObject)
+        .flatMap(_("format"))
+        .flatMap(_.asObject)
+        .flatMap(_("schema"))
+        .filter(!_.isNull)
 
     val cleaned = bodyJson.deepDropNullValues
 
@@ -77,15 +96,18 @@ object OpenAIJson extends ResponseHandlers[OpenAIException, Decoder] {
         cleaned.mapObject { obj =>
           obj("tools").flatMap(_.asArray) match {
             case Some(cleanedTools) =>
-              val restoredTools = cleanedTools.zip(originalParameters).map {
-                case (toolJson, Some(parameters)) =>
-                  toolJson.mapObject { toolObj =>
-                    toolObj("function").flatMap(_.asObject) match {
-                      case Some(functionObj) => toolObj.add("function", Json.fromJsonObject(functionObj.add("parameters", parameters)))
-                      case None              => toolObj
-                    }
+              val restoredTools = cleanedTools.zip(originalParameters).map { case (toolJson, (nestedFunctionParameters, flatParameters)) =>
+                toolJson.mapObject { toolObj =>
+                  val withNested = (nestedFunctionParameters, toolObj("function").flatMap(_.asObject)) match {
+                    case (Some(parameters), Some(functionObj)) =>
+                      toolObj.add("function", Json.fromJsonObject(functionObj.add("parameters", parameters)))
+                    case _ => toolObj
                   }
-                case (toolJson, None) => toolJson
+                  flatParameters match {
+                    case Some(parameters) => withNested.add("parameters", parameters)
+                    case None             => withNested
+                  }
+                }
               }
               obj.add("tools", Json.fromValues(restoredTools))
             case None => obj
@@ -94,7 +116,7 @@ object OpenAIJson extends ResponseHandlers[OpenAIException, Decoder] {
       case None => cleaned
     }
 
-    originalResponseFormatSchema match {
+    val withResponseFormatRestored = originalResponseFormatSchema match {
       case Some(schema) =>
         withToolsRestored.mapObject { obj =>
           obj("response_format").flatMap(_.asObject) match {
@@ -111,6 +133,22 @@ object OpenAIJson extends ResponseHandlers[OpenAIException, Decoder] {
           }
         }
       case None => withToolsRestored
+    }
+
+    originalTextFormatSchema match {
+      case Some(schema) =>
+        withResponseFormatRestored.mapObject { obj =>
+          obj("text").flatMap(_.asObject) match {
+            case Some(textObj) =>
+              textObj("format").flatMap(_.asObject) match {
+                case Some(formatObj) =>
+                  obj.add("text", Json.fromJsonObject(textObj.add("format", Json.fromJsonObject(formatObj.add("schema", schema)))))
+                case None => obj
+              }
+            case None => obj
+          }
+        }
+      case None => withResponseFormatRestored
     }
   }
 

--- a/openai/src/main/scala/sttp/ai/openai/json/OpenAIManualCodecs.scala
+++ b/openai/src/main/scala/sttp/ai/openai/json/OpenAIManualCodecs.scala
@@ -11,6 +11,7 @@ import sttp.ai.openai.requests.completions.Stop
 import sttp.ai.openai.requests.completions.Stop.{MultipleStop, SingleStop}
 import sttp.ai.openai.requests.completions.chat.ChatRequestBody
 import sttp.ai.openai.requests.completions.chat.FunctionCall
+import sttp.ai.openai.requests.completions.chat.SchemaSupport
 import sttp.ai.openai.requests.completions.chat.ToolCall
 import sttp.ai.openai.requests.completions.chat.message.ToolResources
 import sttp.ai.openai.requests.embeddings.EmbeddingsRequestBody.{EmbeddingsInput, EmbeddingsModel}
@@ -101,6 +102,47 @@ object OpenAIManualCodecs {
     ),
     Encoder[String].contramap(_.value)
   )
+
+  // Hand-written (not `deriveAdtEncoder`) so the `json_schema` case can gate schema normalization on the actual `strict` flag: `strict:
+  // true` gets OpenAI strict-mode shape via `SchemaSupport.normalizeForStrict`, everything else (`None`/`Some(false)`) gets a faithful
+  // encoding via `SchemaSupport.schemaCodec`. Wire format otherwise matches the old `deriveAdtEncoder` output: `text` / `json_object` ->
+  // flat `{"type":"..."}`; `json_schema` -> `{"type":"json_schema","json_schema":{name, strict, schema, description}}`.
+  implicit val chatResponseFormatEncoder: Encoder[ChatRequestBody.ResponseFormat] = Encoder.instance {
+    case ChatRequestBody.ResponseFormat.Text                                          => Json.obj("type" -> "text".asJson)
+    case ChatRequestBody.ResponseFormat.JsonObject                                    => Json.obj("type" -> "json_object".asJson)
+    case ChatRequestBody.ResponseFormat.JsonSchema(name, strict, schema, description) =>
+      val schemaJson = schema.map { s =>
+        if (strict.contains(true)) SchemaSupport.normalizeForStrict(s) else SchemaSupport.schemaCodec(s)
+      }
+      Json.obj(
+        "type" -> "json_schema".asJson,
+        "json_schema" -> Json.obj(
+          "name" -> name.asJson,
+          "strict" -> strict.asJson,
+          "schema" -> schemaJson.asJson,
+          "description" -> description.asJson
+        )
+      )
+  }
+
+  // responses/ResponsesRequestBody `text.format` (encode-only): the Responses API analog of chat's `ResponseFormat`, same strict-mode
+  // shape rules, but the OpenAI wire form flattens the fields alongside "type" (no nested wrapper object). Hand-written for the same
+  // reason as `chatResponseFormatEncoder`: gate schema normalization on the actual `strict` flag instead of applying it unconditionally.
+  implicit val responsesRequestFormatEncoder: Encoder[ResponsesRequestBody.Format] = Encoder.instance {
+    case _: ResponsesRequestBody.Format.Text                                       => Json.obj("type" -> "text".asJson)
+    case _: ResponsesRequestBody.Format.JsonObject                                 => Json.obj("type" -> "json_object".asJson)
+    case ResponsesRequestBody.Format.JsonSchema(name, strict, schema, description) =>
+      val schemaJson = schema.map { s =>
+        if (strict.contains(true)) SchemaSupport.normalizeForStrict(s) else SchemaSupport.schemaCodec(s)
+      }
+      Json.obj(
+        "type" -> "json_schema".asJson,
+        "name" -> name.asJson,
+        "strict" -> strict.asJson,
+        "schema" -> schemaJson.asJson,
+        "description" -> description.asJson
+      )
+  }
 
   // --- completions/chat/ToolCall ---
   implicit val functionToolCallCodec: Codec[ToolCall.FunctionToolCall] = Codec.from(

--- a/openai/src/main/scala/sttp/ai/openai/requests/assistants/Tool.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/assistants/Tool.scala
@@ -59,7 +59,7 @@ object Tool {
       */
     def withTapirSchema[T: TSchema](description: String, name: String, strict: Option[Boolean]): Function = {
       val schema = TapirSchemaToJsonSchema(implicitly[TSchema[T]], markOptionsAsNullable = true)
-      val schemaJson = SchemaSupport.schemaCodec(schema)
+      val schemaJson = if (strict.contains(true)) SchemaSupport.normalizeForStrict(schema) else SchemaSupport.schemaCodec(schema)
       Function(description, name, schemaJson.asObject.map(_.toMap).getOrElse(Map.empty), strict)
     }
   }

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/SchemaSupport.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/SchemaSupport.scala
@@ -3,17 +3,29 @@ package sttp.ai.openai.requests.completions.chat
 import io.circe.syntax._
 import io.circe.{Codec, Encoder, Json, JsonNumber, JsonObject}
 import sttp.apispec.Schema
+import sttp.apispec.circe.encoderSchema
 
 object SchemaSupport {
 
-  /** circe codec for apispec `Schema` that, on encode, rewrites the JSON to satisfy OpenAI's structured-output rules (all fields required,
-    * `additionalProperties: false` on objects). Both directions delegate to the apispec circe codecs explicitly (rather than `asJson`/
-    * `Decoder[Schema]`) to avoid recursing into this codec.
+  /** circe codec for apispec `Schema` that encodes FAITHFULLY, i.e. it does not rewrite the JSON in any way: it's a plain apispec codec
+    * that additionally drops unset-field nulls (via `deepDropNullValues`) on encode. Use this whenever the caller has not asked for OpenAI
+    * strict-mode shape (e.g. `strict = None`/`Some(false)`, or a schema factory with no strict concept at all). For strict mode, use
+    * [[normalizeForStrict]] instead.
     */
   implicit val schemaCodec: Codec[Schema] = Codec.from(
     sttp.apispec.circe.schemaDecoder,
-    Encoder.instance(s => sttp.apispec.circe.encoderSchema(s).deepDropNullValues.foldWith(schemaFolder))
+    Encoder.instance(s => encoderSchema(s).deepDropNullValues)
   )
+
+  /** Normalizes a JSON Schema (already encoded as `Json`) to OpenAI's strict-mode rules: `additionalProperties: false` on every object,
+    * every property listed in `required`, and properties that were originally optional made nullable (including adding `null` to `enum`).
+    * Only apply this when the caller actually requested strict mode (`strict: true`); everything else should get a faithful encoding (see
+    * [[schemaCodec]]).
+    */
+  def normalizeForStrict(schemaJson: Json): Json = schemaJson.foldWith(schemaFolder)
+
+  /** Normalizes an apispec `Schema` to OpenAI's strict-mode rules. See [[normalizeForStrict(Json)]]. */
+  def normalizeForStrict(schema: Schema): Json = normalizeForStrict(encoderSchema(schema).deepDropNullValues)
 
   private case class FolderState(
       fields: List[(String, Json)],
@@ -44,7 +56,13 @@ object SchemaSupport {
 
       val state = value.toList.foldRight(FolderState(Nil, addAdditionalProperties = false, Nil)) { case ((k, v), acc) =>
         if (k == "properties") {
-          val foldedProps = v.foldWith(this)
+          // The container map's own entries are parameter NAMES (which may themselves be "properties", "type", "required", ...), not
+          // schema keywords: fold each entry's schema VALUE, but never fold the container object itself through `onObject` (F6 - doing so
+          // would treat a parameter literally named "properties"/"type"/"required" as if it were a schema keyword of the container).
+          val foldedProps = v.asObject match {
+            case Some(props) => Json.fromJsonObject(JsonObject.fromIterable(props.toList.map { case (n, s) => n -> s.foldWith(this) }))
+            case None        => v.foldWith(this)
+          }
           val nullableProps = foldedProps.asObject match {
             case Some(propsObj) =>
               Json.fromJsonObject(JsonObject.fromIterable(propsObj.toList.map { case (name, propSchema) =>
@@ -104,10 +122,19 @@ object SchemaSupport {
             if (types.contains(Json.fromString("null"))) propSchema
             else Json.fromJsonObject(addNullToEnum(obj.add("type", Json.fromValues(types :+ Json.fromString("null")))))
           case _ =>
-            Json.obj("anyOf" -> Json.arr(propSchema, Json.obj("type" -> Json.fromString("null"))))
+            if (isAlreadyNullableAnyOf(obj)) propSchema
+            else Json.obj("anyOf" -> Json.arr(propSchema, Json.obj("type" -> Json.fromString("null"))))
         }
       case None => propSchema
     }
+
+  /** F3 guard: a property may already be nullable via `anyOf: [X, {"type":"null"}]` (what tapir emits for `Option[<case class>]`, and a
+    * common MCP idiom). Wrapping it again in `anyOf` would double-wrap it, so detect this shape and leave it unchanged.
+    */
+  private def isAlreadyNullableAnyOf(obj: JsonObject): Boolean =
+    obj("anyOf")
+      .flatMap(_.asArray)
+      .exists(_.contains(Json.obj("type" -> Json.fromString("null"))))
 
   /** OpenAI requires optional enum properties to permit `null` in both `type` and `enum`
     * (https://platform.openai.com/docs/guides/structured-outputs#all-fields-must-be-required).

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/SchemaSupport.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/SchemaSupport.scala
@@ -37,14 +37,27 @@ object SchemaSupport {
     def onString(value: String): Json = Json.fromString(value)
     def onArray(value: Vector[Json]): Json = Json.fromValues(value.map(_.foldWith(this)))
     def onObject(value: JsonObject): Json = {
+      val originalRequired: Set[String] = value("required")
+        .flatMap(_.asArray)
+        .map(_.flatMap(_.asString).toSet)
+        .getOrElse(Set.empty)
+
       val state = value.toList.foldRight(FolderState(Nil, addAdditionalProperties = false, Nil)) { case ((k, v), acc) =>
-        if (k == "properties")
+        if (k == "properties") {
+          val foldedProps = v.foldWith(this)
+          val nullableProps = foldedProps.asObject match {
+            case Some(propsObj) =>
+              Json.fromJsonObject(JsonObject.fromIterable(propsObj.toList.map { case (name, propSchema) =>
+                if (originalRequired.contains(name)) name -> propSchema else name -> makeNullable(propSchema)
+              }))
+            case None => foldedProps
+          }
           acc.copy(
-            fields = (k, v.foldWith(this)) :: acc.fields,
+            fields = (k, nullableProps) :: acc.fields,
             addAdditionalProperties = true,
             requiredProperties = v.asObject.fold(List.empty[String])(_.keys.toList)
           )
-        else if (k == "type")
+        } else if (k == "type")
           acc.copy(
             fields = (k, v.foldWith(this)) :: acc.fields,
             addAdditionalProperties = acc.addAdditionalProperties || v.asString.contains("object")
@@ -74,4 +87,25 @@ object SchemaSupport {
       Json.fromFields(fields)
     }
   }
+
+  /** OpenAI strict mode requires every property to be listed in `required`; optionality is expressed by making the property's type nullable
+    * (https://platform.openai.com/docs/guides/structured-outputs#all-fields-must-be-required). Properties that were optional in the source
+    * schema (absent from its original `required`) are made nullable here before the full `required` list is emitted.
+    */
+  private def makeNullable(propSchema: Json): Json =
+    propSchema.asObject match {
+      case Some(obj) =>
+        obj("type") match {
+          case Some(t) if t.isString =>
+            if (t.asString.contains("null")) propSchema
+            else Json.fromJsonObject(obj.add("type", Json.arr(t, Json.fromString("null"))))
+          case Some(t) if t.isArray =>
+            val types = t.asArray.getOrElse(Vector.empty)
+            if (types.contains(Json.fromString("null"))) propSchema
+            else Json.fromJsonObject(obj.add("type", Json.fromValues(types :+ Json.fromString("null"))))
+          case _ =>
+            Json.obj("anyOf" -> Json.arr(propSchema, Json.obj("type" -> Json.fromString("null"))))
+        }
+      case None => propSchema
+    }
 }

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/SchemaSupport.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/SchemaSupport.scala
@@ -98,14 +98,23 @@ object SchemaSupport {
         obj("type") match {
           case Some(t) if t.isString =>
             if (t.asString.contains("null")) propSchema
-            else Json.fromJsonObject(obj.add("type", Json.arr(t, Json.fromString("null"))))
+            else Json.fromJsonObject(addNullToEnum(obj.add("type", Json.arr(t, Json.fromString("null")))))
           case Some(t) if t.isArray =>
             val types = t.asArray.getOrElse(Vector.empty)
             if (types.contains(Json.fromString("null"))) propSchema
-            else Json.fromJsonObject(obj.add("type", Json.fromValues(types :+ Json.fromString("null"))))
+            else Json.fromJsonObject(addNullToEnum(obj.add("type", Json.fromValues(types :+ Json.fromString("null")))))
           case _ =>
             Json.obj("anyOf" -> Json.arr(propSchema, Json.obj("type" -> Json.fromString("null"))))
         }
       case None => propSchema
+    }
+
+  /** OpenAI requires optional enum properties to permit `null` in both `type` and `enum`
+    * (https://platform.openai.com/docs/guides/structured-outputs#all-fields-must-be-required).
+    */
+  private def addNullToEnum(obj: JsonObject): JsonObject =
+    obj("enum").flatMap(_.asArray) match {
+      case Some(values) if !values.contains(Json.Null) => obj.add("enum", Json.fromValues(values :+ Json.Null))
+      case _                                           => obj
     }
 }

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/message/Tool.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/message/Tool.scala
@@ -59,7 +59,8 @@ object Tool {
       */
     def withSchema[T: TSchema](name: String, description: Option[String], strict: Option[Boolean]): Function = {
       val schema = TapirSchemaToJsonSchema(implicitly[TSchema[T]], markOptionsAsNullable = true)
-      Function(name, description, SchemaSupport.schemaCodec(schema).asObject.map(_.toMap), strict)
+      val schemaJson = if (strict.contains(true)) SchemaSupport.normalizeForStrict(schema) else SchemaSupport.schemaCodec(schema)
+      Function(name, description, schemaJson.asObject.map(_.toMap), strict)
     }
   }
 

--- a/openai/src/main/scala/sttp/ai/openai/requests/responses/Tool.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/responses/Tool.scala
@@ -58,7 +58,7 @@ object Tool {
       */
     def withTapirSchema[T: TSchema](name: String, description: Option[String], strict: Boolean): Function = {
       val schema = TapirSchemaToJsonSchema(implicitly[TSchema[T]], markOptionsAsNullable = true)
-      val schemaJson = SchemaSupport.schemaCodec(schema)
+      val schemaJson = if (strict) SchemaSupport.normalizeForStrict(schema) else SchemaSupport.schemaCodec(schema)
       Function(name, schemaJson.asObject.map(_.toMap).getOrElse(Map.empty), strict, description)
     }
   }

--- a/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
@@ -24,10 +24,8 @@ class OpenAIAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
   private def backend(strictTools: Boolean): OpenAIAgentBackend[Identity] =
     new OpenAIAgentBackend[Identity](new OpenAI("test-key"), "gpt-4o-mini", Seq(testTool), None, None, strictTools)(IdentityMonad)
 
-  "OpenAIAgentBackend" should "register tools as strict with normalized schemas by default" in {
-    val fn = new OpenAIAgentBackend[Identity](new OpenAI("test-key"), "gpt-4o-mini", Seq(testTool), None, None)(
-      IdentityMonad
-    ).convertedTools.head
+  "OpenAIAgentBackend" should "register tools as strict with normalized schemas when strictTools is true" in {
+    val fn = backend(strictTools = true).convertedTools.head
     fn.strict shouldBe Some(true)
     val params = Json.fromFields(fn.parameters.get)
     params.hcursor.downField("additionalProperties").as[Boolean] shouldBe Right(false)

--- a/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
@@ -1,0 +1,46 @@
+package sttp.ai.openai.agent
+
+import io.circe.Json
+import io.circe.parser.parse
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.core.agent.AgentTool
+import sttp.ai.openai.OpenAI
+import sttp.apispec.Schema
+import sttp.monad.IdentityMonad
+import sttp.shared.Identity
+
+class OpenAIAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  private val rawSchema =
+    """{"type":"object","properties":{"title":{"type":"string"},"note":{"type":"string"}},"required":["title"]}"""
+
+  private def testTool: AgentTool[Identity, _] = {
+    val schema = parse(rawSchema).value.as[Schema](sttp.apispec.circe.schemaDecoder).value
+    AgentTool.dynamic("create", "Creates a thing", schema)(_ => "ok")
+  }
+
+  private def backend(strictTools: Boolean): OpenAIAgentBackend[Identity] =
+    new OpenAIAgentBackend[Identity](new OpenAI("test-key"), "gpt-4o-mini", Seq(testTool), None, None, strictTools)(IdentityMonad)
+
+  "OpenAIAgentBackend" should "register tools as strict with normalized schemas by default" in {
+    val fn = new OpenAIAgentBackend[Identity](new OpenAI("test-key"), "gpt-4o-mini", Seq(testTool), None, None)(
+      IdentityMonad
+    ).convertedTools.head
+    fn.strict shouldBe Some(true)
+    val params = Json.fromFields(fn.parameters.get)
+    params.hcursor.downField("additionalProperties").as[Boolean] shouldBe Right(false)
+    params.hcursor.downField("required").as[List[String]] shouldBe Right(List("title", "note"))
+    params.hcursor.downField("properties").downField("note").downField("type").as[List[String]] shouldBe Right(List("string", "null"))
+  }
+
+  it should "register tools as non-strict with the original schema when strictTools is false" in {
+    val fn = backend(strictTools = false).convertedTools.head
+    fn.strict shouldBe Some(false)
+    val params = Json.fromFields(fn.parameters.get)
+    params.hcursor.downField("additionalProperties").focus shouldBe None
+    params.hcursor.downField("required").as[List[String]] shouldBe Right(List("title"))
+    params.hcursor.downField("properties").downField("note").downField("type").as[String] shouldBe Right("string")
+  }
+}

--- a/openai/src/test/scala/sttp/ai/openai/integration/OpenAIAgentIntegrationSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/integration/OpenAIAgentIntegrationSpec.scala
@@ -20,7 +20,8 @@ class OpenAIAgentIntegrationSpec extends AgentIntegrationSpecBase {
       "gpt-4o-mini",
       agentConfig.userTools,
       agentConfig.systemPrompt,
-      agentConfig.responseSchema
+      agentConfig.responseSchema,
+      strictTools = true
     )(IdentityMonad)
     Agent(agentBackend, agentConfig)(IdentityMonad)
   }

--- a/openai/src/test/scala/sttp/ai/openai/json/OpenAIJsonSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/json/OpenAIJsonSpec.scala
@@ -1,0 +1,73 @@
+package sttp.ai.openai.json
+
+import io.circe.Json
+import io.circe.parser.parse
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.apispec.{ExampleSingleValue, Schema, SchemaType}
+import sttp.ai.openai.OpenAI
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.{ChatBody, ChatCompletionModel}
+import sttp.ai.openai.requests.completions.chat.SchemaSupport
+import sttp.ai.openai.requests.completions.chat.message.{Content, Message, Tool}
+import sttp.client4.StringBody
+
+import scala.collection.immutable.ListMap
+
+/** Regression coverage for the null-drop-vs-schema-fidelity fix in [[OpenAIJson.asJson]]: `deepDropNullValues` is applied to the whole
+  * request body (to omit unset `Option` fields), but it also strips null VALUES nested inside JSON arrays, which corrupts tool `parameters`
+  * schemas that legitimately contain `null` -- in particular the `null` that `SchemaSupport.normalizeForStrict` adds to an optional
+  * property's `enum` so strict mode can accept it as "not provided". The body must preserve `tools[*].function.parameters` verbatim while
+  * still dropping unset-field nulls everywhere else.
+  */
+class OpenAIJsonSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  private def requestBodyOf(chatBody: ChatBody): String =
+    new OpenAI("test-key").createChatCompletion(chatBody).body match {
+      case StringBody(s, _, _) => s
+      case other               => fail(s"expected a StringBody request body, got $other")
+    }
+
+  "OpenAI.createChatCompletion" should
+    "retain the null strict-mode normalization adds to an optional enum property, while dropping unrelated unset-field nulls" in {
+      val schema = Schema(SchemaType.Object).copy(
+        properties = ListMap(
+          "name" -> Schema(SchemaType.String),
+          "priority" -> Schema(SchemaType.String).copy(`enum` = Some(List(ExampleSingleValue("low"), ExampleSingleValue("high"))))
+        ),
+        required = List("name") // "priority" is optional -> normalizeForStrict makes it nullable and appends null to its enum
+      )
+      val parametersJson = SchemaSupport.normalizeForStrict(schema)
+
+      val tool = Tool.Function(
+        name = "set_priority",
+        description = Some("Sets the priority"),
+        parameters = parametersJson.asObject.map(_.toMap),
+        strict = Some(true)
+      )
+
+      val chatBody = ChatBody(
+        messages = Seq(Message.User(content = Content.TextContent("hi"))),
+        model = ChatCompletionModel.GPT4oMini,
+        tools = Some(Seq(tool))
+        // frequencyPenalty, user, seed, ... are all left as their `None` default: their JSON `null`s should be dropped.
+      )
+
+      val json = parse(requestBodyOf(chatBody)).value
+
+      val enumValues = json.hcursor
+        .downField("tools")
+        .downArray
+        .downField("function")
+        .downField("parameters")
+        .downField("properties")
+        .downField("priority")
+        .get[List[Json]]("enum")
+        .value
+      enumValues should contain(Json.Null)
+
+      json.hcursor.downField("frequency_penalty").succeeded shouldBe false
+      json.hcursor.downField("user").succeeded shouldBe false
+      json.hcursor.downField("tool_choice").succeeded shouldBe false
+    }
+}

--- a/openai/src/test/scala/sttp/ai/openai/json/OpenAIJsonSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/json/OpenAIJsonSpec.scala
@@ -7,9 +7,12 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.apispec.{ExampleSingleValue, Schema, SchemaType}
 import sttp.ai.openai.OpenAI
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody
 import sttp.ai.openai.requests.completions.chat.ChatRequestBody.{ChatBody, ChatCompletionModel}
 import sttp.ai.openai.requests.completions.chat.SchemaSupport
 import sttp.ai.openai.requests.completions.chat.message.{Content, Message, Tool}
+import sttp.ai.openai.requests.responses.{ResponsesModel, ResponsesRequestBody, Tool => RespTool}
+import sttp.ai.openai.requests.responses.ResponsesRequestBody.{Format => RequestFormat, TextConfig => RequestTextConfig}
 import sttp.client4.StringBody
 
 import scala.collection.immutable.ListMap
@@ -70,4 +73,109 @@ class OpenAIJsonSpec extends AnyFlatSpec with Matchers with EitherValues {
       json.hcursor.downField("user").succeeded shouldBe false
       json.hcursor.downField("tool_choice").succeeded shouldBe false
     }
+
+  it should "omit the parameters key entirely when a Tool.Function has no parameters (capture-leak regression)" in {
+    val tool = Tool.Function(name = "no_args_tool", description = Some("Takes no arguments"), parameters = None, strict = Some(true))
+
+    val chatBody = ChatBody(
+      messages = Seq(Message.User(content = Content.TextContent("hi"))),
+      model = ChatCompletionModel.GPT4oMini,
+      tools = Some(Seq(tool))
+    )
+
+    val json = parse(requestBodyOf(chatBody)).value
+
+    json.hcursor.downField("tools").downArray.downField("function").downField("parameters").succeeded shouldBe false
+  }
+
+  it should "omit the schema key entirely when a ResponseFormat.JsonSchema has no schema (capture-leak regression)" in {
+    val chatBody = ChatBody(
+      messages = Seq(Message.User(content = Content.TextContent("hi"))),
+      model = ChatCompletionModel.GPT4oMini,
+      responseFormat =
+        Some(ChatRequestBody.ResponseFormat.JsonSchema(name = "my_schema", strict = Some(true), schema = None, description = None))
+    )
+
+    val json = parse(requestBodyOf(chatBody)).value
+
+    json.hcursor.downField("response_format").downField("json_schema").downField("schema").succeeded shouldBe false
+  }
+
+  private def responsesRequestBodyOf(requestBody: ResponsesRequestBody): String =
+    new OpenAI("test-key").createModelResponse(requestBody).body match {
+      case StringBody(s, _, _) => s
+      case other               => fail(s"expected a StringBody request body, got $other")
+    }
+
+  "OpenAI.createModelResponse" should
+    "retain the null strict-mode normalization adds to an optional enum property in a flat Responses-API function tool" in {
+      val schema = Schema(SchemaType.Object).copy(
+        properties = ListMap(
+          "name" -> Schema(SchemaType.String),
+          "priority" -> Schema(SchemaType.String).copy(`enum` = Some(List(ExampleSingleValue("low"), ExampleSingleValue("high"))))
+        ),
+        required = List("name") // "priority" is optional -> normalizeForStrict makes it nullable and appends null to its enum
+      )
+      val parametersJson = SchemaSupport.normalizeForStrict(schema)
+
+      val tool = RespTool.Function(
+        name = "set_priority",
+        parameters = parametersJson.asObject.map(_.toMap).getOrElse(Map.empty),
+        strict = true,
+        description = Some("Sets the priority")
+      )
+
+      val requestBody = ResponsesRequestBody(
+        model = Some(ResponsesModel.GPT4o),
+        input = Some(Left("hi")),
+        tools = Some(List(tool))
+      )
+
+      val json = parse(responsesRequestBodyOf(requestBody)).value
+
+      // Unlike chat's `tools[*].function.parameters`, the Responses API encodes function tools flat: `tools[*].parameters`.
+      val enumValues = json.hcursor
+        .downField("tools")
+        .downArray
+        .downField("parameters")
+        .downField("properties")
+        .downField("priority")
+        .get[List[Json]]("enum")
+        .value
+      enumValues should contain(Json.Null)
+
+      json.hcursor.downField("temperature").succeeded shouldBe false
+    }
+
+  it should "retain the enum null at text.format.schema for a strict Responses-API JsonSchema format" in {
+    val schema = Schema(SchemaType.Object).copy(
+      properties = ListMap(
+        "name" -> Schema(SchemaType.String),
+        "priority" -> Schema(SchemaType.String).copy(`enum` = Some(List(ExampleSingleValue("low"), ExampleSingleValue("high"))))
+      ),
+      required = List("name") // "priority" is optional -> normalizeForStrict (triggered by strict = Some(true)) appends null to its enum
+    )
+
+    val requestBody = ResponsesRequestBody(
+      model = Some(ResponsesModel.GPT4o),
+      input = Some(Left("hi")),
+      text = Some(
+        RequestTextConfig(format =
+          Some(RequestFormat.JsonSchema(name = "priority_schema", strict = Some(true), schema = Some(schema), description = None))
+        )
+      )
+    )
+
+    val json = parse(responsesRequestBodyOf(requestBody)).value
+
+    val enumValues = json.hcursor
+      .downField("text")
+      .downField("format")
+      .downField("schema")
+      .downField("properties")
+      .downField("priority")
+      .get[List[Json]]("enum")
+      .value
+    enumValues should contain(Json.Null)
+  }
 }

--- a/openai/src/test/scala/sttp/ai/openai/openai/fixtures/JsonSchemaFixture.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/fixtures/JsonSchemaFixture.scala
@@ -53,10 +53,10 @@ object JsonSchemaFixture {
       |      "type": "object",
       |      "properties": {
       |        "foo": {
-      |          "type": "string"
+      |          "type": ["string", "null"]
       |        },
       |        "bar": {
-      |          "type": "number"
+      |          "type": ["number", "null"]
       |        }
       |      }
       |    }

--- a/openai/src/test/scala/sttp/ai/openai/openai/fixtures/ToolFixture.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/fixtures/ToolFixture.scala
@@ -2,6 +2,8 @@ package sttp.ai.openai.fixtures
 
 object ToolFixture {
 
+  // Non-strict (the 2-arg `withSchema` defaults to `strict = Some(false)`): the schema is encoded FAITHFULLY -- no injected
+  // `additionalProperties: false`, `required` kept as produced by tapir.
   val jsonToolCall: String =
     """{
       |  "type": "function",
@@ -9,7 +11,6 @@ object ToolFixture {
       |    "description": "Books a flight for a passenger with full details",
       |    "name": "book_flight",
       |    "parameters": {
-      |      "additionalProperties": false,
       |      "required": [
       |        "passenger",
       |        "departureCity",
@@ -18,7 +19,6 @@ object ToolFixture {
       |      "$schema": "https://json-schema.org/draft/2020-12/schema",
       |      "$defs": {
       |        "Passenger": {
-      |          "additionalProperties": false,
       |          "required": [
       |            "name",
       |            "age"

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/JsonSchemaSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/JsonSchemaSpec.scala
@@ -1,12 +1,13 @@
 package sttp.ai.openai.requests.completions.chat
 
+import io.circe.Json
 import io.circe.parser.parse
 import io.circe.syntax._
 import sttp.ai.openai.json.OpenAIDerivedCodecs._
 import sttp.ai.openai.json.OpenAIManualCodecs._
 
 import cats.implicits.catsSyntaxOptionId
-import org.scalatest.EitherValues
+import org.scalatest.{EitherValues, OptionValues}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.apispec.{Schema, SchemaType}
@@ -16,7 +17,7 @@ import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ResponseFormat.J
 
 import scala.collection.immutable.ListMap
 
-class JsonSchemaSpec extends AnyFlatSpec with Matchers with EitherValues {
+class JsonSchemaSpec extends AnyFlatSpec with Matchers with EitherValues with OptionValues {
   "Given string JSON schema" should "be properly serialized to Json" in {
     val schema = Schema(SchemaType.String)
 
@@ -66,5 +67,20 @@ class JsonSchemaSpec extends AnyFlatSpec with Matchers with EitherValues {
     val serializedSchema = (JsonSchema("testArray", true.some, schema.some, None): ResponseFormat).asJson.deepDropNullValues
 
     serializedSchema shouldBe jsonArraySchema
+  }
+
+  "Given object JSON schema with strict = None" should "be serialized faithfully, without strict-mode additionalProperties/required injection" in {
+    val schema = Schema(SchemaType.Object)
+      .copy(properties = ListMap("foo" -> Schema(SchemaType.String), "bar" -> Schema(SchemaType.Number)))
+
+    val serializedSchema = (JsonSchema("testObject", None, schema.some, None): ResponseFormat).asJson.deepDropNullValues
+
+    val schemaJson = serializedSchema.hcursor.downField("json_schema").get[Json]("schema").value
+    val schemaObj = schemaJson.asObject.value
+
+    schemaObj.contains("additionalProperties") shouldBe false
+    schemaObj.contains("required") shouldBe false
+    schemaJson.hcursor.downField("properties").downField("foo").get[String]("type").value shouldBe "string"
+    schemaJson.hcursor.downField("properties").downField("bar").get[String]("type").value shouldBe "number"
   }
 }

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/SchemaSupportSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/SchemaSupportSpec.scala
@@ -1,0 +1,117 @@
+package sttp.ai.openai.requests.completions.chat
+
+import io.circe.Json
+import io.circe.parser.parse
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.apispec.Schema
+
+class SchemaSupportSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  private def normalize(rawSchema: String): Json = {
+    val schema = parse(rawSchema).value.as[Schema](sttp.apispec.circe.schemaDecoder).value
+    SchemaSupport.schemaCodec(schema)
+  }
+
+  "strict-mode normalization" should "make an optional property with a simple type nullable" in {
+    val result = normalize("""{"type":"object","properties":{"a":{"type":"string"},"b":{"type":"integer"}},"required":["a"]}""")
+    val expected = parse(
+      """{"type":"object",
+        |"properties":{"a":{"type":"string"},"b":{"type":["integer","null"]}},
+        |"required":["a","b"],
+        |"additionalProperties":false}""".stripMargin
+    ).value
+    result shouldBe expected
+  }
+
+  it should "append null to an optional property that already has a type array" in {
+    val result = normalize("""{"type":"object","properties":{"a":{"type":["string","integer"]}},"required":[]}""")
+    val expected = parse(
+      """{"type":"object",
+        |"properties":{"a":{"type":["string","integer","null"]}},
+        |"required":["a"],
+        |"additionalProperties":false}""".stripMargin
+    ).value
+    result shouldBe expected
+  }
+
+  it should "not add null twice to an already-nullable optional property" in {
+    val result = normalize("""{"type":"object","properties":{"a":{"type":["string","null"]}}}""")
+    val expected = parse(
+      """{"type":"object",
+        |"properties":{"a":{"type":["string","null"]}},
+        |"required":["a"],
+        |"additionalProperties":false}""".stripMargin
+    ).value
+    result shouldBe expected
+  }
+
+  it should "wrap an optional property without a type in anyOf with a null schema" in {
+    val result = normalize(
+      """{"type":"object","properties":{"a":{"anyOf":[{"type":"string"},{"type":"integer"}]}},"required":[]}"""
+    )
+    val expected = parse(
+      """{"type":"object",
+        |"properties":{"a":{"anyOf":[{"anyOf":[{"type":"string"},{"type":"integer"}]},{"type":"null"}]}},
+        |"required":["a"],
+        |"additionalProperties":false}""".stripMargin
+    ).value
+    result shouldBe expected
+  }
+
+  it should "treat all properties as optional when the object has no required array" in {
+    val result = normalize("""{"type":"object","properties":{"a":{"type":"string"}}}""")
+    val expected = parse(
+      """{"type":"object",
+        |"properties":{"a":{"type":["string","null"]}},
+        |"required":["a"],
+        |"additionalProperties":false}""".stripMargin
+    ).value
+    result shouldBe expected
+  }
+
+  it should "apply nullability recursively inside nested objects" in {
+    val result = normalize(
+      """{"type":"object",
+        |"properties":{
+        |  "location":{"type":"object","properties":{"lat":{"type":"number"},"note":{"type":"string"}},"required":["lat"]}
+        |},
+        |"required":["location"]}""".stripMargin
+    )
+    val expected = parse(
+      """{"type":"object",
+        |"properties":{
+        |  "location":{"type":"object",
+        |    "properties":{"lat":{"type":"number"},"note":{"type":["string","null"]}},
+        |    "required":["lat","note"],
+        |    "additionalProperties":false}
+        |},
+        |"required":["location"],
+        |"additionalProperties":false}""".stripMargin
+    ).value
+    result shouldBe expected
+  }
+
+  it should "keep originally-required properties unchanged" in {
+    val result = normalize("""{"type":"object","properties":{"a":{"type":"string"}},"required":["a"]}""")
+    val expected = parse(
+      """{"type":"object",
+        |"properties":{"a":{"type":"string"}},
+        |"required":["a"],
+        |"additionalProperties":false}""".stripMargin
+    ).value
+    result shouldBe expected
+  }
+
+  it should "still skip additionalProperties on discriminated unions" in {
+    val result = normalize(
+      """{"type":"object",
+        |"properties":{"kind":{"type":"string"}},
+        |"required":["kind"],
+        |"discriminator":{"propertyName":"kind"}}""".stripMargin
+    )
+    result.hcursor.downField("additionalProperties").focus shouldBe None
+    result.hcursor.downField("required").as[List[String]] shouldBe Right(List("kind"))
+  }
+}

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/SchemaSupportSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/SchemaSupportSpec.scala
@@ -9,10 +9,8 @@ import sttp.apispec.Schema
 
 class SchemaSupportSpec extends AnyFlatSpec with Matchers with EitherValues {
 
-  private def normalize(rawSchema: String): Json = {
-    val schema = parse(rawSchema).value.as[Schema](sttp.apispec.circe.schemaDecoder).value
-    SchemaSupport.schemaCodec(schema)
-  }
+  private def normalize(rawSchema: String): Json =
+    SchemaSupport.normalizeForStrict(parse(rawSchema).value)
 
   "strict-mode normalization" should "make an optional property with a simple type nullable" in {
     val result = normalize("""{"type":"object","properties":{"a":{"type":"string"},"b":{"type":"integer"}},"required":["a"]}""")
@@ -124,5 +122,54 @@ class SchemaSupportSpec extends AnyFlatSpec with Matchers with EitherValues {
     )
     result.hcursor.downField("additionalProperties").focus shouldBe None
     result.hcursor.downField("required").as[List[String]] shouldBe Right(List("kind"))
+  }
+
+  // F3: a property already nullable via anyOf (what tapir emits for Option[<case class>], and a common MCP idiom) must not be
+  // double-wrapped in another anyOf.
+  it should "not double-wrap an optional property that is already nullable via anyOf" in {
+    val result = normalize(
+      """{"type":"object",
+        |"properties":{"a":{"anyOf":[{"type":"string"},{"type":"null"}]}},
+        |"required":[]}""".stripMargin
+    )
+    val expected = parse(
+      """{"type":"object",
+        |"properties":{"a":{"anyOf":[{"type":"string"},{"type":"null"}]}},
+        |"required":["a"],
+        |"additionalProperties":false}""".stripMargin
+    ).value
+    result shouldBe expected
+  }
+
+  // F6: the folder must not treat the `properties` CONTAINER map as a schema. A parameter literally named `properties`/`type` must keep
+  // its own shape intact - no anyOf mangling, no `additionalProperties` injected INSIDE the container map itself.
+  it should "not corrupt parameters literally named properties or type" in {
+    val result = normalize(
+      """{"type":"object",
+        |"properties":{
+        |  "properties":{"type":"object","properties":{"x":{"type":"string"}},"required":["x"]},
+        |  "type2":{"type":"string"}
+        |},
+        |"required":["properties"]}""".stripMargin
+    )
+    val expected = parse(
+      """{"type":"object",
+        |"properties":{
+        |  "properties":{"type":"object","properties":{"x":{"type":"string"}},"required":["x"],"additionalProperties":false},
+        |  "type2":{"type":["string","null"]}
+        |},
+        |"required":["properties","type2"],
+        |"additionalProperties":false}""".stripMargin
+    ).value
+    result shouldBe expected
+  }
+
+  "the faithful codec" should "no longer inject additionalProperties or rewrite required" in {
+    val rawSchema = """{"type":"object","properties":{"a":{"type":"string"},"b":{"type":"integer"}},"required":["a"]}"""
+    val schema = parse(rawSchema).value.as[Schema](sttp.apispec.circe.schemaDecoder).value
+
+    val result = SchemaSupport.schemaCodec(schema)
+
+    result shouldBe parse(rawSchema).value
   }
 }

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/SchemaSupportSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/SchemaSupportSpec.scala
@@ -104,6 +104,17 @@ class SchemaSupportSpec extends AnyFlatSpec with Matchers with EitherValues {
     result shouldBe expected
   }
 
+  it should "add null to the enum of an optional enum property" in {
+    val result = normalize("""{"type":"object","properties":{"a":{"type":"string","enum":["x","y"]}},"required":[]}""")
+    val expected = parse(
+      """{"type":"object",
+        |"properties":{"a":{"type":["string","null"],"enum":["x","y",null]}},
+        |"required":["a"],
+        |"additionalProperties":false}""".stripMargin
+    ).value
+    result shouldBe expected
+  }
+
   it should "still skip additionalProperties on discriminated unions" in {
     val result = normalize(
       """{"type":"object",


### PR DESCRIPTION
## What

OpenAI — strict mode made correct, and optional.
- Optional parameters survive strict mode: originally-optional properties are encoded per OpenAI's documented pattern ("type": [..., "null"], null appended to enums), recursively per nesting level, instead of being silently forced mandatory (the model previously had to invent values for them). Already-nullable anyOf properties (tapir's Option[caseclass] shape) are not double-wrapped.
- Normalization is applied only where strict is actually requested: it moved out of the shared implicit Codec[Schema] into an explicit SchemaSupport.normalizeForStrict, so structured outputs and withSchema/withTapirSchema with strict = false/absent now get a faithful encoding (previously they were rewritten unconditionally, with no opt-out).
- Escape hatch: strictTools flag on the OpenAIAgent factories (default true): OpenAIAgent.synchronous(OpenAI.fromEnv, "gpt-4o-mini", strictTools = false) registers tools non-strict with their original schemas.
- Normalizer bug fixes: a parameter literally named properties/type/required no longer corrupts the schema (the properties container was folded as if it were itself a schema — pre-existing, made destructive by the nullability rewrite, now fixed properly).

Claude — flattening removed, full pass-through.
- New additive Tool.CustomRaw(name, description, inputSchema: Json, cacheControl) (existing Tool.Custom/ToolInputSchema/PropertySchema untouched; decoder falls back to CustomRaw only for JSON Custom can't represent, so existing decode behavior is preserved).
- ClaudeAgentBackend sends the schema structure verbatim instead of collapsing it to a flat type/description/enum map, adding only a top-level "type": "object" when the schema omits it (Anthropic requires it; MCP allows {} for no-arg tools — previously a request-time 400).

Cross-cutting — the schema you get is the schema the server sent.
- AgentTool.rawJsonSchema: Json (core, default derived from jsonSchema): MCP tools carry the server's original schema JSON end-to-end, eliminating the lossy apispec round-trip (which stringified enum nulls and dropped unknown keywords).
- Both clients' send-time deepDropNullValues now exempts schema subtrees, so legitimate JSON nulls in schemas (enum: [..., null], default: null) reach the wire intact.
- Client-introduced nulls are cleaned up before they hit MCP servers: arguments that are null for parameters the server declared optional-by-absence are stripped before tools/call (validating servers, e.g. zod .optional(), reject explicit nulls); nulls for server-required params are forwarded as-is.

## Testing

- Unit/golden coverage for every rule: SchemaSupportSpec (nullability incl. enums, idempotency, anyOf guard, keyword-named params, recursion, discriminator skip, faithful codec), OpenAIAgentBackendSpec (both strict modes), ToolCustomRawSpec (wire JSON + decode fallback), ClaudeAgentBackendSpec (nested + byte-identical pass-through + type default), McpToolsSpec (raw pass-through, null-strip keep/drop), serialization specs proving schema nulls survive request encoding while other nulls are still dropped.
- API-key-gated McpAgentIntegrationSpec (self-cancels without keys — zero CI cost): an agent per backend drives a tool from an in-process chimp MCP server whose input has an optional nested object and an optional scalar. Both backends verified live on the final commit — notably proving OpenAI strict mode accepts type: ["object","null"] and chimp's format/title/$schema keywords.
- Independently verified by a wire-capture harness (fake LLM endpoints + body-logging proxy in front of a real MCP server): 25/25 checks, including the null-strip observed on the actual tools/call payload.