### PR TITLE
Mcp tool robustness

### DIFF
--- a/docs/agents/mcp.md
+++ b/docs/agents/mcp.md
@@ -63,9 +63,12 @@ Notes:
   `fromClient` call end up with the same exposed name (a sanitization/prefix collision, or a server-side
   name reused for genuinely different tools), `fromClient` fails with a `McpToolConversionException` naming
   the colliding tools, rather than silently routing calls to the wrong one — an MCP server re-listing the
-  exact same tool across pages is harmless and is deduplicated instead. This check does not extend across
-  multiple `fromClient` calls or to manually defined tools; combining tools from different sources safely
-  is the caller's responsibility (`namePrefix` is the recommended way to keep them distinct).
+  same tool across pages is harmless and is deduplicated instead, even if its metadata varies slightly
+  between listings. This check does not extend across multiple `fromClient` calls or to manually defined
+  tools: an agent looks tools up by name, so if you combine tools from several sources without keeping
+  their exposed names distinct yourself, the last one loaded silently shadows any earlier tool with the
+  same name — no error is raised, and calls intended for one tool can silently execute another.
+  `namePrefix` is the recommended way to keep multiple sources distinct.
 * Results are rendered as text for the agent loop: text content blocks are joined with newlines, other
   block types are rendered as compact JSON, and results the server marks as errors are returned to the
   LLM prefixed with `Tool execution failed:`. Transport failures surface as exceptions and go through the

--- a/docs/agents/mcp.md
+++ b/docs/agents/mcp.md
@@ -63,8 +63,9 @@ Notes:
   `fromClient` call end up with the same exposed name (a sanitization/prefix collision, or a server-side
   name reused for genuinely different tools), `fromClient` fails with a `McpToolConversionException` naming
   the colliding tools, rather than silently routing calls to the wrong one — an MCP server re-listing the
-  same tool across pages is harmless and is deduplicated instead, even if its metadata varies slightly
-  between listings. This check does not extend across multiple `fromClient` calls or to manually defined
+  same tool across pages is harmless and is deduplicated instead, even if its free-form `_meta` field
+  varies between listings (a differing description, title, or schema still counts as a real collision).
+  This check does not extend across multiple `fromClient` calls or to manually defined
   tools: an agent looks tools up by name, so if you combine tools from several sources without keeping
   their exposed names distinct yourself, the last one loaded silently shadows any earlier tool with the
   same name — no error is raised, and calls intended for one tool can silently execute another.

--- a/docs/agents/mcp.md
+++ b/docs/agents/mcp.md
@@ -57,6 +57,11 @@ Notes:
 * `namePrefix` is optional — with `Some("mcp")`, a server tool `add` is exposed to the LLM as `mcp_add`
   (the original name is still used when calling the server). Use it to avoid name collisions with manual
   tools or tools from other MCP servers.
+* Exposed names are sanitized to the cross-backend-safe form `[A-Za-z0-9_-]`, truncated to 64 characters
+  (after prefixing) — MCP allows names with dots or slashes that OpenAI's function calling rejects. The
+  original name is still used when calling the server. If two tools end up with the same exposed name
+  (a duplicate on the server, or a sanitization/prefix collision), `fromClient` fails with a
+  `McpToolConversionException` naming the colliding tools rather than silently dropping one.
 * Results are rendered as text for the agent loop: text content blocks are joined with newlines, other
   block types are rendered as compact JSON, and results the server marks as errors are returned to the
   LLM prefixed with `Tool execution failed:`. Transport failures surface as exceptions and go through the

--- a/docs/agents/mcp.md
+++ b/docs/agents/mcp.md
@@ -58,10 +58,14 @@ Notes:
   (the original name is still used when calling the server). Use it to avoid name collisions with manual
   tools or tools from other MCP servers.
 * Exposed names are sanitized to the cross-backend-safe form `[A-Za-z0-9_-]`, truncated to 64 characters
-  (after prefixing) — MCP allows names with dots or slashes that OpenAI's function calling rejects. The
-  original name is still used when calling the server. If two tools end up with the same exposed name
-  (a duplicate on the server, or a sanitization/prefix collision), `fromClient` fails with a
-  `McpToolConversionException` naming the colliding tools rather than silently dropping one.
+  (after prefixing) — MCP allows names with dots, slashes, or non-ASCII characters that OpenAI's function
+  calling rejects. The original name is still used when calling the server. If two tools from **the same**
+  `fromClient` call end up with the same exposed name (a sanitization/prefix collision, or a server-side
+  name reused for genuinely different tools), `fromClient` fails with a `McpToolConversionException` naming
+  the colliding tools, rather than silently routing calls to the wrong one — an MCP server re-listing the
+  exact same tool across pages is harmless and is deduplicated instead. This check does not extend across
+  multiple `fromClient` calls or to manually defined tools; combining tools from different sources safely
+  is the caller's responsibility (`namePrefix` is the recommended way to keep them distinct).
 * Results are rendered as text for the agent loop: text content blocks are joined with newlines, other
   block types are rendered as compact JSON, and results the server marks as errors are returned to the
   LLM prefixed with `Tool execution failed:`. Transport failures surface as exceptions and go through the

