### PR TITLE
Worktree extra body support

### DIFF
--- a/core/src/main/scala/sttp/ai/core/json/CirceHelpers.scala
+++ b/core/src/main/scala/sttp/ai/core/json/CirceHelpers.scala
@@ -14,4 +14,19 @@ object CirceHelpers {
     j.mapObject(_.filter { case (_, v) => !(v.asArray.exists(_.isEmpty) || v.asObject.exists(_.isEmpty)) })
 
   implicit val omitFalse: Encoder[Option[Boolean]] = Encoder.encodeOption[Boolean].contramap(_.filter(identity))
+
+  /** Splices the JSON object under `fieldName` into the top level of `json`, dropping the `fieldName` wrapper key. Used to implement
+    * `extraBody`-style escape hatches: a request body encodes its `extraBody: Map[String, Json]` field as a nested object under `fieldName`
+    * like any other field, and this then flattens it into siblings of the body's other fields, overriding any of them it collides with
+    * (`deepMerge` is right-biased). A no-op if `fieldName` is absent or not a JSON object.
+    */
+  def mergeExtraBody(fieldName: String)(json: Json): Json =
+    json.asObject match {
+      case Some(obj) =>
+        obj(fieldName).flatMap(_.asObject) match {
+          case Some(extra) => Json.fromJsonObject(obj.remove(fieldName)).deepMerge(Json.fromJsonObject(extra))
+          case None        => json
+        }
+      case None => json
+    }
 }

--- a/core/src/test/scala/sttp/ai/core/json/CirceHelpersSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/json/CirceHelpersSpec.scala
@@ -1,0 +1,48 @@
+package sttp.ai.core.json
+
+import io.circe.Json
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.core.json.CirceHelpers.mergeExtraBody
+
+class CirceHelpersSpec extends AnyFlatSpec with Matchers {
+
+  "mergeExtraBody" should "splice the object under the given field into the top level, dropping the wrapper key" in {
+    val json = Json.obj(
+      "model" -> Json.fromString("gpt-4o"),
+      "extra_body" -> Json.obj(
+        "guided_json" -> Json.obj("type" -> Json.fromString("object")),
+        "top_k" -> Json.fromInt(40)
+      )
+    )
+
+    val merged = mergeExtraBody("extra_body")(json)
+
+    merged shouldBe Json.obj(
+      "model" -> Json.fromString("gpt-4o"),
+      "guided_json" -> Json.obj("type" -> Json.fromString("object")),
+      "top_k" -> Json.fromInt(40)
+    )
+  }
+
+  it should "let the extra field's entries override a colliding top-level field" in {
+    val json = Json.obj(
+      "temperature" -> Json.fromDoubleOrNull(0.2),
+      "extra_body" -> Json.obj("temperature" -> Json.fromDoubleOrNull(0.9))
+    )
+
+    mergeExtraBody("extra_body")(json) shouldBe Json.obj("temperature" -> Json.fromDoubleOrNull(0.9))
+  }
+
+  it should "leave the JSON unchanged when the given field is absent" in {
+    val json = Json.obj("model" -> Json.fromString("gpt-4o"))
+
+    mergeExtraBody("extra_body")(json) shouldBe json
+  }
+
+  it should "leave the JSON unchanged when the given field is present but not an object" in {
+    val json = Json.obj("model" -> Json.fromString("gpt-4o"), "extra_body" -> Json.Null)
+
+    mergeExtraBody("extra_body")(json) shouldBe json
+  }
+}

--- a/docs/openai/compatible-apis.md
+++ b/docs/openai/compatible-apis.md
@@ -151,7 +151,6 @@ object Main:
 
     println(chatResponse)
 ```
-```
 
 Grok with cats-effect based backend:
 

