### PR TITLE
Fix strict-mode schemas with neither properties nor a type keyword

### DIFF
--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/SchemaSupport.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/SchemaSupport.scala
@@ -22,7 +22,7 @@ object SchemaSupport {
     * Only apply this when the caller actually requested strict mode (`strict: true`); everything else should get a faithful encoding (see
     * [[schemaCodec]]).
     */
-  def normalizeForStrict(schemaJson: Json): Json = schemaJson.foldWith(schemaFolder)
+  def normalizeForStrict(schemaJson: Json): Json = ensureStrictObjectRoot(schemaJson.foldWith(schemaFolder))
 
   /** Normalizes an apispec `Schema` to OpenAI's strict-mode rules. See [[normalizeForStrict(Json)]]. */
   def normalizeForStrict(schema: Schema): Json = normalizeForStrict(encoderSchema(schema).deepDropNullValues)
@@ -143,5 +143,21 @@ object SchemaSupport {
     obj("enum").flatMap(_.asArray) match {
       case Some(values) if !values.contains(Json.Null) => obj.add("enum", Json.fromValues(values :+ Json.Null))
       case _                                           => obj
+    }
+
+  /** `normalizeForStrict` is only ever called on a schema OpenAI itself requires to be an object (a tool's `parameters`, or a
+    * structured-output schema's root) — but the folder above only adds `additionalProperties: false` to an object when it sees a
+    * `"properties"` or `"type": "object"` key to trigger on. A schema with NEITHER (e.g. a genuinely argument-less tool advertising a bare
+    * `{}`) would otherwise reach OpenAI missing the one field strict mode always requires, and be rejected at request time.
+    *
+    * The guard mirrors the folder's own trigger condition exactly: a schema that already has `"properties"` or `"type"` is left alone even
+    * if `additionalProperties` ended up absent, since that can be a deliberate choice (e.g. the folder's discriminated-union skip) rather
+    * than the degenerate case this handles.
+    */
+  private def ensureStrictObjectRoot(json: Json): Json =
+    json.asObject match {
+      case Some(obj) if !obj.contains("properties") && !obj.contains("type") =>
+        Json.fromJsonObject(obj.add("type", Json.fromString("object")).add("additionalProperties", Json.fromBoolean(false)))
+      case _ => json
     }
 }

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/SchemaSupport.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/SchemaSupport.scala
@@ -146,9 +146,10 @@ object SchemaSupport {
     }
 
   /** `normalizeForStrict` is only ever called on a schema OpenAI itself requires to be an object (a tool's `parameters`, or a
-    * structured-output schema's root) — but the folder above only adds `additionalProperties: false` to an object when it sees a
-    * `"properties"` or `"type": "object"` key to trigger on. A schema with NEITHER (e.g. a genuinely argument-less tool advertising a bare
-    * `{}`) would otherwise reach OpenAI missing the one field strict mode always requires, and be rejected at request time.
+    * structured-output schema's root) — but the folder above only adds `additionalProperties: false`/`properties` to an object when it sees
+    * a `"properties"` or `"type": "object"` key to trigger on. A schema with NEITHER (e.g. a genuinely argument-less tool advertising a
+    * bare `{}`) would otherwise reach OpenAI missing fields strict mode always requires (`type`, `properties`, `additionalProperties`), and
+    * be rejected at request time.
     *
     * The guard mirrors the folder's own trigger condition exactly: a schema that already has `"properties"` or `"type"` is left alone even
     * if `additionalProperties` ended up absent, since that can be a deliberate choice (e.g. the folder's discriminated-union skip) rather
@@ -157,7 +158,12 @@ object SchemaSupport {
   private def ensureStrictObjectRoot(json: Json): Json =
     json.asObject match {
       case Some(obj) if !obj.contains("properties") && !obj.contains("type") =>
-        Json.fromJsonObject(obj.add("type", Json.fromString("object")).add("additionalProperties", Json.fromBoolean(false)))
+        Json.fromJsonObject(
+          obj
+            .add("type", Json.fromString("object"))
+            .add("properties", Json.obj())
+            .add("additionalProperties", Json.fromBoolean(false))
+        )
       case _ => json
     }
 }

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/SchemaSupportSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/SchemaSupportSpec.scala
@@ -164,6 +164,25 @@ class SchemaSupportSpec extends AnyFlatSpec with Matchers with EitherValues {
     result shouldBe expected
   }
 
+  // Found via a live smoke test: a genuinely argument-less MCP tool can advertise a bare `{}` input schema (no "type", no "properties" --
+  // e.g. via chimp's `inputJson(Json.obj())`, bypassing tapir derivation entirely). The folder only triggers `additionalProperties: false`
+  // on a "properties" or "type": "object" key, so this schema reached OpenAI missing it and was rejected at request time.
+  it should "add type:object and additionalProperties:false to a schema with neither properties nor a type" in {
+    val result = normalize("{}")
+    result shouldBe parse("""{"type":"object","additionalProperties":false}""").value
+  }
+
+  it should "not duplicate or override an existing top-level type/additionalProperties" in {
+    val result = normalize("""{"type":"object","properties":{"a":{"type":"string"}},"required":["a"]}""")
+    val expected = parse(
+      """{"type":"object",
+        |"properties":{"a":{"type":"string"}},
+        |"required":["a"],
+        |"additionalProperties":false}""".stripMargin
+    ).value
+    result shouldBe expected
+  }
+
   "the faithful codec" should "no longer inject additionalProperties or rewrite required" in {
     val rawSchema = """{"type":"object","properties":{"a":{"type":"string"},"b":{"type":"integer"}},"required":["a"]}"""
     val schema = parse(rawSchema).value.as[Schema](sttp.apispec.circe.schemaDecoder).value

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/SchemaSupportSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/chat/SchemaSupportSpec.scala
@@ -165,11 +165,12 @@ class SchemaSupportSpec extends AnyFlatSpec with Matchers with EitherValues {
   }
 
   // Found via a live smoke test: a genuinely argument-less MCP tool can advertise a bare `{}` input schema (no "type", no "properties" --
-  // e.g. via chimp's `inputJson(Json.obj())`, bypassing tapir derivation entirely). The folder only triggers `additionalProperties: false`
-  // on a "properties" or "type": "object" key, so this schema reached OpenAI missing it and was rejected at request time.
-  it should "add type:object and additionalProperties:false to a schema with neither properties nor a type" in {
+  // e.g. via chimp's `inputJson(Json.obj())`, bypassing tapir derivation entirely). The folder only triggers "type"/"properties"/
+  // "additionalProperties: false" on a "properties" or "type": "object" key, so this schema reached OpenAI missing all three and was
+  // rejected at request time -- first for missing additionalProperties, then (once that alone was fixed) for missing properties too.
+  it should "add type:object, properties:{}, and additionalProperties:false to a schema with neither properties nor a type" in {
     val result = normalize("{}")
-    result shouldBe parse("""{"type":"object","additionalProperties":false}""").value
+    result shouldBe parse("""{"type":"object","properties":{},"additionalProperties":false}""").value
   }
 
   it should "not duplicate or override an existing top-level type/additionalProperties" in {


### PR DESCRIPTION
A genuinely argument-less MCP tool can advertise a bare {} input schema (no "type", no "properties") -- e.g. via chimp's inputJson(Json.obj()), bypassing tapir derivation entirely. SchemaSupport's strict-mode folder only adds additionalProperties: false when it sees a "properties" or "type": "object" key to trigger on, so such a schema reached OpenAI missing the one field strict mode always requires, and was rejected at request time with: 'additionalProperties is required to be supplied and to be false'.

Found via a live smoke test driving a real chimp MCP server with a no-argument tool through OpenAIAgent.