### PR TITLE
Handle MaxIterations/TokenLimit gracefully in Agent.runAs

### DIFF
--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -93,10 +93,17 @@ class Agent[F[_]](
 
   def runAs[T](
       initialPrompt: String
-  )(backend: Backend[F])(implicit r: Decoder[T]): F[AgentResult[Either[AgentParseError, T]]] =
+  )(backend: Backend[F])(implicit r: Decoder[T]): F[AgentResult[Either[AgentFailure, T]]] =
     monad.map(run(initialPrompt)(backend)) { res =>
-      val parsed: Either[AgentParseError, T] =
-        decode[T](res.finalAnswer).left.map(e => AgentParseError(res.finalAnswer, e))
+      val parsed: Either[AgentFailure, T] = res.finishReason match {
+        case FinishReason.NaturalStop =>
+          decode[T](res.finalAnswer).left.map(e => AgentParseError(res.finalAnswer, e))
+        case FinishReason.MaxIterations =>
+          // The last iteration forces a no-tools, schema-guided answer, so it may still be valid.
+          decode[T](res.finalAnswer).left.map(e => AgentIncomplete(res.finalAnswer, res.finishReason, Some(e)))
+        case FinishReason.TokenLimit | FinishReason.Error(_) =>
+          Left(AgentIncomplete(res.finalAnswer, res.finishReason, parseError = None))
+      }
       AgentResult(parsed, res.iterations, res.toolCalls, res.finishReason)
     }
 

--- a/core/src/main/scala/sttp/ai/core/agent/AgentResult.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentResult.scala
@@ -24,7 +24,17 @@ final case class AgentResult[T](
     finishReason: FinishReason
 )
 
+sealed trait AgentFailure {
+  def rawAnswer: String
+}
+
 final case class AgentParseError(
     rawAnswer: String,
     cause: Throwable
-)
+) extends AgentFailure
+
+final case class AgentIncomplete(
+    rawAnswer: String,
+    finishReason: FinishReason,
+    parseError: Option[Throwable]
+) extends AgentFailure

--- a/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
@@ -437,12 +437,34 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     result.iterations shouldBe 1: Unit
     result.finishReason shouldBe FinishReason.NaturalStop: Unit
     result.finalAnswer.isLeft shouldBe true: Unit
-    val err = result.finalAnswer.left.toOption.get
-    err.rawAnswer should include("wrong"): Unit
-    err.cause should not be null
+    result.finalAnswer.left.toOption.get match {
+      case AgentParseError(rawAnswer, cause) =>
+        rawAnswer should include("wrong"): Unit
+        cause should not be null
+      case other => fail(s"Expected AgentParseError, got $other")
+    }
   }
 
