### PR TITLE
Fix circular class-init deadlock between OpenAIManualCodecs and OpenAIDerivedCodecs

### DIFF
--- a/openai/src/main/scala/sttp/ai/openai/json/OpenAIManualCodecs.scala
+++ b/openai/src/main/scala/sttp/ai/openai/json/OpenAIManualCodecs.scala
@@ -252,10 +252,10 @@ object OpenAIManualCodecs {
     )
 
   implicit val rrespInputMessageContentDecoder: Decoder[Either[String, List[ResponsesResponseBody.InputItem.InputContent]]] =
-    Decoder[String].either(Decoder[List[ResponsesResponseBody.InputItem.InputContent]])
+    Decoder.instance(c => Decoder[String].either(Decoder[List[ResponsesResponseBody.InputItem.InputContent]]).apply(c))
 
   implicit val rrespInstructionsDecoder: Decoder[Either[String, List[ResponsesResponseBody.InputItem]]] =
-    Decoder[String].either(Decoder[List[ResponsesResponseBody.InputItem]])
+    Decoder.instance(c => Decoder[String].either(Decoder[List[ResponsesResponseBody.InputItem]]).apply(c))
 
   // --- responses/Tool ---
   implicit val respWebSearchPreviewCodec: Codec[RespTool.WebSearchPreview] = Codec.from(


### PR DESCRIPTION
OpenAIManualCodecs and OpenAIDerivedCodecs reference each other, and the file's own doc comment establishes a one-way init dependency: OpenAIDerivedCodecs may depend on OpenAIManualCodecs, but OpenAIManualCodecs must never *eagerly* trigger OpenAIDerivedCodecs's class initialization. Every such reference must sit inside a lazy Encoder.instance/Decoder.instance body instead.

rrespInputMessageContentDecoder and rrespInstructionsDecoder violated this: their RHS called Decoder[List[...]] directly at the top level, eagerly summoning decoders (rrespInInputContentDecoder / rrespInputItemDecoder) that are only defined in OpenAIDerivedCodecs. This forced OpenAIDerivedCodecs's <clinit> to run synchronously inside OpenAIManualCodecs's own <clinit>. When two threads first-touch the two objects concurrently (e.g. parallel test suites), JVM class-init locking deadlocks: one thread blocks in OpenAIManualCodecs$.<clinit> waiting on OpenAIDerivedCodecs$'s monitor while the other blocks in OpenAIDerivedCodecs$.<clinit> waiting on OpenAIManualCodecs$'s monitor, hanging `sbt openai/test` indefinitely.

Reproduced the hang via thread dump on unmodified master (confirmed both threads blocked exactly as described, at OpenAIManualCodecs.scala:255 and OpenAIDerivedCodecs.scala:327). Fixed by deferring the List[...] decoder summon inside Decoder.instance, matching the pattern already used by rrespMessageDecoder a few lines above. Audited the rest of the file for the same eager-summon pattern; no other violations found.

Verified with 10 consecutive `sbt openai/test` runs (all green, 165 tests each, no hangs) plus a `core/test` regression check.