--- a/docs/openai/compatible-apis.md
+++ b/docs/openai/compatible-apis.md
@@ -108,6 +108,51 @@ object Main:
   */
 ```
 
+### Extra body parameters (vLLM, etc.)
+
+Some OpenAI-compatible backends — vLLM in particular — accept request parameters that aren't part of the official OpenAI API and have no
+typed field on `ChatBody`, `CompletionsBody`, or `EmbeddingsBody` (e.g. vLLM's `guided_json` or `top_k`). Use `extraBody` to merge arbitrary
+JSON values into the top level of the serialized request, alongside the typed fields:
+
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::openai:@VERSION@
+
+import io.circe.Json
+import sttp.model.Uri.*
+import sttp.ai.openai.OpenAISyncClient
+import sttp.ai.openai.requests.completions.chat.ChatRequestResponseData.ChatResponse
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.{ChatBody, ChatCompletionModel}
+import sttp.ai.openai.requests.completions.chat.message.*
+
+object Main:
+  def main(args: Array[String]): Unit =
+    val openAI: OpenAISyncClient = OpenAISyncClient("vllm", uri"http://localhost:8000/v1")
+
+    val bodyMessages: Seq[Message] = Seq(
+      Message.User(
+        content = Content.TextContent("List three colors as JSON."),
+      )
+    )
+
+    val chatRequestBody: ChatBody = ChatBody(
+      model = ChatCompletionModel.CustomChatCompletionModel("meta-llama/Llama-3.1-8B-Instruct"),
+      messages = bodyMessages,
+      // vLLM-specific parameters with no typed field on ChatBody, merged into the top-level request JSON:
+      extraBody = Map(
+        "guided_json" -> Json.obj(
+          "type" -> Json.fromString("object"),
+          "properties" -> Json.obj("colors" -> Json.obj("type" -> Json.fromString("array")))
+        ),
+        "top_k" -> Json.fromInt(40)
+      )
+    )
+
+    val chatResponse: ChatResponse = openAI.createChatCompletion(chatRequestBody)
+
+    println(chatResponse)
+```
+```
+
 Grok with cats-effect based backend:
 
 ```scala mdoc:compile-only

