### PR TITLE
No tools final iteration

### DIFF
--- a/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
+++ b/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
@@ -81,7 +81,8 @@ private[claude] class ClaudeAgentBackend[F[_]](
 
   override def sendRequest(
       history: ConversationHistory,
-      backend: Backend[F]
+      backend: Backend[F],
+      includeTools: Boolean
   ): F[AgentResponse] = {
     val messages = buildMessages(history)
     val request = MessageRequest(
@@ -89,7 +90,7 @@ private[claude] class ClaudeAgentBackend[F[_]](
       messages = messages.toList,
       maxTokens = 4096,
       system = systemPrompt,
-      tools = if (convertedTools.nonEmpty) Some(convertedTools.toList) else None,
+      tools = if (includeTools && convertedTools.nonEmpty) Some(convertedTools.toList) else None,
       outputConfig = outputConfig
     )
 

--- a/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
@@ -126,7 +126,7 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
       captured.set(request)
       ResponseStub.adjust(minimalMessageResponse, StatusCode.Ok)
     }
-    backend.sendRequest(ConversationHistory.withInitialPrompt("hello"), httpStub, includeTools = includeTools)
+    backend.sendRequest(ConversationHistory.withInitialPrompt("hello"), httpStub, includeTools = includeTools): Unit
     captured.get().body match {
       case StringBody(s, _, _) => s
       case other               => fail(s"expected StringBody, got $other")

--- a/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
@@ -9,9 +9,15 @@ import sttp.ai.claude.ClaudeClient
 import sttp.ai.claude.config.ClaudeConfig
 import sttp.ai.claude.models.Tool
 import sttp.ai.core.agent.AgentTool
+import sttp.ai.core.agent.ConversationHistory
 import sttp.apispec.Schema
+import sttp.client4._
+import sttp.client4.testing.ResponseStub
+import sttp.model.StatusCode
 import sttp.monad.IdentityMonad
 import sttp.shared.Identity
+
+import java.util.concurrent.atomic.AtomicReference
 
 class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues {
 
@@ -96,5 +102,42 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
       case raw: Tool.CustomRaw => raw.inputSchema shouldBe parse("""{"type":"object"}""").value
       case other               => fail(s"expected Tool.CustomRaw, got $other")
     }
+  }
+
+  private val minimalMessageResponse =
+    """{
+      |  "id": "msg_1",
+      |  "type": "message",
+      |  "role": "assistant",
+      |  "content": [{"type": "text", "text": "done"}],
+      |  "model": "claude-haiku-4-5-20251001",
+      |  "stop_reason": "end_turn",
+      |  "usage": {"input_tokens": 10, "output_tokens": 20}
+      |}""".stripMargin
+
+  private def captureRequestBody(includeTools: Boolean): String = {
+    val schema = parse(rawSchema).value.as[Schema](sttp.apispec.circe.schemaDecoder).value
+    val tool = AgentTool.dynamic("create-event", "Creates an event", schema)(_ => "ok")
+    val client = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
+    val backend = new ClaudeAgentBackend[Identity](client, "claude-haiku-4-5-20251001", Seq(tool), None, None)(IdentityMonad)
+
+    val captured = new AtomicReference[GenericRequest[_, _]](null)
+    val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF { request =>
+      captured.set(request)
+      ResponseStub.adjust(minimalMessageResponse, StatusCode.Ok)
+    }
+    backend.sendRequest(ConversationHistory.withInitialPrompt("hello"), httpStub, includeTools = includeTools)
+    captured.get().body match {
+      case StringBody(s, _, _) => s
+      case other               => fail(s"expected StringBody, got $other")
+    }
+  }
+
+  it should "include tools in the request body when includeTools is true" in {
+    captureRequestBody(includeTools = true) should include("\"tools\"")
+  }
+
+  it should "omit tools from the request body when includeTools is false" in {
+    captureRequestBody(includeTools = false) should not include "\"tools\""
   }
 }

--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -32,13 +32,15 @@ class Agent[F[_]](
           )
         )
       } else {
+        val isLastIteration = iteration == config.maxIterations - 1
+
         val historyWithMarker = if (iteration > 0) {
           history.addIterationMarker(iteration + 1, config.maxIterations)
         } else {
           history
         }
 
-        val response = agentBackend.sendRequest(historyWithMarker, backend)
+        val response = agentBackend.sendRequest(historyWithMarker, backend, includeTools = !isLastIteration)
 
         response.flatMap { response =>
           if (response.stopReason == StopReason.MaxTokens) {
@@ -48,6 +50,19 @@ class Agent[F[_]](
                 iterations = iteration + 1,
                 toolCalls = toolCallRecords,
                 finishReason = FinishReason.TokenLimit
+              )
+            )
+          } else if (isLastIteration) {
+            // Tools were not offered on the last allowed iteration, so any tool calls in the response are
+            // spurious and must not be executed. Force the final answer: prefer the model's text, and fall
+            // back to the last tool result / assistant text if the model returned no text.
+            val finalAnswer = if (response.textContent.nonEmpty) response.textContent else extractFinalAnswer(history)
+            monad.unit(
+              AgentResult(
+                finalAnswer = finalAnswer,
+                iterations = iteration + 1,
+                toolCalls = toolCallRecords,
+                finishReason = FinishReason.MaxIterations
               )
             )
           } else if (response.toolCalls.isEmpty) {

--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -22,6 +22,8 @@ class Agent[F[_]](
     val initialHistory = ConversationHistory.withInitialPrompt(initialPrompt)
 
     def loop(history: ConversationHistory, iteration: Int, toolCallRecords: Seq[ToolCallRecord]): F[AgentResult[String]] =
+      // Safety net for maxIterations <= 0. For maxIterations >= 1 this is unreachable: the isLastIteration branch below
+      // always returns at iteration == maxIterations - 1, so the loop never recurses to iteration == maxIterations.
       if (iteration >= config.maxIterations) {
         monad.unit(
           AgentResult(

--- a/core/src/main/scala/sttp/ai/core/agent/AgentBackend.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentBackend.scala
@@ -28,12 +28,16 @@ trait AgentBackend[F[_]] {
     *   The complete conversation history including prompts, responses, tool calls, and results
     * @param backend
     *   The HTTP backend used to send requests (supports various effect systems via sttp)
+    * @param includeTools
+    *   Whether the agent's tools should be offered on this call. The agent loop sets this to `false` on the last allowed iteration so the
+    *   model is forced to produce a final answer instead of making tool calls whose results would be discarded.
     * @return
     *   The LLM's response wrapped in the effect type F, containing text content, tool calls, and stop reason
     */
   def sendRequest(
       history: ConversationHistory,
-      backend: Backend[F]
+      backend: Backend[F],
+      includeTools: Boolean
   ): F[AgentResponse]
 }
 

--- a/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
@@ -16,15 +16,18 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
   class StubAgentBackend(responses: Seq[AgentResponse]) extends AgentBackend[Identity] {
     private var callCount = 0
     var receivedHistories: Seq[ConversationHistory] = Seq.empty
+    var receivedIncludeTools: Seq[Boolean] = Seq.empty
 
     override def tools: Seq[AgentTool[Identity, _]] = Seq.empty
     override def systemPrompt: Option[String] = None
 
     override def sendRequest(
         history: ConversationHistory,
-        backend: sttp.client4.Backend[Identity]
+        backend: sttp.client4.Backend[Identity],
+        includeTools: Boolean
     ): Identity[AgentResponse] = {
       receivedHistories = receivedHistories :+ history
+      receivedIncludeTools = receivedIncludeTools :+ includeTools
       val response = if (callCount < responses.length) {
         responses(callCount)
       } else {
@@ -80,7 +83,30 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
 
     result.finishReason shouldBe FinishReason.MaxIterations
     result.iterations shouldBe 5
-    result.toolCalls should have size 5
+    result.toolCalls should have size 4
+  }
+
+  it should "not offer tools on the last iteration and use the forced text answer" in {
+    val dummyTool = AgentTool.fromFunction(
+      "dummy",
+      "Dummy tool"
+    )((_: DummyInput) => "dummy result")
+
+    val stubBackend = new StubAgentBackend(
+      Seq(
+        AgentResponse("r1", Seq(ToolCall(id = "call_1", toolName = "dummy", input = "{}")), StopReason.ToolUse),
+        AgentResponse("r2", Seq(ToolCall(id = "call_2", toolName = "dummy", input = "{}")), StopReason.ToolUse),
+        AgentResponse("final answer", Seq(ToolCall(id = "call_3", toolName = "dummy", input = "{}")), StopReason.ToolUse)
+      )
+    )
+
+    val result = runLoop(AgentBuilder[Identity](_ => stubBackend)(IdentityMonad).maxIterations(3).tools(dummyTool))
+
+    stubBackend.receivedIncludeTools shouldBe Seq(true, true, false)
+    result.toolCalls should have size 2
+    result.iterations shouldBe 3
+    result.finishReason shouldBe FinishReason.MaxIterations
+    result.finalAnswer shouldBe "final answer"
   }
 
   it should "complete the loop when the response has no tool calls and empty text" in {
@@ -224,7 +250,7 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     config.userTools.head.name shouldBe "custom"
   }
 
-  it should "extract final answer from last tool result on max iterations" in {
+  it should "use the model's forced text answer on the last iteration instead of a discarded tool result" in {
     val dummyTool = AgentTool.fromFunction(
       "dummy",
       "Dummy tool"
@@ -239,7 +265,7 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     )
 
     result.finishReason shouldBe FinishReason.MaxIterations
-    result.finalAnswer shouldBe "final tool result"
+    result.finalAnswer shouldBe "Third response"
     result.iterations shouldBe 3
   }
 

--- a/core/src/test/scala/sttp/ai/core/agent/integration/AgentIntegrationSpecBase.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/integration/AgentIntegrationSpecBase.scala
@@ -164,6 +164,19 @@ abstract class AgentIntegrationSpecBase extends AnyFlatSpec with Matchers {
     ()
   }
 
+  it should "force a tool-free final answer without an API error when tool history precedes the last iteration" in
+    withAgent(maxIter = 2, tools = Seq(calculatorTool)) { (agent, backend) =>
+      val result = agent.run(
+        "Use the calculator to add 2 and 3, then tell me the result in a sentence."
+      )(backend)
+
+      assertToolCalled(result, "calculator", minTimes = 1)
+      result.iterations shouldBe 2
+      result.finishReason shouldBe FinishReason.MaxIterations
+      result.finalAnswer should not be empty
+      ()
+    }
+
   case class TripSummary(weather: String, calculation: String, conclusion: String)
   implicit val tripSummaryCodec: Codec[TripSummary] = deriveCodec
   implicit val tripSummarySchema: Schema[TripSummary] = Schema.derived

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -14,6 +14,12 @@ val agent = OpenAIAgent
   .build
 ```
 
+`maxIterations` bounds the total number of model calls. The **last** allowed iteration is sent without tools, forcing the
+model to produce a final text answer instead of a tool call whose result would be discarded (that iteration finishes with
+`FinishReason.MaxIterations`). Tools are therefore only available for the first `maxIterations - 1` iterations — so with
+`maxIterations = 1` the agent never gets to use its tools. Set `maxIterations` at least one higher than the number of
+tool-using steps you expect the task to need.
+
 The OpenAI factories additionally accept a `strictTools` flag (default `true`): when `true`, tool schemas are
 normalized for OpenAI's strict function calling (`additionalProperties: false`, all properties required, optional
 properties nullable); when `false`, tools are registered as non-strict with their original schemas.

--- a/examples/src/main/scala/examples/FinalIterationNoToolsExample.scala
+++ b/examples/src/main/scala/examples/FinalIterationNoToolsExample.scala
@@ -1,0 +1,103 @@
+//> using dep com.softwaremill.sttp.ai::openai:0.5.2
+//> using dep ch.qos.logback:logback-classic:1.5.38
+
+package examples
+
+import sttp.ai.core.agent.*
+import sttp.ai.openai.OpenAI
+import sttp.ai.openai.agent.OpenAIAgent
+import sttp.capabilities.Effect
+import sttp.client4.wrappers.DelegateBackend
+import sttp.client4.{Backend, DefaultSyncBackend, GenericRequest, Response, StringBody, SyncBackend}
+import sttp.shared.Identity
+import sttp.tapir.Schema
+
+/** Production-like check for "no tools on the final agent iteration".
+  *
+  * The agent is given a task that needs several sequential tool calls, but only `maxIterations = 3` in which to solve it. Iterations 0 and
+  * 1 are offered the calculator tool; on the last iteration (index 2) the loop sends the request WITHOUT tools, forcing a final text
+  * answer.
+  *
+  * We wrap the HTTP backend in a small logging decorator that inspects each outgoing request body and prints whether it declared `tools`.
+  * The expected output is `true, true, false` — and, crucially, the run finishes with a real answer and `FinishReason.MaxIterations`
+  * instead of throwing an API error. A successful finish is the evidence that the provider accepts a tools-omitted request whose message
+  * history still contains the earlier tool_use / tool_result entries.
+  *
+  * Run against the local build (not the published artifact) with:
+  * {{{
+  * OPENAI_API_KEY=sk-... sbt "examples/runMain examples.FinalIterationNoToolsExample"
+  * }}}
+  */
+object FinalIterationNoToolsExample extends App {
+
+  /** Logs, per real LLM call, whether the serialized request body declared any tools. */
+  class ToolVisibilityLoggingBackend(delegate: SyncBackend) extends DelegateBackend[Identity, Any](delegate) with Backend[Identity] {
+    private var callNumber = 0
+
+    override def send[T](request: GenericRequest[T, Any & Effect[Identity]]): Response[T] = {
+      callNumber += 1
+      val toolsOffered = request.body match {
+        case StringBody(body, _, _) => body.contains("\"tools\"")
+        case _                      => false
+      }
+      println(s"[LLM call #$callNumber] tools offered in request body: $toolsOffered")
+      delegate.send(request)
+    }
+  }
+
+  case class CalculatorInput(operation: String, a: Double, b: Double) derives io.circe.Codec.AsObject, Schema
+
+  val calculatorTool = AgentTool.fromFunction(
+    "calculate",
+    "Perform a single arithmetic operation (one of: add, subtract, multiply, divide)"
+  ) { (input: CalculatorInput) =>
+    val result = input.operation match {
+      case "add"      => input.a + input.b
+      case "subtract" => input.a - input.b
+      case "multiply" => input.a * input.b
+      case "divide"   => if (input.b != 0) input.a / input.b else Double.NaN
+      case _          => 0.0
+    }
+    s"${input.a} ${input.operation} ${input.b} = $result"
+  }
+
+  val prompt =
+    """Use the calculate tool for EVERY arithmetic step (never compute in your head):
+      |1. add 17 and 25
+      |2. multiply that sum by 3
+      |3. subtract 6 from that result
+      |Then state the final number in one sentence.""".stripMargin
+
+  val maxIterations = 3
+
+  println("=== Final-iteration no-tools example ===\n")
+  println(s"maxIterations = $maxIterations")
+  println(s"User: $prompt\n")
+
+  val openai = OpenAI.fromEnv
+  val backend = new ToolVisibilityLoggingBackend(DefaultSyncBackend())
+  try {
+    val agent = OpenAIAgent
+      .synchronous(openai, "gpt-4o-mini")
+      .maxIterations(maxIterations)
+      .tools(calculatorTool)
+      .build
+
+    val result = agent.run(prompt)(backend)
+
+    println("\n=== Result ===")
+    println(s"Finish reason: ${result.finishReason}")
+    println(s"Iterations:    ${result.iterations}")
+    println(s"Tool calls (${result.toolCalls.length}):")
+    result.toolCalls.foreach { tc =>
+      println(s"  [iteration ${tc.iteration}] ${tc.toolName}(${tc.input}) -> ${tc.output}")
+    }
+    println(s"Final answer:  ${result.finalAnswer}")
+
+    val lastIterationHadTools = result.toolCalls.exists(_.iteration >= maxIterations)
+    println("\n=== Interpretation ===")
+    println(s"- No tool call executed on the final iteration ($maxIterations): ${!lastIterationHadTools}")
+    println(s"- Run completed without an API error and reached ${result.finishReason}")
+    println("- Expect the LLM-call log above to read: tools offered = true, true, false")
+  } finally backend.close()
+}

--- a/examples/src/main/scala/examples/FinalIterationNoToolsExample.scala
+++ b/examples/src/main/scala/examples/FinalIterationNoToolsExample.scala
@@ -1,5 +1,8 @@
 //> using dep com.softwaremill.sttp.ai::openai:0.5.2
 //> using dep ch.qos.logback:logback-classic:1.5.38
+// NOTE: the pinned release above does NOT yet contain the "no tools on the final iteration" behaviour, so running this
+// file directly with scala-cli would log `tools offered: true, true, true`. Run it against the local build to observe the
+// fix (see the run instructions below); the dependency line is bumped to the release that includes it at publish time.
 
 package examples
 

--- a/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
+++ b/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
@@ -81,13 +81,14 @@ private[openai] class OpenAIAgentBackend[F[_]](
 
   override def sendRequest(
       history: ConversationHistory,
-      backend: Backend[F]
+      backend: Backend[F],
+      includeTools: Boolean
   ): F[AgentResponse] = {
     val messages = buildMessages(history)
     val request = ChatBody(
       model = ChatCompletionModel.CustomChatCompletionModel(modelName),
       messages = messages,
-      tools = if (convertedTools.nonEmpty) Some(convertedTools) else None,
+      tools = if (includeTools && convertedTools.nonEmpty) Some(convertedTools) else None,
       responseFormat = responseFormat
     )
     monad.flatMap(monad.map(openAI.createChatCompletion(request).send(backend))(_.body)) {

--- a/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
@@ -6,10 +6,16 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.ai.core.agent.AgentTool
+import sttp.ai.core.agent.ConversationHistory
 import sttp.ai.openai.OpenAI
 import sttp.apispec.Schema
+import sttp.client4._
+import sttp.client4.testing.ResponseStub
+import sttp.model.StatusCode
 import sttp.monad.IdentityMonad
 import sttp.shared.Identity
+
+import java.util.concurrent.atomic.AtomicReference
 
 class OpenAIAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues {
 
@@ -40,5 +46,30 @@ class OpenAIAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     params.hcursor.downField("additionalProperties").focus shouldBe None
     params.hcursor.downField("required").as[List[String]] shouldBe Right(List("title"))
     params.hcursor.downField("properties").downField("note").downField("type").as[String] shouldBe Right("string")
+  }
+
+  private def captureRequestBody(includeTools: Boolean): String = {
+    val captured = new AtomicReference[GenericRequest[_, _]](null)
+    val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF { request =>
+      captured.set(request)
+      ResponseStub.adjust(sttp.ai.openai.fixtures.CompletionsFixture.structuredOutputsResponse, StatusCode.Ok)
+    }
+    backend(strictTools = true).sendRequest(
+      ConversationHistory.withInitialPrompt("hello"),
+      httpStub,
+      includeTools = includeTools
+    )
+    captured.get().body match {
+      case StringBody(s, _, _) => s
+      case other               => fail(s"expected StringBody, got $other")
+    }
+  }
+
+  it should "include tools in the request body when includeTools is true" in {
+    captureRequestBody(includeTools = true) should include("\"tools\"")
+  }
+
+  it should "omit tools from the request body when includeTools is false" in {
+    captureRequestBody(includeTools = false) should not include "\"tools\""
   }
 }

--- a/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
@@ -58,7 +58,7 @@ class OpenAIAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
       ConversationHistory.withInitialPrompt("hello"),
       httpStub,
       includeTools = includeTools
-    )
+    ): Unit
     captured.get().body match {
       case StringBody(s, _, _) => s
       case other               => fail(s"expected StringBody, got $other")


### PR DESCRIPTION
## Problem

The agent loop offered tools on every model call, including the last allowed iteration (iteration == maxIterations - 1). The default system prompt (rule 4) already asked the model to give a final answer on that last iteration, but nothing enforced it: if the model made a tool call there, the results were computed and then discarded — the loop hits the iteration cap before the model ever sees them — and the "final answer" degraded to a raw tool-result string.

## Change

On the last allowed iteration, the request is now sent without tools, forcing the model to return a text answer.

- AgentBackend.sendRequest gains an explicit third parameter includeTools: Boolean — the loop is the only place that knows the iteration count, so it owns the decision.
- OpenAIAgentBackend / ClaudeAgentBackend attach tools only when includeTools && convertedTools.nonEmpty.
- Agent.loop computes isLastIteration and passes includeTools = !isLastIteration. On the last iteration it terminates with FinishReason.MaxIterations, using the model's text answer (or falling back to extractFinalAnswer(history) if that text is empty), and ignores any spurious tool calls in that response (they are neither executed nor recorded). The top-of-loop iteration >= maxIterations guard is retained purely as a safety net for maxIterations <= 0.

FinishReason.MaxIterations now means "the answer was forced on the final iteration" — honest telemetry that the run was truncated rather than the model finishing naturally.

## ⚠️ Breaking change

AgentBackend.sendRequest gains a required includeTools: Boolean parameter. This is source- and binary-breaking for anyone who has implemented AgentBackend for a custom provider — a trivial one-parameter addition. All in-repo implementers (OpenAI, Claude, test stub) are updated in this PR.

Behavior note

maxIterations now reserves the last iteration for the final answer, so tools are available for the first maxIterations - 1 iterations. With maxIterations = 1 the agent never gets to use its tools. Documented in docs/agents/configuration.md.

## Tests & verification

- AgentSpec (loop, stub backend): asserts the last iteration is called with includeTools = false (Seq(true, true, false)), its tool calls are not executed, and the forced text answer is used. Two existing tests updated to the corrected behavior.
- Backend specs (OpenAI + Claude): capture the serialized request body and assert tools is present when includeTools = true, absent when false.
- Integration test (shared base, runs for OpenAI/Claude/MCP): with maxIterations = 2 the model calls a tool on iteration 1 and is forced to answer tool-free on iteration 2 — validating the APIs accept a tools-omitted request whose history contains tool_use/tool_result entries. Auto-skips without keys.
- All JVM suites pass on Scala 2.13 and 3.3.
- Verified live against the real OpenAI API: the integration test passes (1/1), and the added examples/FinalIterationNoToolsExample logs tools offered: true → true → false and completes with MaxIterations and no API error — confirming OpenAI accepts a tools-omitted request carrying prior tool history. (Claude not yet exercised live — same code path, per-provider risk.)