-  it should "return Left(AgentParseError) on the maxIterations path where the capped answer is not schema-shaped" in {
+  it should "return Right(T) on the maxIterations path when the forced final answer is schema-shaped" in {
+    val dummyTool = AgentTool.fromFunction(
+      "dummy",
+      "Dummy tool"
+    )((_: DummyInput) => "dummy result")
+
+    val result = agentBuilder(
+      AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "dummy", input = "{}")), StopReason.ToolUse),
+      AgentResponse("""{"city":"Krakow","temp_c":12.0,"conditions":"sunny"}""", Seq.empty, StopReason.EndTurn)
+    ).maxIterations(2)
+      .tools(dummyTool)
+      .deriveResponseSchema[WeatherSummary]
+      .build
+      .runAs[WeatherSummary]("What's the weather?")(backend)
+
+    result.finishReason shouldBe FinishReason.MaxIterations: Unit
+    result.finalAnswer shouldBe Right(WeatherSummary("Krakow", 12.0, "sunny"))
+  }
+
+  it should "return Left(AgentIncomplete) with the parse error on the maxIterations path where the capped answer is not schema-shaped" in {
     val dummyTool = AgentTool.fromFunction(
       "dummy",
       "Dummy tool"
@@ -457,7 +479,24 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
 
     result.finishReason shouldBe FinishReason.MaxIterations: Unit
     result.finalAnswer.isLeft shouldBe true: Unit
-    result.finalAnswer.left.toOption.get.rawAnswer shouldBe "not json"
+    result.finalAnswer.left.toOption.get match {
+      case AgentIncomplete(rawAnswer, finishReason, parseError) =>
+        rawAnswer shouldBe "not json": Unit
+        finishReason shouldBe FinishReason.MaxIterations: Unit
+        parseError shouldBe defined
+      case other => fail(s"Expected AgentIncomplete, got $other")
+    }
+  }
+
+  it should "return Left(AgentIncomplete) without attempting a parse when the token limit is hit" in {
+    val result = agentBuilder(
+      AgentResponse("""{"city":"Krakow","temp_c":12.0,"conditions":"sunny"}""", Seq.empty, StopReason.MaxTokens)
+    ).deriveResponseSchema[WeatherSummary].build.runAs[WeatherSummary]("What's the weather?")(backend)
+
+    result.finishReason shouldBe FinishReason.TokenLimit: Unit
+    result.finalAnswer shouldBe Left(
+      AgentIncomplete("""{"city":"Krakow","temp_c":12.0,"conditions":"sunny"}""", FinishReason.TokenLimit, parseError = None)
+    )
   }
 
   "Agent finish reason" should "be TokenLimit when the final answer is cut off by the token limit" in {

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -50,6 +50,8 @@ On failure the iteration trace is preserved: `finalAnswer` is a `Left(AgentFailu
 - `AgentParseError` - the loop stopped naturally but the answer couldn't be parsed as `T`.
 - `AgentIncomplete` - the loop was cut short (`FinishReason.MaxIterations` or `FinishReason.TokenLimit`). On `MaxIterations` a parse is still attempted (the final iteration forces a schema-guided answer without tools), and `parseError` carries the cause if it failed; on `TokenLimit` the answer is truncated, so no parse is attempted and `parseError` is `None`.
 
+Note that because `MaxIterations` still parses, `finalAnswer` can be `Right(t)` even though the run hit the iteration cap - check `AgentResult.finishReason` if you need to distinguish a capped run from a natural stop.
+
 ```scala mdoc:compile-only
 //> using dep com.softwaremill.sttp.ai::openai:@VERSION@
 
@@ -76,8 +78,8 @@ object TypedAgentExample extends App {
       .deriveResponseSchema[TripSummary]
       .build
     agent.runAs[TripSummary]("What's the weather in Paris?")(backend).finalAnswer match {
-      case Right(summary)                             => println(s"Weather: ${summary.weather}")
-      case Left(AgentParseError(raw, cause))          => println(s"Parse failed: ${cause.getMessage}; raw=$raw")
+      case Right(summary)                              => println(s"Weather: ${summary.weather}")
+      case Left(AgentParseError(raw, cause))           => println(s"Parse failed: ${cause.getMessage}; raw=$raw")
       case Left(AgentIncomplete(raw, finishReason, _)) => println(s"Run incomplete ($finishReason); raw=$raw")
     }
   } finally backend.close()

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -45,7 +45,10 @@ case class AgentResult[T](
 
 Set `responseSchema` on `AgentConfig` and use `runAs[T]` to receive a parsed Scala value as the agent's final answer. The response schema, derived from `T`, is sent to the model to define the structured output of the agent's final answer. The answer is then parsed back into `T` via circe.
 
-On parse failure the iteration trace is preserved: `finalAnswer` is `Left(AgentParseError)` rather than a thrown exception.
+On failure the iteration trace is preserved: `finalAnswer` is a `Left(AgentFailure)` rather than a thrown exception. There are two failure cases:
+
+- `AgentParseError` - the loop stopped naturally but the answer couldn't be parsed as `T`.
+- `AgentIncomplete` - the loop was cut short (`FinishReason.MaxIterations` or `FinishReason.TokenLimit`). On `MaxIterations` a parse is still attempted (the final iteration forces a schema-guided answer without tools), and `parseError` carries the cause if it failed; on `TokenLimit` the answer is truncated, so no parse is attempted and `parseError` is `None`.
 
 ```scala mdoc:compile-only
 //> using dep com.softwaremill.sttp.ai::openai:@VERSION@
@@ -73,8 +76,9 @@ object TypedAgentExample extends App {
       .deriveResponseSchema[TripSummary]
       .build
     agent.runAs[TripSummary]("What's the weather in Paris?")(backend).finalAnswer match {
-      case Right(summary) => println(s"Weather: ${summary.weather}")
-      case Left(err)      => println(s"Parse failed: ${err.cause.getMessage}; raw=${err.rawAnswer}")
+      case Right(summary)                             => println(s"Weather: ${summary.weather}")
+      case Left(AgentParseError(raw, cause))          => println(s"Parse failed: ${cause.getMessage}; raw=$raw")
+      case Left(AgentIncomplete(raw, finishReason, _)) => println(s"Run incomplete ($finishReason); raw=$raw")
     }
   } finally backend.close()
 }

--- a/examples/src/main/scala/examples/TypedAgentLoopExample.scala
+++ b/examples/src/main/scala/examples/TypedAgentLoopExample.scala
@@ -49,9 +49,11 @@ object TypedAgentLoopExample extends App {
         println(s"weather:     ${summary.weatherSummary}")
         println(s"calculation: ${summary.calculation}")
         println(s"conclusion:  ${summary.conclusion}")
-      case Left(err) =>
-        println(s"Failed to parse structured answer: ${err.cause.getMessage}")
-        println(s"Raw answer was: ${err.rawAnswer}")
+      case Left(AgentParseError(rawAnswer, cause)) =>
+        println(s"Failed to parse structured answer: ${cause.getMessage}")
+        println(s"Raw answer was: $rawAnswer")
+      case Left(AgentIncomplete(rawAnswer, finishReason, _)) =>
+        println(s"Agent did not finish cleanly ($finishReason), raw answer was: $rawAnswer")
     }
   } finally backend.close()
 }

--- a/examples/src/main/scala/examples/TypedAgentLoopExample.scala
+++ b/examples/src/main/scala/examples/TypedAgentLoopExample.scala
@@ -49,10 +49,15 @@ object TypedAgentLoopExample extends App {
         println(s"weather:     ${summary.weatherSummary}")
         println(s"calculation: ${summary.calculation}")
         println(s"conclusion:  ${summary.conclusion}")
-      // err is an AgentParseError (a clean stop whose answer couldn't be parsed) or, since 0.5.5,
-      // an AgentIncomplete (the run was cut short by the iteration cap or the token limit)
       case Left(err) =>
         println(s"No structured answer available, raw answer was: ${err.rawAnswer}")
+      // TODO: replace the case above with the two cases below once a version with AgentIncomplete is released
+      // (examples are compiled by CI against the released artifact, which doesn't contain it yet)
+      // case Left(AgentParseError(rawAnswer, cause)) =>
+      //   println(s"Failed to parse structured answer: ${cause.getMessage}")
+      //   println(s"Raw answer was: $rawAnswer")
+      // case Left(AgentIncomplete(rawAnswer, finishReason, _)) =>
+      //   println(s"Agent did not finish cleanly ($finishReason), raw answer was: $rawAnswer")
     }
   } finally backend.close()
 }

--- a/examples/src/main/scala/examples/TypedAgentLoopExample.scala
+++ b/examples/src/main/scala/examples/TypedAgentLoopExample.scala
@@ -49,11 +49,10 @@ object TypedAgentLoopExample extends App {
         println(s"weather:     ${summary.weatherSummary}")
         println(s"calculation: ${summary.calculation}")
         println(s"conclusion:  ${summary.conclusion}")
-      case Left(AgentParseError(rawAnswer, cause)) =>
-        println(s"Failed to parse structured answer: ${cause.getMessage}")
-        println(s"Raw answer was: $rawAnswer")
-      case Left(AgentIncomplete(rawAnswer, finishReason, _)) =>
-        println(s"Agent did not finish cleanly ($finishReason), raw answer was: $rawAnswer")
+      // err is an AgentParseError (a clean stop whose answer couldn't be parsed) or, since 0.5.5,
+      // an AgentIncomplete (the run was cut short by the iteration cap or the token limit)
+      case Left(err) =>
+        println(s"No structured answer available, raw answer was: ${err.rawAnswer}")
     }
   } finally backend.close()
 }


### PR DESCRIPTION
## Problem

`runAs[T]` always attempted `decode[T]` on the final answer, regardless of how the loop finished. When the loop ended with `FinishReason.TokenLimit` (truncated output) or `FinishReason.MaxIterations`, a decode failure surfaced as `AgentParseError` — indistinguishable from "the model returned malformed JSON on a clean stop". For `TokenLimit` the parse attempt is meaningless: the output is truncated by construction.

## Changes

- `finalAnswer`'s `Left` type widens from `AgentParseError` to a new sealed trait `AgentFailure` with two cases:
  - `AgentParseError(rawAnswer, cause)` — unchanged name and fields; a clean stop whose answer couldn't be parsed as `T`.
  - `AgentIncomplete(rawAnswer, finishReason, parseError: Option[Throwable])` — the loop was cut short.
- Decision table in `runAs[T]`:

  | `finishReason` | Behavior |
  |---|---|
  | `NaturalStop` | Parse; failure → `AgentParseError` (unchanged) |
  | `MaxIterations` | Parse (the forced final iteration is schema-guided and tool-free, so often valid); failure → `AgentIncomplete` with `parseError = Some(cause)` |
  | `TokenLimit` / `Error` | Never parse → `AgentIncomplete` with `parseError = None` |

- Docs (`docs/agents/tools.md`) updated to describe both failure cases. Because `MaxIterations` still parses, `Right(t)` can coexist with `finishReason = MaxIterations` — documented, with a pointer to `AgentResult.finishReason` for callers that need to distinguish capped runs.
- `TypedAgentLoopExample` keeps a release-compatible `case Left(err)` match (CI compiles examples with scala-cli against the published artifact, which doesn't contain `AgentIncomplete` yet); the intended two-case match is included as a TODO to swap in after the next release.

## ⚠️ Breaking change

Source-breaking for `runAs[T]` callers: the `Left` type widens from `AgentParseError` to `AgentFailure`, which only exposes `rawAnswer`. Code like `case Left(err) => err.cause` no longer compiles.

**Migration:** match on the cases — `case Left(AgentParseError(raw, cause)) => ...` / `case Left(AgentIncomplete(raw, finishReason, parseError)) => ...`. Code that only uses `.isRight`/`.toOption`/`rawAnswer`, or that constructs/matches `AgentParseError` directly, compiles unchanged.

## Testing

- New/updated `AgentSpec` unit tests cover every row of the table, including that `TokenLimit` skips the parse even when the raw text happens to be valid JSON.
- `core/test` and `core3/test`: 47/47 pass; `compileDocumentation` passes; examples verified with scala-cli against the published 0.5.4; scalafmt clean.