### PR TITLE
Use the two-case AgentFailure match in TypedAgentLoopExample

### DIFF
--- a/examples/src/main/scala/examples/TypedAgentLoopExample.scala
+++ b/examples/src/main/scala/examples/TypedAgentLoopExample.scala
@@ -1,4 +1,4 @@
-//> using dep com.softwaremill.sttp.ai::openai:0.5.4
+//> using dep com.softwaremill.sttp.ai::openai:0.5.5
 //> using dep ch.qos.logback:logback-classic:1.5.38
 
 package examples
@@ -49,15 +49,11 @@ object TypedAgentLoopExample extends App {
         println(s"weather:     ${summary.weatherSummary}")
         println(s"calculation: ${summary.calculation}")
         println(s"conclusion:  ${summary.conclusion}")
-      case Left(err) =>
-        println(s"No structured answer available, raw answer was: ${err.rawAnswer}")
-      // TODO: replace the case above with the two cases below once a version with AgentIncomplete is released
-      // (examples are compiled by CI against the released artifact, which doesn't contain it yet)
-      // case Left(AgentParseError(rawAnswer, cause)) =>
-      //   println(s"Failed to parse structured answer: ${cause.getMessage}")
-      //   println(s"Raw answer was: $rawAnswer")
-      // case Left(AgentIncomplete(rawAnswer, finishReason, _)) =>
-      //   println(s"Agent did not finish cleanly ($finishReason), raw answer was: $rawAnswer")
+      case Left(AgentParseError(rawAnswer, cause)) =>
+        println(s"Failed to parse structured answer: ${cause.getMessage}")
+        println(s"Raw answer was: $rawAnswer")
+      case Left(AgentIncomplete(rawAnswer, finishReason, _)) =>
+        println(s"Agent did not finish cleanly ($finishReason), raw answer was: $rawAnswer")
     }
   } finally backend.close()
 }


### PR DESCRIPTION
Resolves the TODO from #534: 0.5.5 with AgentIncomplete is now released, so the example can demonstrate the intended match. Bumps the example's dep directive to 0.5.5.