--- a/openai/src/main/scala-2/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
+++ b/openai/src/main/scala-2/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
@@ -275,7 +275,8 @@ object OpenAIDerivedCodecs {
   implicit val chatChunkResponseCodec: Codec[Chunk.ChatChunkResponse] = deriveConfiguredCodec
 
   // request bodies
-  implicit val embeddingsBodyEncoder: Encoder[EmbReq.EmbeddingsBody] = deriveConfiguredEncoder
+  implicit val embeddingsBodyEncoder: Encoder[EmbReq.EmbeddingsBody] =
+    deriveConfiguredEncoder[EmbReq.EmbeddingsBody].mapJson(mergeExtraBody("extra_body"))
   implicit val moderationsBodyEncoder: Encoder[ModReq.ModerationsBody] = deriveConfiguredEncoder
   implicit val completionsBodyEncoder: Encoder[CompReq.CompletionsBody] =
     deriveConfiguredEncoder[CompReq.CompletionsBody].mapJson(mergeExtraBody("extra_body"))

--- a/openai/src/main/scala-2/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
+++ b/openai/src/main/scala-2/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
@@ -277,7 +277,8 @@ object OpenAIDerivedCodecs {
   // request bodies
   implicit val embeddingsBodyEncoder: Encoder[EmbReq.EmbeddingsBody] = deriveConfiguredEncoder
   implicit val moderationsBodyEncoder: Encoder[ModReq.ModerationsBody] = deriveConfiguredEncoder
-  implicit val completionsBodyEncoder: Encoder[CompReq.CompletionsBody] = deriveConfiguredEncoder
+  implicit val completionsBodyEncoder: Encoder[CompReq.CompletionsBody] =
+    deriveConfiguredEncoder[CompReq.CompletionsBody].mapJson(mergeExtraBody("extra_body"))
   implicit val speechRequestBodyEncoder: Encoder[SpeechRequestBody] = deriveConfiguredEncoder
 
   // embeddings response

--- a/openai/src/main/scala-2/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
+++ b/openai/src/main/scala-2/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
@@ -9,7 +9,7 @@ import io.circe.generic.extras.semiauto.{
   deriveEnumerationEncoder
 }
 import sttp.ai.core.json.CirceConfiguration.jsonConfiguration
-import sttp.ai.core.json.CirceHelpers.dropEmptyTopLevel
+import sttp.ai.core.json.CirceHelpers.{dropEmptyTopLevel, mergeExtraBody}
 import sttp.ai.openai.requests.completions.{CompletionTokensDetails, PromptTokensDetails, Usage}
 import sttp.ai.openai.requests.completions.chat.Audio
 import sttp.ai.openai.requests.completions.chat.{ChatChunkRequestResponseData => Chunk, ChatRequestResponseData => Resp}
@@ -250,7 +250,7 @@ object OpenAIDerivedCodecs {
     Codec.from(deriveConfiguredDecoder[Message], deriveConfiguredEncoder[Message].mapJson(dropEmptyTopLevel))
   }
 
-  implicit val chatBodyEncoder: Encoder[ChatBody] = deriveConfiguredEncoder
+  implicit val chatBodyEncoder: Encoder[ChatBody] = deriveConfiguredEncoder[ChatBody].mapJson(mergeExtraBody("extra_body"))
 
   // usage
   implicit val completionTokensDetailsCodec: Codec[CompletionTokensDetails] = deriveConfiguredCodec

--- a/openai/src/main/scala-3/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
+++ b/openai/src/main/scala-3/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
@@ -258,7 +258,8 @@ object OpenAIDerivedCodecs {
   implicit val chatChunkResponseCodec: Codec[Chunk.ChatChunkResponse] = ConfiguredCodec.derived
 
   // request bodies
-  implicit val embeddingsBodyEncoder: Encoder[EmbReq.EmbeddingsBody] = ConfiguredEncoder.derived
+  implicit val embeddingsBodyEncoder: Encoder[EmbReq.EmbeddingsBody] =
+    ConfiguredEncoder.derived[EmbReq.EmbeddingsBody].mapJson(mergeExtraBody("extra_body"))
   implicit val moderationsBodyEncoder: Encoder[ModReq.ModerationsBody] = ConfiguredEncoder.derived
   implicit val completionsBodyEncoder: Encoder[CompReq.CompletionsBody] =
     ConfiguredEncoder.derived[CompReq.CompletionsBody].mapJson(mergeExtraBody("extra_body"))

--- a/openai/src/main/scala-3/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
+++ b/openai/src/main/scala-3/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
@@ -260,7 +260,8 @@ object OpenAIDerivedCodecs {
   // request bodies
   implicit val embeddingsBodyEncoder: Encoder[EmbReq.EmbeddingsBody] = ConfiguredEncoder.derived
   implicit val moderationsBodyEncoder: Encoder[ModReq.ModerationsBody] = ConfiguredEncoder.derived
-  implicit val completionsBodyEncoder: Encoder[CompReq.CompletionsBody] = ConfiguredEncoder.derived
+  implicit val completionsBodyEncoder: Encoder[CompReq.CompletionsBody] =
+    ConfiguredEncoder.derived[CompReq.CompletionsBody].mapJson(mergeExtraBody("extra_body"))
   implicit val speechRequestBodyEncoder: Encoder[SpeechRequestBody] = ConfiguredEncoder.derived
 
   // embeddings response

--- a/openai/src/main/scala-3/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
+++ b/openai/src/main/scala-3/sttp/ai/openai/json/OpenAIDerivedCodecs.scala
@@ -3,7 +3,7 @@ package sttp.ai.openai.json
 import io.circe.{Codec, Decoder, DecodingFailure, Encoder, Json, JsonObject}
 import io.circe.derivation.{Configuration, ConfiguredCodec, ConfiguredDecoder, ConfiguredEncoder, ConfiguredEnumCodec}
 import sttp.ai.core.json.CirceConfiguration.jsonConfiguration
-import sttp.ai.core.json.CirceHelpers.dropEmptyTopLevel
+import sttp.ai.core.json.CirceHelpers.{dropEmptyTopLevel, mergeExtraBody}
 import scala.deriving.Mirror
 import sttp.ai.openai.requests.completions.{CompletionTokensDetails, PromptTokensDetails, Usage}
 import sttp.ai.openai.requests.completions.chat.Audio
@@ -233,7 +233,7 @@ object OpenAIDerivedCodecs {
     Codec.from(ConfiguredDecoder.derived[Message], ConfiguredEncoder.derived[Message].mapJson(dropEmptyTopLevel))
   }
 
-  implicit val chatBodyEncoder: Encoder[ChatBody] = ConfiguredEncoder.derived
+  implicit val chatBodyEncoder: Encoder[ChatBody] = ConfiguredEncoder.derived[ChatBody].mapJson(mergeExtraBody("extra_body"))
 
   // usage
   implicit val completionTokensDetailsCodec: Codec[CompletionTokensDetails] = ConfiguredCodec.derived

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/CompletionsRequestBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/CompletionsRequestBody.scala
@@ -43,7 +43,9 @@ object CompletionsRequestBody {
     *   Arbitrary extra parameters merged into the top level of the serialized request JSON, alongside the fields above. Useful for
     *   parameters supported only by an OpenAI-compatible backend, which have no typed field here. If a key collides with one of the typed
     *   fields above, the `extraBody` value wins for scalar/array values; if both sides are JSON objects, they are merged recursively (deep
-    *   merge), so unset sub-keys of the typed field's object may still survive alongside `extraBody`'s.
+    *   merge), so unset sub-keys of the typed field's object may still survive alongside `extraBody`'s. Map keys are used as-is, with no
+    *   snake_case conversion (unlike the typed fields above), so use the backend's actual wire name for each key. Explicit `Json.Null`
+    *   values are dropped like any other unset field and will not reach the wire.
     *
     * For more information please visit: [[https://platform.openai.com/docs/api-reference/completions/create]]
     */

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/CompletionsRequestBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/CompletionsRequestBody.scala
@@ -42,7 +42,8 @@ object CompletionsRequestBody {
     * @param extraBody
     *   Arbitrary extra parameters merged into the top level of the serialized request JSON, alongside the fields above. Useful for
     *   parameters supported only by an OpenAI-compatible backend, which have no typed field here. If a key collides with one of the typed
-    *   fields above, the `extraBody` value wins.
+    *   fields above, the `extraBody` value wins for scalar/array values; if both sides are JSON objects, they are merged recursively (deep
+    *   merge), so unset sub-keys of the typed field's object may still survive alongside `extraBody`'s.
     *
     * For more information please visit: [[https://platform.openai.com/docs/api-reference/completions/create]]
     */

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/CompletionsRequestBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/CompletionsRequestBody.scala
@@ -1,5 +1,7 @@
 package sttp.ai.openai.requests.completions
 
+import io.circe.Json
+
 object CompletionsRequestBody {
 
   /** @param model
@@ -37,6 +39,10 @@ object CompletionsRequestBody {
     *   Modify the likelihood of specified tokens appearing in the completion.
     * @param user
     *   A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    * @param extraBody
+    *   Arbitrary extra parameters merged into the top level of the serialized request JSON, alongside the fields above. Useful for
+    *   parameters supported only by an OpenAI-compatible backend, which have no typed field here. If a key collides with one of the typed
+    *   fields above, the `extraBody` value wins.
     *
     * For more information please visit: [[https://platform.openai.com/docs/api-reference/completions/create]]
     */
@@ -55,7 +61,8 @@ object CompletionsRequestBody {
       frequencyPenalty: Option[Double] = None,
       bestOf: Option[Int] = None,
       logitBias: Option[Map[String, Float]] = None,
-      user: Option[String] = None
+      user: Option[String] = None,
+      extraBody: Map[String, Json] = Map.empty
   )
 
   sealed abstract class CompletionModel(val value: String)

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestBody.scala
@@ -132,6 +132,8 @@ object ChatRequestBody {
     *   parameters supported only by an OpenAI-compatible backend (e.g. vLLM's `guided_json`, `top_k`), which have no typed field here. If a
     *   key collides with one of the typed fields above, the `extraBody` value wins for scalar/array values; if both sides are JSON objects,
     *   they are merged recursively (deep merge), so unset sub-keys of the typed field's object may still survive alongside `extraBody`'s.
+    *   Map keys are used as-is, with no snake_case conversion (unlike the typed fields above), so use the backend's actual wire name for
+    *   each key. Explicit `Json.Null` values are dropped like any other unset field and will not reach the wire.
     */
   case class ChatBody(
       messages: Seq[Message],

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestBody.scala
@@ -127,6 +127,10 @@ object ChatRequestBody {
     * @param promptCacheRetention
     *   Can be used to specify policy on how long the prompt cache should be retained, not every model support every policy, check the API
     *   documentation for more details.
+    * @param extraBody
+    *   Arbitrary extra parameters merged into the top level of the serialized request JSON, alongside the fields above. Useful for
+    *   parameters supported only by an OpenAI-compatible backend (e.g. vLLM's `guided_json`, `top_k`), which have no typed field here. If a
+    *   key collides with one of the typed fields above, the `extraBody` value wins.
     */
   case class ChatBody(
       messages: Seq[Message],
@@ -157,7 +161,8 @@ object ChatRequestBody {
       prediction: Option[Prediction] = None,
       audio: Option[Audio] = None,
       promptCacheKey: Option[String] = None,
-      promptCacheRetention: Option[CacheRetentionPolicy] = None
+      promptCacheRetention: Option[CacheRetentionPolicy] = None,
+      extraBody: Map[String, Json] = Map.empty
   )
 
   object ChatBody {

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestBody.scala
@@ -130,7 +130,8 @@ object ChatRequestBody {
     * @param extraBody
     *   Arbitrary extra parameters merged into the top level of the serialized request JSON, alongside the fields above. Useful for
     *   parameters supported only by an OpenAI-compatible backend (e.g. vLLM's `guided_json`, `top_k`), which have no typed field here. If a
-    *   key collides with one of the typed fields above, the `extraBody` value wins.
+    *   key collides with one of the typed fields above, the `extraBody` value wins for scalar/array values; if both sides are JSON objects,
+    *   they are merged recursively (deep merge), so unset sub-keys of the typed field's object may still survive alongside `extraBody`'s.
     */
   case class ChatBody(
       messages: Seq[Message],

--- a/openai/src/main/scala/sttp/ai/openai/requests/embeddings/EmbeddingsRequestBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/embeddings/EmbeddingsRequestBody.scala
@@ -16,7 +16,9 @@ object EmbeddingsRequestBody {
     *   Arbitrary extra parameters merged into the top level of the serialized request JSON, alongside the fields above. Useful for
     *   parameters supported only by an OpenAI-compatible backend, which have no typed field here. If a key collides with one of the typed
     *   fields above, the `extraBody` value wins for scalar/array values; if both sides are JSON objects, they are merged recursively (deep
-    *   merge), so unset sub-keys of the typed field's object may still survive alongside `extraBody`'s.
+    *   merge), so unset sub-keys of the typed field's object may still survive alongside `extraBody`'s. Map keys are used as-is, with no
+    *   snake_case conversion (unlike the typed fields above), so use the backend's actual wire name for each key. Explicit `Json.Null`
+    *   values are dropped like any other unset field and will not reach the wire.
     */
   case class EmbeddingsBody(
       model: EmbeddingsModel,

--- a/openai/src/main/scala/sttp/ai/openai/requests/embeddings/EmbeddingsRequestBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/embeddings/EmbeddingsRequestBody.scala
@@ -1,5 +1,7 @@
 package sttp.ai.openai.requests.embeddings
 
+import io.circe.Json
+
 object EmbeddingsRequestBody {
 
   /** @param model
@@ -10,8 +12,18 @@ object EmbeddingsRequestBody {
     *   A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
     * @param dimensions
     *   The number of dimensions for the embeddings. Only supported in text-embedding-3 and later models.
+    * @param extraBody
+    *   Arbitrary extra parameters merged into the top level of the serialized request JSON, alongside the fields above. Useful for
+    *   parameters supported only by an OpenAI-compatible backend, which have no typed field here. If a key collides with one of the typed
+    *   fields above, the `extraBody` value wins.
     */
-  case class EmbeddingsBody(model: EmbeddingsModel, input: EmbeddingsInput, user: Option[String] = None, dimensions: Option[Int] = None)
+  case class EmbeddingsBody(
+      model: EmbeddingsModel,
+      input: EmbeddingsInput,
+      user: Option[String] = None,
+      dimensions: Option[Int] = None,
+      extraBody: Map[String, Json] = Map.empty
+  )
 
   sealed abstract class EmbeddingsModel(val value: String)
 

--- a/openai/src/main/scala/sttp/ai/openai/requests/embeddings/EmbeddingsRequestBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/embeddings/EmbeddingsRequestBody.scala
@@ -15,7 +15,8 @@ object EmbeddingsRequestBody {
     * @param extraBody
     *   Arbitrary extra parameters merged into the top level of the serialized request JSON, alongside the fields above. Useful for
     *   parameters supported only by an OpenAI-compatible backend, which have no typed field here. If a key collides with one of the typed
-    *   fields above, the `extraBody` value wins.
+    *   fields above, the `extraBody` value wins for scalar/array values; if both sides are JSON objects, they are merged recursively (deep
+    *   merge), so unset sub-keys of the typed field's object may still survive alongside `extraBody`'s.
     */
   case class EmbeddingsBody(
       model: EmbeddingsModel,

--- a/openai/src/test/scala/sttp/ai/openai/json/OpenAIJsonSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/json/OpenAIJsonSpec.scala
@@ -101,6 +101,36 @@ class OpenAIJsonSpec extends AnyFlatSpec with Matchers with EitherValues {
     json.hcursor.downField("response_format").downField("json_schema").downField("schema").succeeded shouldBe false
   }
 
+  it should "merge extraBody entries into the top level of the serialized request" in {
+    val chatBody = ChatBody(
+      messages = Seq(Message.User(content = Content.TextContent("hi"))),
+      model = ChatCompletionModel.GPT4oMini,
+      extraBody = Map(
+        "guided_json" -> Json.obj("type" -> Json.fromString("object")),
+        "top_k" -> Json.fromInt(40)
+      )
+    )
+
+    val json = parse(requestBodyOf(chatBody)).value
+
+    json.hcursor.downField("guided_json").as[Json].value shouldBe Json.obj("type" -> Json.fromString("object"))
+    json.hcursor.downField("top_k").as[Int].value shouldBe 40
+    json.hcursor.downField("extra_body").succeeded shouldBe false
+  }
+
+  it should "let an extraBody entry override a colliding typed field" in {
+    val chatBody = ChatBody(
+      messages = Seq(Message.User(content = Content.TextContent("hi"))),
+      model = ChatCompletionModel.GPT4oMini,
+      temperature = Some(0.2),
+      extraBody = Map("temperature" -> Json.fromDoubleOrNull(0.9))
+    )
+
+    val json = parse(requestBodyOf(chatBody)).value
+
+    json.hcursor.downField("temperature").as[Double].value shouldBe 0.9
+  }
+
   private def responsesRequestBodyOf(requestBody: ResponsesRequestBody): String =
     new OpenAI("test-key").createModelResponse(requestBody).body match {
       case StringBody(s, _, _) => s

--- a/openai/src/test/scala/sttp/ai/openai/json/OpenAIJsonSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/json/OpenAIJsonSpec.scala
@@ -131,6 +131,17 @@ class OpenAIJsonSpec extends AnyFlatSpec with Matchers with EitherValues {
     json.hcursor.downField("temperature").as[Double].value shouldBe 0.9
   }
 
+  it should "omit the extra_body key entirely when extraBody is left at its default empty map" in {
+    val chatBody = ChatBody(
+      messages = Seq(Message.User(content = Content.TextContent("hi"))),
+      model = ChatCompletionModel.GPT4oMini
+    )
+
+    val json = parse(requestBodyOf(chatBody)).value
+
+    json.hcursor.downField("extra_body").succeeded shouldBe false
+  }
+
   private def responsesRequestBodyOf(requestBody: ResponsesRequestBody): String =
     new OpenAI("test-key").createModelResponse(requestBody).body match {
       case StringBody(s, _, _) => s

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/CompletionsDataSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/completions/CompletionsDataSpec.scala
@@ -7,6 +7,7 @@ import sttp.ai.openai.fixtures
 import sttp.ai.openai.requests.completions.Stop.SingleStop
 import io.circe.parser.{decode, parse}
 import io.circe.syntax._
+import io.circe.Json
 import sttp.ai.openai.json.OpenAIDerivedCodecs._
 import sttp.ai.openai.json.OpenAIManualCodecs._
 
@@ -230,6 +231,23 @@ class CompletionsDataSpec extends AnyFlatSpec with Matchers with EitherValues {
 
     // then
     serializedJson shouldBe jsonRequest
+  }
+
+  "Given completions request with extraBody" should "merge extraBody entries into the top level of the serialized Json" in {
+    import sttp.ai.openai.requests.completions.CompletionsRequestBody.CompletionModel.GPT35TurboInstruct
+    import sttp.ai.openai.requests.completions.CompletionsRequestBody.CompletionsBody._
+    import sttp.ai.openai.requests.completions.CompletionsRequestBody._
+
+    val givenRequest = CompletionsRequestBody.CompletionsBody(
+      model = GPT35TurboInstruct,
+      prompt = Some(SinglePrompt("Say this is a test")),
+      extraBody = Map("top_k" -> Json.fromInt(40))
+    )
+
+    val serializedJson: io.circe.Json = givenRequest.asJson.deepDropNullValues
+
+    serializedJson.hcursor.downField("top_k").as[Int].value shouldBe 40
+    serializedJson.hcursor.downField("extra_body").succeeded shouldBe false
   }
 
 }

--- a/openai/src/test/scala/sttp/ai/openai/openai/requests/embeddings/EmbeddingsDataSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/requests/embeddings/EmbeddingsDataSpec.scala
@@ -7,6 +7,8 @@ import sttp.ai.openai.fixtures
 import sttp.ai.openai.requests.embeddings.EmbeddingsRequestBody.EmbeddingsModel
 import sttp.ai.openai.requests.embeddings.EmbeddingsResponseBody._
 import io.circe.parser.decode
+import io.circe.Json
+import io.circe.syntax._
 import sttp.ai.openai.json.OpenAIDerivedCodecs._
 import sttp.ai.openai.json.OpenAIManualCodecs._
 
@@ -37,6 +39,19 @@ class EmbeddingsDataSpec extends AnyFlatSpec with Matchers with EitherValues {
 
     // then
     givenResponse.value shouldBe expectedResponse
+  }
+
+  "Given embeddings request with extraBody" should "merge extraBody entries into the top level of the serialized Json" in {
+    val givenRequest = EmbeddingsRequestBody.EmbeddingsBody(
+      model = EmbeddingsModel.TextEmbeddingAda002,
+      input = EmbeddingsRequestBody.EmbeddingsInput.SingleInput("hello"),
+      extraBody = Map("truncate" -> Json.fromString("END"))
+    )
+
+    val serializedJson = givenRequest.asJson.deepDropNullValues
+
+    serializedJson.hcursor.downField("truncate").as[String].value shouldBe "END"
+    serializedJson.hcursor.downField("extra_body").succeeded shouldBe false
   }
 
 }


### PR DESCRIPTION
## Summary

Adds an `extraBody` escape hatch to `ChatBody`, `CompletionsBody`, and `EmbeddingsBody`, letting callers merge arbitrary JSON parameters into the top level of the serialized request — for parameters that OpenAI-compatible backends (vLLM, etc.) accept but this library has no typed field for (e.g. vLLM's `guided_json`, `top_k`). Mirrors the semantics of the OpenAI Python client's `extra_body`.

- `extraBody: Map[String, Json] = Map.empty` added as the last constructor parameter on all three case classes.
- A single shared helper, `CirceHelpers.mergeExtraBody(fieldName)(json)`, splices the object under `"extra_body"` into the top level of the encoded JSON and drops the wrapper key. Wired into each body's encoder via `.mapJson(mergeExtraBody("extra_body"))`, identically in both the Scala 2 and Scala 3 `OpenAIDerivedCodecs.scala` files.
- On a key collision with a typed field, `extraBody` wins (right-biased `deepMerge`) — documented as a clean override for scalar/array values; object-typed collisions merge recursively rather than replace, which is called out explicitly in the Scaladoc.
- Encode-only; none of the three bodies decode from JSON in this library, so there's no round-trip concern.
- New docs section in `docs/openai/compatible-apis.md` with a vLLM example.