--- a/docs/agents/mcp.md
+++ b/docs/agents/mcp.md
@@ -50,49 +50,55 @@ finally
   client.close()
 ```
 
-Notes:
+## Lifecycle
 
-* You own the client's lifecycle: it must stay open while the agent runs, and you close it afterwards.
+* You own the client: keep it open while the agent runs, and close it afterwards.
 * The tool list is a snapshot taken by `fromClient`; `tools/list_changed` notifications are not observed.
-* `namePrefix` is optional — with `Some("mcp")`, a server tool `add` is exposed to the LLM as `mcp_add`
-  (the original name is still used when calling the server). Use it to avoid name collisions with manual
-  tools or tools from other MCP servers.
-* Exposed names are sanitized to the cross-backend-safe form `[A-Za-z0-9_-]`, truncated to 64 characters
-  (after prefixing) — MCP allows names with dots, slashes, or non-ASCII characters that OpenAI's function
-  calling rejects. The original name is still used when calling the server. If two tools from **the same**
-  `fromClient` call end up with the same exposed name (a sanitization/prefix collision, or a server-side
-  name reused for genuinely different tools), `fromClient` fails with a `McpToolConversionException` naming
-  the colliding tools, rather than silently routing calls to the wrong one — an MCP server re-listing the
-  same tool across pages is harmless and is deduplicated instead, even if its free-form `_meta` field
-  varies between listings (a differing description, title, or schema still counts as a real collision).
-  This check does not extend across multiple `fromClient` calls or to manually defined
-  tools: an agent looks tools up by name, so if you combine tools from several sources without keeping
-  their exposed names distinct yourself, the last one loaded silently shadows any earlier tool with the
-  same name — no error is raised, and calls intended for one tool can silently execute another.
-  `namePrefix` is the recommended way to keep multiple sources distinct.
-* Results are rendered as text for the agent loop: text content blocks are joined with newlines, other
-  block types are rendered as compact JSON, and results the server marks as errors are returned to the
-  LLM prefixed with `Tool execution failed:`. Transport failures surface as exceptions and go through the
-  agent's configured `ExceptionHandler`.
+
+## Tool names
+
+MCP allows names with dots, slashes, non-ASCII characters, and up to 128 characters. OpenAI's function calling
+requires `^[a-zA-Z0-9_-]{1,64}$` and rejects the whole request otherwise, so `fromClient` adapts names in two steps:
+
+* **`namePrefix`** (optional) is applied first: with `Some("mcp")`, a server tool `add` is exposed as `mcp_add`.
+  Use it to keep tools from different sources — other MCP servers, or manually defined tools — distinct from
+  each other.
+* **Sanitization** then rewrites the (possibly prefixed) name to `[A-Za-z0-9_-]`, truncated to 64 characters. The
+  server always receives the tool's original, unprefixed, unsanitized name in `tools/call`.
+
+**Duplicate detection.** If two tools from the *same* `fromClient` call end up with the same exposed name — a
+sanitization collision, or a server reusing one name for genuinely different tools — `fromClient` fails with
+`McpToolConversionException` naming every collision, instead of silently routing calls to the wrong tool. An MCP
+server re-listing the exact same tool across pages is deduplicated instead (even if its free-form `_meta` field
+varies); a genuinely different definition under the same name still fails. `namePrefix` cannot fix a collision
+reported this way — it is applied identically to every tool in one `fromClient` call, so it can never separate
+two names that already collide; rename one of them on the server instead.
+
+This check does not extend across multiple `fromClient` calls or to manually defined tools: an agent looks tools
+up by name, so if you combine tools from several sources without keeping their exposed names distinct yourself
+(with `namePrefix`), the one loaded last silently shadows any earlier tool with the same name — no error is
+raised.
+
+## Results and errors
+
+* Results are rendered as text: text content blocks are joined with newlines, other block types as compact JSON.
+* Results the server marks as errors are returned to the LLM prefixed with `Tool execution failed:`.
+* Transport failures surface as exceptions, subject to the agent's configured `ExceptionHandler`.
+* Before a tool call reaches the server, arguments that are JSON `null` are dropped for parameters the server's
+  schema does not list as `required` (the server then sees them as simply missing, not explicitly `null`); nulls
+  for `required` parameters — including ones strict-mode normalization made nullable — are left in place.
 
 ## Backend caveats
 
-* The OpenAI agent backend registers tools with `strict: true` function calling by default. Schemas are automatically
-  normalized to strict-mode rules: `additionalProperties: false` is set on objects, all properties are listed as
-  `required`, and originally-optional properties are made nullable (the model passes `null` instead of omitting them;
-  those nulls are stripped client-side before the tool call reaches the MCP server — see below). If a schema uses JSON
-  Schema features strict mode cannot accept, the API rejects it at request time — pass `strictTools = false` to the
-  builder as an escape hatch:
+* The OpenAI agent backend registers tools with `strict: true` function calling by default, normalizing schemas to
+  strict-mode rules: `additionalProperties: false` on objects, all properties listed as `required`, and
+  originally-optional properties made nullable (the model passes `null` for them instead of omitting them). If a
+  schema uses JSON Schema features strict mode cannot accept, the API rejects it at request time — pass
+  `strictTools = false` to the builder as an escape hatch:
 
   ```scala
   OpenAIAgent.synchronous(OpenAI.fromEnv, "gpt-4o-mini", strictTools = false)
   ```
-
-* Before an argument map reaches the MCP server's `tools/call`, top-level arguments that are JSON `null` are dropped
-  if the server's original schema does not list that parameter as `required` — i.e. "optional-by-absence" — so the
-  server sees the parameter as simply missing rather than explicitly `null`. Nulls for parameters the server *does*
-  list as `required` (e.g. a required-but-nullable property, as strict-mode normalization produces) are left in place
-  and forwarded as-is.
 
 * The Claude agent backend passes the server's original tool schema JSON through untouched — nested objects, arrays,
   enums, `required` lists, and any other JSON Schema keywords are all forwarded as received. The only modification is

--- a/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
+++ b/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
@@ -13,7 +13,9 @@ import sttp.monad.syntax.*
 /** Thrown when a tool advertised by an MCP server cannot be converted into an [[sttp.ai.core.agent.AgentTool]] (e.g. its input schema is
   * not valid JSON Schema).
   */
-class McpToolConversionException(message: String, cause: Throwable) extends RuntimeException(message, cause)
+class McpToolConversionException(message: String, cause: Throwable) extends RuntimeException(message, cause) {
+  def this(message: String) = this(message, null)
+}
 
 object McpTools {
 
@@ -42,18 +44,28 @@ object McpTools {
       client: McpClient[F],
       namePrefix: Option[String] = None
   )(using monad: MonadError[F]): F[Seq[AgentTool[F, Map[String, Json]]]] =
-    listAllTools(client, cursor = None, acc = Vector.empty).map { definitions =>
-      val tools = definitions.map(d => toAgentTool(client, d, namePrefix) -> d.name)
-      tools.groupBy(_._1.name).find(_._2.sizeIs > 1).foreach { case (exposed, colliding) =>
-        val originals = colliding.map(_._2).mkString("'", "', '", "'")
-        throw new McpToolConversionException(
-          s"Multiple MCP tools map to the same exposed name '$exposed' (original names: $originals). " +
-            "Rename the tools on the server or load the servers with distinct namePrefix values.",
-          null
-        )
-      }
-      tools.map(_._1)
+    listAllTools(client, cursor = None, acc = Vector.empty).map(definitions => buildTools(client, definitions, namePrefix))
+
+  /** Builds the agent tools and rejects the whole listing when tools end up with the same exposed name (a duplicate on the server, or a
+    * prefix/sanitization collision) — the agent looks tools up by name, so a silent collision would route calls to the wrong tool.
+    */
+  private def buildTools[F[_]](client: McpClient[F], definitions: Vector[ToolDefinition], namePrefix: Option[String])(using
+      MonadError[F]
+  ): Seq[AgentTool[F, Map[String, Json]]] = {
+    val tools = definitions.map(d => toAgentTool(client, d, namePrefix) -> d.name)
+    val collisions = tools.groupBy(_._1.name).filter(_._2.sizeIs > 1)
+    if (collisions.nonEmpty) {
+      val described = collisions.toSeq
+        .sortBy(_._1)
+        .map { case (exposed, colliding) => s"'$exposed' (original names: ${colliding.map(_._2).mkString("'", "', '", "'")})" }
+        .mkString("; ")
+      throw new McpToolConversionException(
+        s"Multiple MCP tools map to the same exposed name: $described. " +
+          "Rename the tools on the server or load the servers with distinct namePrefix values."
+      )
     }
+    tools.map(_._1)
+  }
 
   /** Backends constrain the tool names they accept (OpenAI function calling enforces `^[a-zA-Z0-9_-]{1,64}$`), while MCP permits dots,
     * slashes and longer names. The exposed (LLM-facing) name is sanitized to the cross-backend-safe form; the original name is still used

--- a/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
+++ b/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
@@ -42,7 +42,28 @@ object McpTools {
       client: McpClient[F],
       namePrefix: Option[String] = None
   )(using monad: MonadError[F]): F[Seq[AgentTool[F, Map[String, Json]]]] =
-    listAllTools(client, cursor = None, acc = Vector.empty).map(_.map(toAgentTool(client, _, namePrefix)))
+    listAllTools(client, cursor = None, acc = Vector.empty).map { definitions =>
+      val tools = definitions.map(d => toAgentTool(client, d, namePrefix) -> d.name)
+      tools.groupBy(_._1.name).find(_._2.sizeIs > 1).foreach { case (exposed, colliding) =>
+        val originals = colliding.map(_._2).mkString("'", "', '", "'")
+        throw new McpToolConversionException(
+          s"Multiple MCP tools map to the same exposed name '$exposed' (original names: $originals). " +
+            "Rename the tools on the server or load the servers with distinct namePrefix values.",
+          null
+        )
+      }
+      tools.map(_._1)
+    }
+
+  /** Backends constrain the tool names they accept (OpenAI function calling enforces `^[a-zA-Z0-9_-]{1,64}$`), while MCP permits dots,
+    * slashes and longer names. The exposed (LLM-facing) name is sanitized to the cross-backend-safe form; the original name is still used
+    * when calling the server.
+    */
+  private def sanitizeName(name: String): String = {
+    def legal(c: Char): Boolean =
+      (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-'
+    name.iterator.map(c => if (legal(c)) c else '_').mkString.take(64)
+  }
 
   private def listAllTools[F[_]](client: McpClient[F], cursor: Option[Cursor], acc: Vector[ToolDefinition])(using
       monad: MonadError[F]
@@ -63,7 +84,7 @@ object McpTools {
       case Left(error) =>
         throw new McpToolConversionException(s"Cannot decode the input schema of MCP tool '${definition.name}': ${error.getMessage}", error)
     }
-    val exposedName = namePrefix.fold(definition.name)(prefix => s"${prefix}_${definition.name}")
+    val exposedName = sanitizeName(namePrefix.fold(definition.name)(prefix => s"${prefix}_${definition.name}"))
     val description = definition.description.orElse(definition.title).getOrElse(definition.name)
     val requiredParams =
       definition.inputSchema.hcursor.downField("required").as[List[String]].toOption.getOrElse(Nil).toSet

--- a/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
+++ b/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
@@ -13,9 +13,7 @@ import sttp.monad.syntax.*
 /** Thrown when a tool advertised by an MCP server cannot be converted into an [[sttp.ai.core.agent.AgentTool]] (e.g. its input schema is
   * not valid JSON Schema).
   */
-class McpToolConversionException(message: String, cause: Throwable) extends RuntimeException(message, cause) {
-  def this(message: String) = this(message, null)
-}
+class McpToolConversionException(message: String, cause: Throwable) extends RuntimeException(message, cause)
 
 object McpTools {
 
@@ -80,7 +78,8 @@ object McpTools {
     val emptyNames = withExposedNames.collect { case ("", d) => d.name }
     if (emptyNames.nonEmpty)
       throw new McpToolConversionException(
-        s"MCP tool(s) sanitize to an empty exposed name: ${emptyNames.mkString("'", "', '", "'")}. Rename them on the server."
+        s"MCP tool(s) sanitize to an empty exposed name: ${emptyNames.mkString("'", "', '", "'")}. Rename them on the server.",
+        null
       )
 
     val collisions = withExposedNames.groupBy(_._1).filter(_._2.sizeIs > 1)
@@ -91,7 +90,8 @@ object McpTools {
         .mkString("; ")
       throw new McpToolConversionException(
         s"Multiple MCP tools map to the same exposed name: $described. " +
-          "Rename the tools on the server or load the servers with distinct namePrefix values."
+          "Rename the tools on the server or load the servers with distinct namePrefix values.",
+        null
       )
     }
 

--- a/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
+++ b/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
@@ -13,9 +13,7 @@ import sttp.monad.syntax.*
 /** Thrown when a tool advertised by an MCP server cannot be converted into an [[sttp.ai.core.agent.AgentTool]] (e.g. its input schema is
   * not valid JSON Schema).
   */
-class McpToolConversionException(message: String, cause: Throwable) extends RuntimeException(message, cause) {
-  def this(message: String) = this(message, null)
-}
+class McpToolConversionException(message: String, cause: Throwable = null) extends RuntimeException(message, cause)
 
 object McpTools {
 
@@ -41,35 +39,43 @@ object McpTools {
     *   with manually defined tools or tools loaded from other MCP servers. The original name is still used when calling the server.
     *   `fromClient` fails with [[McpToolConversionException]] if, after sanitizing, two tools from THIS server end up with the same exposed
     *   name (e.g. one server tool named `my.tool` and another named `my/tool`) — this check does not extend across multiple `fromClient`
-    *   calls or to manually defined tools; combining those is the caller's responsibility (`namePrefix` is the recommended way to keep them
-    *   distinct).
+    *   calls or to manually defined tools: an agent's tool lookup is by name, so if you combine tools from several sources without keeping
+    *   their exposed names distinct, the last one loaded silently shadows any earlier tool with the same name — no error is raised, calls
+    *   intended for one tool can silently execute another. `namePrefix` is the recommended way to keep multiple sources distinct.
     */
   def fromClient[F[_]](
       client: McpClient[F],
       namePrefix: Option[String] = None
   )(using monad: MonadError[F]): F[Seq[AgentTool[F, Map[String, Json]]]] =
-    listAllTools(client, cursor = None, acc = Vector.empty).flatMap(definitions => monad.eval(buildTools(client, definitions, namePrefix)))
+    listAllTools(client, cursor = None, acc = Vector.empty).flatMap { definitions =>
+      // `buildTools` can throw (see its doc); a plain `.map`/`monad.eval` would only route that safely through F's error channel if
+      // this particular MonadError's `map`/`eval` happens to catch exceptions, which not all of them do (e.g. the built-in `EitherMonad`
+      // does not). Catching explicitly and going through `monad.unit`/`monad.error` is guaranteed safe for every MonadError instance.
+      scala.util.Try(buildTools(client, definitions, namePrefix)) match {
+        case scala.util.Success(tools) => monad.unit(tools)
+        case scala.util.Failure(e)     => monad.error(e)
+      }
+    }
 
   /** Builds the agent tools, failing before any schema is decoded when the listing cannot be exposed safely:
-    *   - a tool whose name sanitizes to nothing (e.g. a name made entirely of characters outside `[A-Za-z0-9_-]`, or an empty name) could
-    *     never be called by name
+    *   - a tool whose name sanitizes to nothing can never be called by name. This is only possible when the original name itself is empty —
+    *     replacing illegal characters never shortens a name, so a name built entirely of e.g. non-ASCII characters instead collapses to a
+    *     (legal, non-empty) run of underscores, which is handled by the next check
     *   - tools that end up with the same exposed name (a prefix/sanitization collision, or a server-side name reused for genuinely
     *     different tools) would route calls to the wrong tool
     *
-    * An MCP server re-listing the exact same tool across pages is harmless and is silently deduplicated rather than treated as a collision
-    * — only names that collide while their underlying definitions differ are a real ambiguity.
-    *
-    * Building tools (and so throwing, if needed) happens inside `monad.eval` rather than a plain `.map`: for effect types that distinguish
-    * recoverable failures from defects (e.g. ZIO), throwing directly inside `.map` would surface as an unrecoverable defect instead of a
-    * typed failure the caller's `ExceptionHandler`/error-handling can see.
+    * An MCP server re-listing the same tool across pages is harmless and is silently deduplicated rather than treated as a collision, even
+    * if its free-form `_meta` differs between listings (`_meta` is reserved by MCP for implementation-specific metadata, not structural
+    * tool identity) — only names that collide while the rest of their definition differs are a real ambiguity.
     */
   private def buildTools[F[_]](client: McpClient[F], definitions: Vector[ToolDefinition], namePrefix: Option[String])(using
       MonadError[F]
   ): Seq[AgentTool[F, Map[String, Json]]] = {
-    val distinctDefinitions = definitions.distinct
-    val withExposedNames = distinctDefinitions.map(d => exposedNameFor(d.name, namePrefix) -> d.name)
+    val distinctDefinitions =
+      definitions.distinctBy(d => (d.name, d.description, d.inputSchema, d.outputSchema, d.title, d.annotations))
+    val withExposedNames = distinctDefinitions.map(d => exposedNameFor(d.name, namePrefix) -> d)
 
-    val emptyNames = withExposedNames.collect { case ("", original) => original }
+    val emptyNames = withExposedNames.collect { case ("", d) => d.name }
     if (emptyNames.nonEmpty)
       throw new McpToolConversionException(
         s"MCP tool(s) sanitize to an empty exposed name: ${emptyNames.mkString("'", "', '", "'")}. Rename them on the server."
@@ -79,7 +85,7 @@ object McpTools {
     if (collisions.nonEmpty) {
       val described = collisions.toSeq
         .sortBy(_._1)
-        .map { case (exposed, colliding) => s"'$exposed' (original names: ${colliding.map(_._2).mkString("'", "', '", "'")})" }
+        .map { case (exposed, colliding) => s"'$exposed' (original names: ${colliding.map(_._2.name).mkString("'", "', '", "'")})" }
         .mkString("; ")
       throw new McpToolConversionException(
         s"Multiple MCP tools map to the same exposed name: $described. " +
@@ -87,7 +93,7 @@ object McpTools {
       )
     }
 
-    distinctDefinitions.map(d => toAgentTool(client, d, namePrefix))
+    withExposedNames.map { case (exposedName, d) => toAgentTool(client, d, exposedName) }
   }
 
   /** Backends constrain the tool names they accept (OpenAI function calling enforces `^[a-zA-Z0-9_-]{1,64}$`), while MCP permits dots,
@@ -97,11 +103,8 @@ object McpTools {
     * names collapse to the same result, `fromClient`'s duplicate check (in `buildTools`) rejects the listing rather than silently merging
     * them.
     */
-  private def sanitizeName(name: String): String = {
-    def legal(c: Char): Boolean =
-      (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-'
-    name.iterator.map(c => if (legal(c)) c else '_').mkString.take(64)
-  }
+  private def sanitizeName(name: String): String =
+    name.replaceAll("[^A-Za-z0-9_-]", "_").take(64)
 
   private def exposedNameFor(originalName: String, namePrefix: Option[String]): String =
     sanitizeName(namePrefix.fold(originalName)(prefix => s"${prefix}_$originalName"))
@@ -117,7 +120,7 @@ object McpTools {
       }
     }
 
-  private def toAgentTool[F[_]](client: McpClient[F], definition: ToolDefinition, namePrefix: Option[String])(using
+  private def toAgentTool[F[_]](client: McpClient[F], definition: ToolDefinition, exposedName: String)(using
       MonadError[F]
   ): AgentTool[F, Map[String, Json]] = {
     val schema = definition.inputSchema.as[Schema] match {
@@ -125,7 +128,6 @@ object McpTools {
       case Left(error) =>
         throw new McpToolConversionException(s"Cannot decode the input schema of MCP tool '${definition.name}': ${error.getMessage}", error)
     }
-    val exposedName = exposedNameFor(definition.name, namePrefix)
     val description = definition.description.orElse(definition.title).getOrElse(definition.name)
     val requiredParams =
       definition.inputSchema.hcursor.downField("required").as[List[String]].toOption.getOrElse(Nil).toSet

--- a/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
+++ b/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
@@ -37,23 +37,45 @@ object McpTools {
     * Transport-level failures surface as exceptions and are subject to the agent's configured `ExceptionHandler`.
     *
     * @param namePrefix
-    *   When defined, tools are exposed to the LLM as `s"${prefix}_${name}"`, to avoid collisions with manually defined tools or tools
-    *   loaded from other MCP servers. The original name is still used when calling the server.
+    *   When defined, tools are exposed to the LLM as a sanitized form of `s"${prefix}_${name}"` (see `sanitizeName`), to avoid collisions
+    *   with manually defined tools or tools loaded from other MCP servers. The original name is still used when calling the server.
+    *   `fromClient` fails with [[McpToolConversionException]] if, after sanitizing, two tools from THIS server end up with the same exposed
+    *   name (e.g. one server tool named `my.tool` and another named `my/tool`) — this check does not extend across multiple `fromClient`
+    *   calls or to manually defined tools; combining those is the caller's responsibility (`namePrefix` is the recommended way to keep them
+    *   distinct).
     */
   def fromClient[F[_]](
       client: McpClient[F],
       namePrefix: Option[String] = None
   )(using monad: MonadError[F]): F[Seq[AgentTool[F, Map[String, Json]]]] =
-    listAllTools(client, cursor = None, acc = Vector.empty).map(definitions => buildTools(client, definitions, namePrefix))
+    listAllTools(client, cursor = None, acc = Vector.empty).flatMap(definitions => monad.eval(buildTools(client, definitions, namePrefix)))
 
-  /** Builds the agent tools and rejects the whole listing when tools end up with the same exposed name (a duplicate on the server, or a
-    * prefix/sanitization collision) — the agent looks tools up by name, so a silent collision would route calls to the wrong tool.
+  /** Builds the agent tools, failing before any schema is decoded when the listing cannot be exposed safely:
+    *   - a tool whose name sanitizes to nothing (e.g. a name made entirely of characters outside `[A-Za-z0-9_-]`, or an empty name) could
+    *     never be called by name
+    *   - tools that end up with the same exposed name (a prefix/sanitization collision, or a server-side name reused for genuinely
+    *     different tools) would route calls to the wrong tool
+    *
+    * An MCP server re-listing the exact same tool across pages is harmless and is silently deduplicated rather than treated as a collision
+    * — only names that collide while their underlying definitions differ are a real ambiguity.
+    *
+    * Building tools (and so throwing, if needed) happens inside `monad.eval` rather than a plain `.map`: for effect types that distinguish
+    * recoverable failures from defects (e.g. ZIO), throwing directly inside `.map` would surface as an unrecoverable defect instead of a
+    * typed failure the caller's `ExceptionHandler`/error-handling can see.
     */
   private def buildTools[F[_]](client: McpClient[F], definitions: Vector[ToolDefinition], namePrefix: Option[String])(using
       MonadError[F]
   ): Seq[AgentTool[F, Map[String, Json]]] = {
-    val tools = definitions.map(d => toAgentTool(client, d, namePrefix) -> d.name)
-    val collisions = tools.groupBy(_._1.name).filter(_._2.sizeIs > 1)
+    val distinctDefinitions = definitions.distinct
+    val withExposedNames = distinctDefinitions.map(d => exposedNameFor(d.name, namePrefix) -> d.name)
+
+    val emptyNames = withExposedNames.collect { case ("", original) => original }
+    if (emptyNames.nonEmpty)
+      throw new McpToolConversionException(
+        s"MCP tool(s) sanitize to an empty exposed name: ${emptyNames.mkString("'", "', '", "'")}. Rename them on the server."
+      )
+
+    val collisions = withExposedNames.groupBy(_._1).filter(_._2.sizeIs > 1)
     if (collisions.nonEmpty) {
       val described = collisions.toSeq
         .sortBy(_._1)
@@ -64,18 +86,25 @@ object McpTools {
           "Rename the tools on the server or load the servers with distinct namePrefix values."
       )
     }
-    tools.map(_._1)
+
+    distinctDefinitions.map(d => toAgentTool(client, d, namePrefix))
   }
 
   /** Backends constrain the tool names they accept (OpenAI function calling enforces `^[a-zA-Z0-9_-]{1,64}$`), while MCP permits dots,
-    * slashes and longer names. The exposed (LLM-facing) name is sanitized to the cross-backend-safe form; the original name is still used
-    * when calling the server.
+    * slashes, non-ASCII characters and longer names. The exposed (LLM-facing) name is sanitized to the cross-backend-safe form — characters
+    * outside `[A-Za-z0-9_-]` become `_`, truncated to 64 characters — after any `namePrefix` is applied; the original name is still used
+    * when calling the server. Names made up entirely of non-ASCII/unsupported characters collapse to a run of underscores; if two such
+    * names collapse to the same result, `fromClient`'s duplicate check (in `buildTools`) rejects the listing rather than silently merging
+    * them.
     */
   private def sanitizeName(name: String): String = {
     def legal(c: Char): Boolean =
       (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-'
     name.iterator.map(c => if (legal(c)) c else '_').mkString.take(64)
   }
+
+  private def exposedNameFor(originalName: String, namePrefix: Option[String]): String =
+    sanitizeName(namePrefix.fold(originalName)(prefix => s"${prefix}_$originalName"))
 
   private def listAllTools[F[_]](client: McpClient[F], cursor: Option[Cursor], acc: Vector[ToolDefinition])(using
       monad: MonadError[F]
@@ -96,7 +125,7 @@ object McpTools {
       case Left(error) =>
         throw new McpToolConversionException(s"Cannot decode the input schema of MCP tool '${definition.name}': ${error.getMessage}", error)
     }
-    val exposedName = sanitizeName(namePrefix.fold(definition.name)(prefix => s"${prefix}_${definition.name}"))
+    val exposedName = exposedNameFor(definition.name, namePrefix)
     val description = definition.description.orElse(definition.title).getOrElse(definition.name)
     val requiredParams =
       definition.inputSchema.hcursor.downField("required").as[List[String]].toOption.getOrElse(Nil).toSet

--- a/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
+++ b/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
@@ -58,9 +58,10 @@ object McpTools {
     }
 
   /** Builds the agent tools, failing before any schema is decoded when the listing cannot be exposed safely:
-    *   - a tool whose name sanitizes to nothing can never be called by name. This is only possible when the original name itself is empty —
-    *     replacing illegal characters never shortens a name, so a name built entirely of e.g. non-ASCII characters instead collapses to a
-    *     (legal, non-empty) run of underscores, which is handled by the next check
+    *   - a tool with an empty original name can never be called correctly (`tools/call` would be sent an empty name), so this is rejected
+    *     directly on the original name, before any `namePrefix`/sanitization is applied — sanitizing first would miss it, since
+    *     `exposedNameFor` always inserts a literal `"_"` between a prefix and the name, so the exposed name itself can never come out empty
+    *     once a `namePrefix` is set
     *   - tools that end up with the same exposed name (a prefix/sanitization collision, or a server-side name reused for genuinely
     *     different tools) would route calls to the wrong tool
     *
@@ -71,26 +72,30 @@ object McpTools {
   private def buildTools[F[_]](client: McpClient[F], definitions: Vector[ToolDefinition], namePrefix: Option[String])(using
       MonadError[F]
   ): Seq[AgentTool[F, Map[String, Json]]] = {
-    val distinctDefinitions =
-      definitions.distinctBy(d => (d.name, d.description, d.inputSchema, d.outputSchema, d.title, d.annotations))
-    val withExposedNames = distinctDefinitions.map(d => exposedNameFor(d.name, namePrefix) -> d)
+    val distinctDefinitions = definitions.distinctBy(_.copy(_meta = None))
 
-    val emptyNames = withExposedNames.collect { case ("", d) => d.name }
-    if (emptyNames.nonEmpty)
-      throw new McpToolConversionException(
-        s"MCP tool(s) sanitize to an empty exposed name: ${emptyNames.mkString("'", "', '", "'")}. Rename them on the server.",
-        null
-      )
+    // Checked on the ORIGINAL name, before any prefix is applied: `exposedNameFor` always inserts a literal "_" between a namePrefix and
+    // the name, so the exposed name can never actually come out empty once a namePrefix is set (e.g. an empty name with namePrefix =
+    // Some("p") sanitizes to "p_", not ""), even though the server would still be called with the empty original name.
+    val emptyOriginalNames = distinctDefinitions.filter(_.name.isEmpty)
+    if (emptyOriginalNames.nonEmpty)
+      throw new McpToolConversionException("This MCP server advertised a tool with an empty name. Rename it on the server.", null)
+
+    val withExposedNames = distinctDefinitions.map(d => exposedNameFor(d.name, namePrefix) -> d)
 
     val collisions = withExposedNames.groupBy(_._1).filter(_._2.sizeIs > 1)
     if (collisions.nonEmpty) {
+      // namePrefix is NOT a usable remedy here: it is applied identically to every tool from this one fromClient call, and
+      // exposedNameFor's sanitization is a pure per-character transform, so two names that already collide keep colliding under any
+      // shared prefix (sanitize(p + "_" + a) == sanitize(p + "_" + b) whenever sanitize(a) == sanitize(b)). namePrefix only helps
+      // distinguish tools loaded from DIFFERENT fromClient calls (see the docs) -- for a collision reported here, the only fix is
+      // renaming one of the tools on the server.
       val described = collisions.toSeq
         .sortBy(_._1)
         .map { case (exposed, colliding) => s"'$exposed' (original names: ${colliding.map(_._2.name).mkString("'", "', '", "'")})" }
         .mkString("; ")
       throw new McpToolConversionException(
-        s"Multiple MCP tools map to the same exposed name: $described. " +
-          "Rename the tools on the server or load the servers with distinct namePrefix values.",
+        s"Multiple MCP tools map to the same exposed name: $described. Rename the tools on the server.",
         null
       )
     }

--- a/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
+++ b/mcp/src/main/scala/sttp/ai/core/agent/mcp/McpTools.scala
@@ -13,7 +13,9 @@ import sttp.monad.syntax.*
 /** Thrown when a tool advertised by an MCP server cannot be converted into an [[sttp.ai.core.agent.AgentTool]] (e.g. its input schema is
   * not valid JSON Schema).
   */
-class McpToolConversionException(message: String, cause: Throwable = null) extends RuntimeException(message, cause)
+class McpToolConversionException(message: String, cause: Throwable) extends RuntimeException(message, cause) {
+  def this(message: String) = this(message, null)
+}
 
 object McpTools {
 

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
@@ -204,10 +204,10 @@ class McpToolsSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "fail fast rather than silently merge distinct non-ASCII names that sanitize identically" in {
-    val client = new StubMcpClient(pages = Seq(ListToolsResponse(tools = List(toolDef("検索ツール"), toolDef("翻訳機能名")))))
+    val client = new StubMcpClient(pages = Seq(ListToolsResponse(tools = List(toolDef("搜索工具"), toolDef("翻译功能")))))
     val ex = the[McpToolConversionException] thrownBy McpTools.fromClient(client)
-    ex.getMessage should include("検索ツール")
-    ex.getMessage should include("翻訳機能名")
+    ex.getMessage should include("搜索工具")
+    ex.getMessage should include("翻译功能")
   }
 
   it should "fail fast when sanitization makes two names collide, naming both originals" in {

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
@@ -1,6 +1,5 @@
 package sttp.ai.core.agent.mcp
 
-import chimp.client.McpClient
 import chimp.protocol.*
 import io.circe.Json
 import org.scalatest.flatspec.AnyFlatSpec
@@ -298,29 +297,9 @@ class McpToolsSpec extends AnyFlatSpec with Matchers {
     }
   }
 
-  private class NonCatchingMcpClient(pages: Seq[ListToolsResponse]) extends McpClient[NonCatching] {
+  private class NonCatchingMcpClient(pages: Seq[ListToolsResponse]) extends UnsupportedMcpClient[NonCatching] {
     override def listTools(cursor: Option[Cursor]): NonCatching[ListToolsResponse] =
       NonCatching(Right(pages(cursor.fold(0)(_.toInt))))
-    override def ping(): NonCatching[Unit] = NonCatching(Right(()))
-    override def close(): NonCatching[Unit] = NonCatching(Right(()))
-    override def serverCapabilities: ServerCapabilities = ServerCapabilities()
-    override def serverInfo: Implementation = Implementation("fake-server", "0.0.1")
-    override def callTool(name: String, arguments: Json): NonCatching[CallToolResult] = unsupported
-    override def listPrompts(cursor: Option[Cursor]): NonCatching[ListPromptsResult] = unsupported
-    override def getPrompt(name: String, arguments: Map[String, String]): NonCatching[GetPromptResult] = unsupported
-    override def listResources(cursor: Option[Cursor]): NonCatching[ListResourcesResult] = unsupported
-    override def listResourceTemplates(cursor: Option[Cursor]): NonCatching[ListResourceTemplatesResult] = unsupported
-    override def readResource(uri: String): NonCatching[ReadResourceResult] = unsupported
-    override def complete(ref: CompleteRef, argument: CompleteArgument): NonCatching[CompleteResult] = unsupported
-    override def setLoggingLevel(level: LoggingLevel): NonCatching[Unit] = unsupported
-    override def sendProgress(
-        token: ProgressToken,
-        progress: Double,
-        total: Option[Double],
-        message: Option[String]
-    ): NonCatching[Unit] = unsupported
-
-    private def unsupported: Nothing = throw new UnsupportedOperationException("not used by this test")
   }
 
   it should "report a collision through the effect's error channel, not as a raw thrown exception, even when map/flatMap cannot catch" in {

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
@@ -210,10 +210,18 @@ class McpToolsSpec extends AnyFlatSpec with Matchers {
     ex.getMessage should not include "Cannot decode"
   }
 
-  it should "fail fast when a tool sanitizes to an empty exposed name" in {
+  it should "fail fast when a tool has an empty original name" in {
     val client = new StubMcpClient(pages = Seq(ListToolsResponse(tools = List(toolDef("")))))
     val ex = the[McpToolConversionException] thrownBy McpTools.fromClient(client)
-    ex.getMessage should include("empty exposed name")
+    ex.getMessage should include("empty name")
+  }
+
+  it should "fail fast on an empty original name even when a namePrefix is set" in {
+    // exposedNameFor always inserts a literal "_" between a prefix and the name, so with namePrefix = Some("p") an empty original name
+    // would otherwise sanitize to the non-empty "p_" and slip past a check that only looks at the exposed name.
+    val client = new StubMcpClient(pages = Seq(ListToolsResponse(tools = List(toolDef("")))))
+    val ex = the[McpToolConversionException] thrownBy McpTools.fromClient(client, namePrefix = Some("p"))
+    ex.getMessage should include("empty name")
   }
 
   it should "fail fast rather than silently merge distinct non-ASCII names that sanitize identically" in {

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
@@ -231,6 +231,23 @@ class McpToolsSpec extends AnyFlatSpec with Matchers {
     ex.getMessage should include("my_tool")
   }
 
+  it should "detect collisions correctly when a namePrefix is set" in {
+    val client = new StubMcpClient(
+      pages = Seq(ListToolsResponse(tools = List(toolDef("add", description = Some("v1")), toolDef("add", description = Some("v2")))))
+    )
+    val ex = the[McpToolConversionException] thrownBy McpTools.fromClient(client, namePrefix = Some("calc"))
+    ex.getMessage should include("calc_add")
+  }
+
+  it should "report all original names when three or more tools collide on the same exposed name" in {
+    val client = new StubMcpClient(pages = Seq(ListToolsResponse(tools = List(toolDef("my.tool"), toolDef("my/tool"), toolDef("my:tool")))))
+    val ex = the[McpToolConversionException] thrownBy McpTools.fromClient(client)
+    ex.getMessage should include("my.tool")
+    ex.getMessage should include("my/tool")
+    ex.getMessage should include("my:tool")
+    ex.getMessage should include("my_tool")
+  }
+
   it should "expose the server's original schema verbatim via rawJsonSchema, byte-equal, while jsonSchema still decodes" in {
     val lossySchema = Json.obj(
       "type" -> Json.fromString("object"),
@@ -268,17 +285,20 @@ class McpToolsSpec extends AnyFlatSpec with Matchers {
 
   behavior of "McpTools.fromClient (effect safety)"
 
-  /** Mirrors ZIO's own `.map`/`.flatMap`, which propagate an exception thrown by the mapping function uncaught rather than encoding it as a
-    * typed failure — unlike `Identity`/`Try`/`Future`, whose host type either can't distinguish or already catches. Used to prove that
-    * `fromClient` reports failures through `monad.error` (guaranteed safe on every `MonadError` instance) rather than depending on a
-    * particular backend's `.map`/`.eval` to catch for it — a dependency the built-in `sttp.monad.EitherMonad` notably does not satisfy.
+  /** Mirrors `sttp.monad.EitherMonad`'s `.map`/`.flatMap` (and plain Scala `Either`), which let an exception thrown by the mapping function
+    * escape fully uncaught rather than encoding it as a typed failure — unlike `Identity`/`Try`/`Future`, whose host type either can't
+    * distinguish or already catches. ZIO's own `.map` is close but not identical: it captures such an exception into its `Cause.Die`
+    * ("defect") channel instead of letting it fully escape the runtime, but that channel is equally invisible to `.either`/`.catchAll` —
+    * only `.catchAllDefect`/`.sandbox` can see it. Either way, this proves that `fromClient` reports failures through `monad.error`
+    * (guaranteed safe on every `MonadError` instance) rather than depending on a particular backend's `.map`/`.eval` catching for it — a
+    * dependency `EitherMonad` notably does not satisfy, and ZIO only satisfies via its non-typed defect channel.
     */
   private case class NonCatching[A](result: Either[Throwable, A])
 
   private given nonCatchingMonad: MonadError[NonCatching] with {
     override def unit[T](t: T): NonCatching[T] = NonCatching(Right(t))
     override def map[T, T2](fa: NonCatching[T])(f: T => T2): NonCatching[T2] = fa.result match {
-      case Right(a) => NonCatching(Right(f(a))) // if f throws, this propagates uncaught, like ZIO's/EitherMonad's own `.map`
+      case Right(a) => NonCatching(Right(f(a))) // if f throws, this propagates uncaught, like EitherMonad's own `.map`
       case Left(e)  => NonCatching(Left(e))
     }
     override def flatMap[T, T2](fa: NonCatching[T])(f: T => NonCatching[T2]): NonCatching[T2] = fa.result match {
@@ -291,13 +311,15 @@ class McpToolsSpec extends AnyFlatSpec with Matchers {
         case Left(e) if h.isDefinedAt(e) => h(e)
         case _                           => rt
       }
-    override def ensure[T](f: NonCatching[T], e: => NonCatching[Unit]): NonCatching[T] = {
-      val _ = e
-      f
-    }
+    // Not exercised by fromClient; the finalizer `e` is intentionally never evaluated rather than guessing at ordering/exception semantics
+    // this test double doesn't otherwise need to model.
+    override def ensure[T](f: NonCatching[T], e: => NonCatching[Unit]): NonCatching[T] = f
   }
 
   private class NonCatchingMcpClient(pages: Seq[ListToolsResponse]) extends UnsupportedMcpClient[NonCatching] {
+    override def ping(): NonCatching[Unit] = NonCatching(Right(()))
+    override def close(): NonCatching[Unit] = NonCatching(Right(()))
+
     override def listTools(cursor: Option[Cursor]): NonCatching[ListToolsResponse] =
       NonCatching(Right(pages(cursor.fold(0)(_.toInt))))
   }

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
@@ -1,6 +1,7 @@
 package sttp.ai.core.agent.mcp
 
-import chimp.protocol.{CallToolResult, ListToolsResponse, ToolContent, ToolDefinition}
+import chimp.client.McpClient
+import chimp.protocol.*
 import io.circe.Json
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -160,6 +161,19 @@ class McpToolsSpec extends AnyFlatSpec with Matchers {
     McpTools.fromClient(client).map(_.name) shouldBe Seq("add")
   }
 
+  it should "silently deduplicate a repeated tool even if its _meta differs across pages" in {
+    val client = new StubMcpClient(
+      pages = Seq(
+        ListToolsResponse(
+          tools = List(toolDef("add").copy(_meta = Some(Map("requestId" -> Json.fromString("r1"))))),
+          nextCursor = Some("1")
+        ),
+        ListToolsResponse(tools = List(toolDef("add").copy(_meta = Some(Map("requestId" -> Json.fromString("r2"))))))
+      )
+    )
+    McpTools.fromClient(client).map(_.name) shouldBe Seq("add")
+  }
+
   it should "report every colliding exposed name, not just the first" in {
     val client = new StubMcpClient(
       pages = Seq(
@@ -251,5 +265,71 @@ class McpToolsSpec extends AnyFlatSpec with Matchers {
     val tool = McpTools.fromClient(client).head
     tool.execute(Map("a" -> Json.Null, "b" -> Json.Null, "c" -> Json.fromString("x"))) shouldBe "ok"
     client.recordedCalls shouldBe Vector("f" -> Json.obj("a" -> Json.Null, "c" -> Json.fromString("x")))
+  }
+
+  behavior of "McpTools.fromClient (effect safety)"
+
+  /** Mirrors ZIO's own `.map`/`.flatMap`, which propagate an exception thrown by the mapping function uncaught rather than encoding it as a
+    * typed failure — unlike `Identity`/`Try`/`Future`, whose host type either can't distinguish or already catches. Used to prove that
+    * `fromClient` reports failures through `monad.error` (guaranteed safe on every `MonadError` instance) rather than depending on a
+    * particular backend's `.map`/`.eval` to catch for it — a dependency the built-in `sttp.monad.EitherMonad` notably does not satisfy.
+    */
+  private case class NonCatching[A](result: Either[Throwable, A])
+
+  private given nonCatchingMonad: MonadError[NonCatching] with {
+    override def unit[T](t: T): NonCatching[T] = NonCatching(Right(t))
+    override def map[T, T2](fa: NonCatching[T])(f: T => T2): NonCatching[T2] = fa.result match {
+      case Right(a) => NonCatching(Right(f(a))) // if f throws, this propagates uncaught, like ZIO's/EitherMonad's own `.map`
+      case Left(e)  => NonCatching(Left(e))
+    }
+    override def flatMap[T, T2](fa: NonCatching[T])(f: T => NonCatching[T2]): NonCatching[T2] = fa.result match {
+      case Right(a) => f(a)
+      case Left(e)  => NonCatching(Left(e))
+    }
+    override def error[T](t: Throwable): NonCatching[T] = NonCatching(Left(t))
+    override protected def handleWrappedError[T](rt: NonCatching[T])(h: PartialFunction[Throwable, NonCatching[T]]): NonCatching[T] =
+      rt.result match {
+        case Left(e) if h.isDefinedAt(e) => h(e)
+        case _                           => rt
+      }
+    override def ensure[T](f: NonCatching[T], e: => NonCatching[Unit]): NonCatching[T] = {
+      val _ = e
+      f
+    }
+  }
+
+  private class NonCatchingMcpClient(pages: Seq[ListToolsResponse]) extends McpClient[NonCatching] {
+    override def listTools(cursor: Option[Cursor]): NonCatching[ListToolsResponse] =
+      NonCatching(Right(pages(cursor.fold(0)(_.toInt))))
+    override def ping(): NonCatching[Unit] = NonCatching(Right(()))
+    override def close(): NonCatching[Unit] = NonCatching(Right(()))
+    override def serverCapabilities: ServerCapabilities = ServerCapabilities()
+    override def serverInfo: Implementation = Implementation("fake-server", "0.0.1")
+    override def callTool(name: String, arguments: Json): NonCatching[CallToolResult] = unsupported
+    override def listPrompts(cursor: Option[Cursor]): NonCatching[ListPromptsResult] = unsupported
+    override def getPrompt(name: String, arguments: Map[String, String]): NonCatching[GetPromptResult] = unsupported
+    override def listResources(cursor: Option[Cursor]): NonCatching[ListResourcesResult] = unsupported
+    override def listResourceTemplates(cursor: Option[Cursor]): NonCatching[ListResourceTemplatesResult] = unsupported
+    override def readResource(uri: String): NonCatching[ReadResourceResult] = unsupported
+    override def complete(ref: CompleteRef, argument: CompleteArgument): NonCatching[CompleteResult] = unsupported
+    override def setLoggingLevel(level: LoggingLevel): NonCatching[Unit] = unsupported
+    override def sendProgress(
+        token: ProgressToken,
+        progress: Double,
+        total: Option[Double],
+        message: Option[String]
+    ): NonCatching[Unit] = unsupported
+
+    private def unsupported: Nothing = throw new UnsupportedOperationException("not used by this test")
+  }
+
+  it should "report a collision through the effect's error channel, not as a raw thrown exception, even when map/flatMap cannot catch" in {
+    val client = new NonCatchingMcpClient(
+      pages = Seq(ListToolsResponse(tools = List(toolDef("add", description = Some("v1")), toolDef("add", description = Some("v2")))))
+    )
+    McpTools.fromClient(client)(using nonCatchingMonad).result match {
+      case Left(e)  => e.getMessage should include("add")
+      case Right(_) => fail("expected a Left carrying the collision failure, not a successful result")
+    }
   }
 }

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
@@ -142,21 +142,72 @@ class McpToolsSpec extends AnyFlatSpec with Matchers {
     client.recordedCalls.map(_._1) shouldBe Vector("my.tool")
   }
 
-  it should "fail fast when two tools expose the same name" in {
-    val client = new StubMcpClient(pages = Seq(ListToolsResponse(tools = List(toolDef("add"), toolDef("add")))))
+  it should "fail fast when the same name maps to conflicting definitions" in {
+    val client = new StubMcpClient(
+      pages = Seq(ListToolsResponse(tools = List(toolDef("add", description = Some("v1")), toolDef("add", description = Some("v2")))))
+    )
     val ex = the[McpToolConversionException] thrownBy McpTools.fromClient(client)
     ex.getMessage should include("add")
   }
 
+  it should "silently deduplicate an exact repeat of the same tool across pages" in {
+    val client = new StubMcpClient(
+      pages = Seq(
+        ListToolsResponse(tools = List(toolDef("add")), nextCursor = Some("1")),
+        ListToolsResponse(tools = List(toolDef("add")))
+      )
+    )
+    McpTools.fromClient(client).map(_.name) shouldBe Seq("add")
+  }
+
   it should "report every colliding exposed name, not just the first" in {
     val client = new StubMcpClient(
-      pages = Seq(ListToolsResponse(tools = List(toolDef("add"), toolDef("add"), toolDef("my.tool"), toolDef("my/tool"))))
+      pages = Seq(
+        ListToolsResponse(tools =
+          List(
+            toolDef("add", description = Some("v1")),
+            toolDef("add", description = Some("v2")),
+            toolDef("my.tool"),
+            toolDef("my/tool")
+          )
+        )
+      )
     )
     val ex = the[McpToolConversionException] thrownBy McpTools.fromClient(client)
     ex.getMessage should include("'add'")
     ex.getMessage should include("'my_tool'")
     ex.getMessage should include("'my.tool'")
     ex.getMessage should include("'my/tool'")
+  }
+
+  it should "report a name collision even when another tool has an undecodable schema" in {
+    val client = new StubMcpClient(
+      pages = Seq(
+        ListToolsResponse(tools =
+          List(
+            toolDef("add", description = Some("v1")),
+            toolDef("add", description = Some("v2")),
+            toolDef("bad", schema = Json.fromString("nope"))
+          )
+        )
+      )
+    )
+    val ex = the[McpToolConversionException] thrownBy McpTools.fromClient(client)
+    ex.getMessage should include("same exposed name")
+    ex.getMessage should not include "Cannot decode"
+  }
+
+  it should "fail fast when a tool sanitizes to an empty exposed name" in {
+    val client = new StubMcpClient(pages = Seq(ListToolsResponse(tools = List(toolDef("")))))
+    val ex = the[McpToolConversionException] thrownBy McpTools.fromClient(client)
+    ex.getMessage should include("empty exposed name")
+  }
+
+  it should "fail fast rather than silently merge distinct non-ASCII names that sanitize identically" in {
+    val client = new StubMcpClient(pages = Seq(ListToolsResponse(tools = List(toolDef("検索ツール"), toolDef("翻訳機能名")))))
+    val ex = the[McpToolConversionException] thrownBy McpTools.fromClient(client)
+    ex.getMessage should include("検索ツール")
+    ex.getMessage should include("翻訳機能名")
   }
 
   it should "fail fast when sanitization makes two names collide, naming both originals" in {

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
@@ -148,6 +148,17 @@ class McpToolsSpec extends AnyFlatSpec with Matchers {
     ex.getMessage should include("add")
   }
 
+  it should "report every colliding exposed name, not just the first" in {
+    val client = new StubMcpClient(
+      pages = Seq(ListToolsResponse(tools = List(toolDef("add"), toolDef("add"), toolDef("my.tool"), toolDef("my/tool"))))
+    )
+    val ex = the[McpToolConversionException] thrownBy McpTools.fromClient(client)
+    ex.getMessage should include("'add'")
+    ex.getMessage should include("'my_tool'")
+    ex.getMessage should include("'my.tool'")
+    ex.getMessage should include("'my/tool'")
+  }
+
   it should "fail fast when sanitization makes two names collide, naming both originals" in {
     val client = new StubMcpClient(pages = Seq(ListToolsResponse(tools = List(toolDef("my.tool"), toolDef("my/tool")))))
     val ex = the[McpToolConversionException] thrownBy McpTools.fromClient(client)

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/McpToolsSpec.scala
@@ -118,6 +118,44 @@ class McpToolsSpec extends AnyFlatSpec with Matchers {
     McpTools.fromClient(client).head.name shouldBe "add"
   }
 
+  it should "sanitize exposed names to the cross-backend-safe form" in {
+    val client = new StubMcpClient(pages = Seq(ListToolsResponse(tools = List(toolDef("my.tool/name")))))
+    McpTools.fromClient(client).head.name shouldBe "my_tool_name"
+  }
+
+  it should "truncate exposed names to 64 characters after prefixing" in {
+    val longName = "a" * 70
+    val client = new StubMcpClient(pages = Seq(ListToolsResponse(tools = List(toolDef(longName)))))
+    val tool = McpTools.fromClient(client, namePrefix = Some("server")).head
+    tool.name shouldBe ("server_" + "a" * 57)
+    tool.name.length shouldBe 64
+  }
+
+  it should "call the server with the original name even when sanitized" in {
+    val client = new StubMcpClient(
+      pages = Seq(ListToolsResponse(tools = List(toolDef("my.tool")))),
+      callResults = Map("my.tool" -> CallToolResult(List(ToolContent.Text(text = "ok"))))
+    )
+    val tool = McpTools.fromClient(client).head
+    tool.name shouldBe "my_tool"
+    tool.execute(Map.empty) shouldBe "ok"
+    client.recordedCalls.map(_._1) shouldBe Vector("my.tool")
+  }
+
+  it should "fail fast when two tools expose the same name" in {
+    val client = new StubMcpClient(pages = Seq(ListToolsResponse(tools = List(toolDef("add"), toolDef("add")))))
+    val ex = the[McpToolConversionException] thrownBy McpTools.fromClient(client)
+    ex.getMessage should include("add")
+  }
+
+  it should "fail fast when sanitization makes two names collide, naming both originals" in {
+    val client = new StubMcpClient(pages = Seq(ListToolsResponse(tools = List(toolDef("my.tool"), toolDef("my/tool")))))
+    val ex = the[McpToolConversionException] thrownBy McpTools.fromClient(client)
+    ex.getMessage should include("my.tool")
+    ex.getMessage should include("my/tool")
+    ex.getMessage should include("my_tool")
+  }
+
   it should "expose the server's original schema verbatim via rawJsonSchema, byte-equal, while jsonSchema still decodes" in {
     val lossySchema = Json.obj(
       "type" -> Json.fromString("object"),

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/StubMcpClient.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/StubMcpClient.scala
@@ -14,6 +14,9 @@ class StubMcpClient(
   var recordedCalls: Vector[(String, Json)] = Vector.empty
   var recordedCursors: Vector[Option[Cursor]] = Vector.empty
 
+  override def ping(): Unit = ()
+  override def close(): Unit = ()
+
   override def listTools(cursor: Option[Cursor]): ListToolsResponse = {
     recordedCursors = recordedCursors :+ cursor
     pages(cursor.fold(0)(_.toInt))

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/StubMcpClient.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/StubMcpClient.scala
@@ -1,6 +1,5 @@
 package sttp.ai.core.agent.mcp
 
-import chimp.client.McpClient
 import chimp.protocol.*
 import io.circe.Json
 import sttp.shared.Identity
@@ -11,7 +10,7 @@ import sttp.shared.Identity
 class StubMcpClient(
     pages: Seq[ListToolsResponse],
     callResults: Map[String, CallToolResult] = Map.empty
-) extends McpClient[Identity] {
+) extends UnsupportedMcpClient[Identity] {
   var recordedCalls: Vector[(String, Json)] = Vector.empty
   var recordedCursors: Vector[Option[Cursor]] = Vector.empty
 
@@ -24,19 +23,4 @@ class StubMcpClient(
     recordedCalls = recordedCalls :+ (name -> arguments)
     callResults.getOrElse(name, CallToolResult(List(ToolContent.Text(text = s"no canned result for $name"))))
   }
-
-  override def ping(): Unit = ()
-  override def close(): Unit = ()
-  override def serverCapabilities: ServerCapabilities = ServerCapabilities()
-  override def serverInfo: Implementation = Implementation("fake-server", "0.0.1")
-  override def listPrompts(cursor: Option[Cursor]): ListPromptsResult = unsupported
-  override def getPrompt(name: String, arguments: Map[String, String]): GetPromptResult = unsupported
-  override def listResources(cursor: Option[Cursor]): ListResourcesResult = unsupported
-  override def listResourceTemplates(cursor: Option[Cursor]): ListResourceTemplatesResult = unsupported
-  override def readResource(uri: String): ReadResourceResult = unsupported
-  override def complete(ref: CompleteRef, argument: CompleteArgument): CompleteResult = unsupported
-  override def setLoggingLevel(level: LoggingLevel): Unit = unsupported
-  override def sendProgress(token: ProgressToken, progress: Double, total: Option[Double], message: Option[String]): Unit = unsupported
-
-  private def unsupported: Nothing = throw new UnsupportedOperationException("not used by McpTools")
 }

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/UnsupportedMcpClient.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/UnsupportedMcpClient.scala
@@ -3,16 +3,16 @@ package sttp.ai.core.agent.mcp
 import chimp.client.McpClient
 import chimp.protocol.*
 
-/** Base for MCP client test doubles that only need to implement a couple of [[chimp.client.McpClient]]'s members — every other member
-  * throws, since nothing under test exercises them. `serverCapabilities`/`serverInfo` return a generic placeholder, overridable if a test
-  * ever needs otherwise. `listTools` is left abstract: every consumer calls it at least once.
+/** Base for MCP client test doubles that only need to implement a couple of [[chimp.client.McpClient]]'s members. `serverCapabilities`/
+  * `serverInfo` return a generic placeholder, overridable if a test ever needs otherwise. `listTools` is left abstract: every consumer
+  * calls it at least once. `ping`/`close` are also left abstract, NOT included below: they are harmless lifecycle no-ops a test could
+  * legitimately call and expect to succeed, unlike the members below, which no test double built on this trait is expected to ever invoke
+  * and so throw if they are.
   */
 trait UnsupportedMcpClient[F[_]] extends McpClient[F] {
   override def serverCapabilities: ServerCapabilities = ServerCapabilities()
   override def serverInfo: Implementation = Implementation("fake-server", "0.0.1")
 
-  override def ping(): F[Unit] = unsupported
-  override def close(): F[Unit] = unsupported
   override def callTool(name: String, arguments: io.circe.Json): F[CallToolResult] = unsupported
   override def listPrompts(cursor: Option[Cursor]): F[ListPromptsResult] = unsupported
   override def getPrompt(name: String, arguments: Map[String, String]): F[GetPromptResult] = unsupported

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/UnsupportedMcpClient.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/UnsupportedMcpClient.scala
@@ -1,0 +1,27 @@
+package sttp.ai.core.agent.mcp
+
+import chimp.client.McpClient
+import chimp.protocol.*
+
+/** Base for MCP client test doubles that only need to implement a couple of [[chimp.client.McpClient]]'s members — every other member
+  * throws, since nothing under test exercises them. `serverCapabilities`/`serverInfo` return a generic placeholder, overridable if a test
+  * ever needs otherwise. `listTools` is left abstract: every consumer calls it at least once.
+  */
+trait UnsupportedMcpClient[F[_]] extends McpClient[F] {
+  override def serverCapabilities: ServerCapabilities = ServerCapabilities()
+  override def serverInfo: Implementation = Implementation("fake-server", "0.0.1")
+
+  override def ping(): F[Unit] = unsupported
+  override def close(): F[Unit] = unsupported
+  override def callTool(name: String, arguments: io.circe.Json): F[CallToolResult] = unsupported
+  override def listPrompts(cursor: Option[Cursor]): F[ListPromptsResult] = unsupported
+  override def getPrompt(name: String, arguments: Map[String, String]): F[GetPromptResult] = unsupported
+  override def listResources(cursor: Option[Cursor]): F[ListResourcesResult] = unsupported
+  override def listResourceTemplates(cursor: Option[Cursor]): F[ListResourceTemplatesResult] = unsupported
+  override def readResource(uri: String): F[ReadResourceResult] = unsupported
+  override def complete(ref: CompleteRef, argument: CompleteArgument): F[CompleteResult] = unsupported
+  override def setLoggingLevel(level: LoggingLevel): F[Unit] = unsupported
+  override def sendProgress(token: ProgressToken, progress: Double, total: Option[Double], message: Option[String]): F[Unit] = unsupported
+
+  protected def unsupported: Nothing = throw new UnsupportedOperationException("not used by this test double")
+}


### PR DESCRIPTION
## What

- Name sanitization: MCP allows tool names with dots, slashes, non-ASCII characters, and up to 128 chars; OpenAI's function calling enforces ^[a-zA-Z0-9_-]{1,64}$ and rejects the whole request otherwise — before the model even runs, and even if the offending tool is never called. McpTools sanitizes the exposed (LLM-facing) name — illegal characters become _, truncated to 64 chars after namePrefix is applied. The server always receives its own original name in tools/call; already-legal names pass through unchanged.
- Duplicate detection: two tools ending up with the same exposed name (a prefix/sanitization collision, or a server reusing one name for genuinely different tools) previously last-won silently in the agent's toolMap, routing calls meant for one tool to another. fromClient fails fast with McpToolConversionException, listing every colliding exposed name with all its original names. An MCP server re-listing the exact same tool across pages — even if its free-form _meta field varies between listings — is silently deduplicated instead of failing; a genuinely different definition under the same name still fails.
- Validation runs before schema decoding, so a collision or empty-name failure is never masked by an unrelated tool's schema-decode error.
- Effect-safe on every backend: fromClient catches with scala.util.Try and routes through monad.unit/monad.error rather than depending on a particular MonadError's map/eval to catch exceptions for it — a dependency the built-in EitherMonad doesn't satisfy (verified against sttp's actual source), and which would surface as an unrecoverable defect on ZIO backends if relied upon. A dedicated test proves the failure surfaces through the error channel even under a map/flatMap that can't catch.
- Empty-name guard: a tool whose name sanitizes to nothing (only possible when the original name is itself empty — chimp's client-side decoder doesn't validate incoming names) now fails with a clear message instead of silently producing an unusable tool.

## Testing

30 tests in the mcp module (up from 16), covering: sanitization of illegal characters, post-prefix truncation to exactly 64, original-name preservation on tools/call, exact-repeat deduplication across pages (including when _meta varies), same-name-but-conflicting-content failure, multi-way collision reporting (2-way and 3-way, with and without namePrefix), collision-before-schema-decode ordering, empty exposed names, two distinct non-ASCII names (Simplified Chinese) that sanitize to the same string, and effect-channel safety under a hand-rolled MonadError whose map/flatMap can't catch. No backend or live-path changes — the integration specs' tool names are already legal, so their behavior is untouched.

Notes

- Known, deliberately deferred scope limit: the duplicate check covers tools from a single fromClient call only. The agent's own toolMap (core.Agent) is last-wins across all merged tools (manual + every MCP source), so cross-server or MCP-vs-manual collisions aren't caught here. Closing that gap would mean adding a first-time validation to core.Agent, which every PR in this series has deliberately left untouched — and doing so would be a behavior change for the whole library (any existing app with duplicate tool names would start throwing on upgrade rather than silently degrading). namePrefix remains the recommended way to keep multiple sources distinct; left as an explicit, documented follow-up rather than fixed here.