### PR TITLE
Mention OpenRouter support in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ sttp-ai is a Scala library providing a non-official client wrapper for OpenAI, C
 **Key Features:**
 - Native OpenAI API support (Chat, Completions, Embeddings, Audio, Images, etc.)
 - Native Claude (Anthropic) API support with dedicated module
-- OpenAI-compatible API support (Ollama, Grok, etc.)
+- OpenAI-compatible API support (Ollama, Grok, OpenRouter, etc.)
 - Streaming support for all major effect systems
 - Cross-platform: Scala 2.13.16 and Scala 3.3.6
 - Agent loop tools loadable from [MCP](https://modelcontextprotocol.io) servers (`mcp` module, Scala 3 only, via [chimp](https://github.com/softwaremill/chimp)), in addition to manually defined `AgentTool`s
@@ -138,7 +138,7 @@ Each streaming module (`streaming/{effect-system}/`) provides extensions for **b
 - **Sync Clients**: `OpenAISyncClient` / `ClaudeSyncClient` - Use `DefaultSyncBackend`, block on responses, may throw exceptions
 - **Async Clients**: `OpenAI` / `ClaudeClient` - Raw sttp requests, choose backend (cats-effect, ZIO, etc.)
 - **Custom Backends**: Pass backend to `.send(backend)`
-- **OpenAI-Compatible**: Use `OpenAI` client with custom base URL for Ollama, Grok, etc.
+- **OpenAI-Compatible**: Use `OpenAI` client with custom base URL for Ollama, Grok, OpenRouter, etc.
 
 ## Debugging with Scratch Files (*.sc)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ sttp is a family of Scala HTTP-related projects, and currently includes:
 
 * [sttp client](https://github.com/softwaremill/sttp): The Scala HTTP client you always wanted!
 * [sttp tapir](https://github.com/softwaremill/tapir): Typed API descRiptions
-* sttp ai: this project. Non-official Scala client wrapper for OpenAI, Claude (Anthropic), and OpenAI-compatible APIs. Use the power of ChatGPT and Claude inside your code!
+* sttp ai: this project. Non-official Scala client wrapper for OpenAI, Claude (Anthropic), and OpenAI-compatible APIs (e.g. Ollama, Grok, OpenRouter). Use the power of ChatGPT and Claude inside your code!
 
 sttp-ai uses sttp client to describe requests and responses used in OpenAI, Claude (Anthropic), and OpenAI-compatible endpoints.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ sttp is a family of Scala HTTP-related projects, and currently includes:
 
 * [sttp client](https://github.com/softwaremill/sttp): The Scala HTTP client you always wanted!
 * [sttp tapir](https://github.com/softwaremill/tapir): Typed API descRiptions
-* sttp ai: this project. Non-official Scala client wrapper for OpenAI, Claude (Anthropic), and OpenAI-compatible APIs. Use the power of ChatGPT and Claude inside your code!
+* sttp ai: this project. Non-official Scala client wrapper for OpenAI, Claude (Anthropic), and OpenAI-compatible APIs (e.g. Ollama, Grok, OpenRouter). Use the power of ChatGPT and Claude inside your code!
 
 sttp-ai uses sttp client to describe requests and responses used in OpenAI, Claude (Anthropic), and OpenAI-compatible endpoints.
 

--- a/docs/openai/compatible-apis.md
+++ b/docs/openai/compatible-apis.md
@@ -1,6 +1,6 @@
 # OpenAI-compatible APIs
 
-## To use Ollama or Grok (OpenAI-compatible APIs)
+## To use Ollama, Grok, or OpenRouter (OpenAI-compatible APIs)
 
 Ollama with sync backend:
 
@@ -52,6 +52,58 @@ object Main:
       "chat.completion",
       Usage(0, 187, 187),
       Some("fp_ollama")
+    )
+  */
+```
+
+OpenRouter with sync backend:
+
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::openai:@VERSION@
+
+import sttp.model.Uri.*
+import sttp.ai.openai.OpenAISyncClient
+import sttp.ai.openai.requests.completions.chat.ChatRequestResponseData.ChatResponse
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.{ChatBody, ChatCompletionModel}
+import sttp.ai.openai.requests.completions.chat.message.*
+
+object Main:
+  def main(args: Array[String]): Unit =
+    val apiKey = System.getenv("OPENROUTER_API_KEY")
+    val openAI: OpenAISyncClient = OpenAISyncClient(apiKey, uri"https://openrouter.ai/api/v1")
+
+    val bodyMessages: Seq[Message] = Seq(
+      Message.User(
+        content = Content.TextContent("Hello!"),
+      )
+    )
+
+    val chatRequestBody: ChatBody = ChatBody(
+      // OpenRouter model identifiers are "provider/model", see https://openrouter.ai/models
+      model = ChatCompletionModel.CustomChatCompletionModel("openai/gpt-4o-mini"),
+      messages = bodyMessages
+    )
+
+    // be aware that calling `createChatCompletion` may throw an OpenAIException
+    // e.g. AuthenticationException, RateLimitException and many more
+    val chatResponse: ChatResponse = openAI.createChatCompletion(chatRequestBody)
+
+    println(chatResponse)
+  /*
+    ChatResponse(
+      "gen-1234567890-abcdefghijklmnopqrstuvwx",
+      List(
+        Choices(
+          Message(Assistant, """Hello there! How can I help you today?""", List(), None),
+          "stop",
+          0
+        )
+      ),
+      1714663831,
+      "openai/gpt-4o-mini",
+      "chat.completion",
+      Usage(10, 10, 20),
+      None
     )
   */
 ```


### PR DESCRIPTION
Adds an OpenRouter example alongside the existing Ollama/Grok ones in docs/openai/compatible-apis.md, and names OpenRouter explicitly in CLAUDE.md, README.md, and docs/index.md for discoverability.