### PR TITLE
Gemini/01 core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,7 @@ lazy val root = (project in file("."))
 lazy val allAgregates = core.projectRefs ++
   openai.projectRefs ++
   claude.projectRefs ++
+  gemini.projectRefs ++
   fs2.projectRefs ++
   zio.projectRefs ++
   pekko.projectRefs ++
@@ -81,6 +82,23 @@ lazy val openai = (projectMatrix in file("openai"))
   .dependsOn(core % "compile->compile;test->test")
 
 lazy val claude = (projectMatrix in file("claude"))
+  .jvmPlatform(
+    scalaVersions = scala3 ++ scala2 // Scala 3 first priority
+  )
+  .nativePlatform(
+    scalaVersions = scala3
+  )
+  .settings(commonSettings: _*)
+  .settings(
+    libraryDependencies ++=
+      Seq(Libraries.tapirApispecDocs.value) ++
+        Libraries.sttpApispec.value ++ Libraries.circe.value ++
+        Libraries.sttpClient.value ++ Seq(Libraries.scalaTest.value),
+    libraryDependencies ++= (if (scalaVersion.value.startsWith("2.")) Seq(Libraries.circeGenericExtras.value) else Seq.empty)
+  )
+  .dependsOn(core % "compile->compile;test->test")
+
+lazy val gemini = (projectMatrix in file("gemini"))
   .jvmPlatform(
     scalaVersions = scala3 ++ scala2 // Scala 3 first priority
   )

--- a/gemini/src/main/scala-2/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
+++ b/gemini/src/main/scala-2/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
@@ -4,6 +4,7 @@ import io.circe.Codec
 import io.circe.generic.extras.semiauto.deriveConfiguredCodec
 import sttp.ai.gemini.models._
 import sttp.ai.gemini.requests.InteractionRequest
+import sttp.ai.gemini.responses._
 import sttp.ai.core.json.CirceConfiguration.jsonConfiguration
 import GeminiManualCodecs._
 
@@ -15,4 +16,11 @@ object GeminiDerivedCodecs {
   implicit val safetySettingCodec: Codec[SafetySetting] = deriveConfiguredCodec
   implicit val stepCodec: Codec[Step] = deriveConfiguredCodec
   implicit val interactionRequestCodec: Codec[InteractionRequest] = deriveConfiguredCodec
+
+  implicit val interactionResponseCodec: Codec[InteractionResponse] = deriveConfiguredCodec
+  implicit val errorDetailCodec: Codec[ErrorDetail] = deriveConfiguredCodec
+  implicit val errorResponseCodec: Codec[ErrorResponse] = deriveConfiguredCodec
+  implicit val streamErrorCodec: Codec[StreamError] = deriveConfiguredCodec
+  implicit val streamMetadataCodec: Codec[StreamMetadata] = deriveConfiguredCodec
+  implicit val interactionStreamEventCodec: Codec[InteractionStreamEvent] = deriveConfiguredCodec
 }

--- a/gemini/src/main/scala-2/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
+++ b/gemini/src/main/scala-2/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
@@ -3,7 +3,9 @@ package sttp.ai.gemini.json
 import io.circe.Codec
 import io.circe.generic.extras.semiauto.deriveConfiguredCodec
 import sttp.ai.gemini.models._
+import sttp.ai.gemini.requests.InteractionRequest
 import sttp.ai.core.json.CirceConfiguration.jsonConfiguration
+import GeminiManualCodecs._
 
 object GeminiDerivedCodecs {
 
@@ -11,4 +13,6 @@ object GeminiDerivedCodecs {
   implicit val contentCodec: Codec[Content] = deriveConfiguredCodec
   implicit val generationConfigCodec: Codec[GenerationConfig] = deriveConfiguredCodec
   implicit val safetySettingCodec: Codec[SafetySetting] = deriveConfiguredCodec
+  implicit val stepCodec: Codec[Step] = deriveConfiguredCodec
+  implicit val interactionRequestCodec: Codec[InteractionRequest] = deriveConfiguredCodec
 }

--- a/gemini/src/main/scala-2/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
+++ b/gemini/src/main/scala-2/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
@@ -1,6 +1,6 @@
 package sttp.ai.gemini.json
 
-import io.circe.Codec
+import io.circe.{Codec, Decoder, Encoder, Json}
 import io.circe.generic.extras.semiauto.deriveConfiguredCodec
 import sttp.ai.gemini.models._
 import sttp.ai.gemini.requests.InteractionRequest
@@ -14,11 +14,21 @@ object GeminiDerivedCodecs {
   implicit val contentCodec: Codec[Content] = deriveConfiguredCodec
   implicit val generationConfigCodec: Codec[GenerationConfig] = deriveConfiguredCodec
   implicit val safetySettingCodec: Codec[SafetySetting] = deriveConfiguredCodec
-  implicit val stepCodec: Codec[Step] = deriveConfiguredCodec
+
+  // Derived codec for the known Step discriminators only; unrecognized `type` values fall back to Step.Unknown so that
+  // decoding a response never fails just because the API introduced a new step type.
+  private val stepBaseCodec: Codec[Step] = deriveConfiguredCodec
+  implicit val stepCodec: Codec[Step] = Codec.from(
+    stepBaseCodec.or(Decoder[Json].map(Step.Unknown.apply)),
+    Encoder.instance {
+      case Step.Unknown(raw) => raw
+      case other             => stepBaseCodec(other)
+    }
+  )
+
   implicit val interactionRequestCodec: Codec[InteractionRequest] = deriveConfiguredCodec
 
   implicit val interactionResponseCodec: Codec[InteractionResponse] = deriveConfiguredCodec
-  implicit val errorDetailCodec: Codec[ErrorDetail] = deriveConfiguredCodec
   implicit val errorResponseCodec: Codec[ErrorResponse] = deriveConfiguredCodec
   implicit val streamErrorCodec: Codec[StreamError] = deriveConfiguredCodec
   implicit val streamMetadataCodec: Codec[StreamMetadata] = deriveConfiguredCodec

--- a/gemini/src/main/scala-2/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
+++ b/gemini/src/main/scala-2/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
@@ -1,0 +1,13 @@
+package sttp.ai.gemini.json
+
+import io.circe.Codec
+import io.circe.generic.extras.semiauto.deriveConfiguredCodec
+import sttp.ai.gemini.models._
+import sttp.ai.core.json.CirceConfiguration.jsonConfiguration
+import GeminiManualCodecs._
+
+object GeminiDerivedCodecs {
+
+  implicit val usageCodec: Codec[Usage] = deriveConfiguredCodec
+  implicit val contentCodec: Codec[Content] = deriveConfiguredCodec
+}

--- a/gemini/src/main/scala-2/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
+++ b/gemini/src/main/scala-2/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
@@ -4,10 +4,11 @@ import io.circe.Codec
 import io.circe.generic.extras.semiauto.deriveConfiguredCodec
 import sttp.ai.gemini.models._
 import sttp.ai.core.json.CirceConfiguration.jsonConfiguration
-import GeminiManualCodecs._
 
 object GeminiDerivedCodecs {
 
   implicit val usageCodec: Codec[Usage] = deriveConfiguredCodec
   implicit val contentCodec: Codec[Content] = deriveConfiguredCodec
+  implicit val generationConfigCodec: Codec[GenerationConfig] = deriveConfiguredCodec
+  implicit val safetySettingCodec: Codec[SafetySetting] = deriveConfiguredCodec
 }

--- a/gemini/src/main/scala-2/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
+++ b/gemini/src/main/scala-2/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
@@ -2,6 +2,7 @@ package sttp.ai.gemini.json
 
 import io.circe.{Codec, Decoder, Encoder, Json}
 import io.circe.generic.extras.semiauto.deriveConfiguredCodec
+import io.circe.syntax._
 import sttp.ai.gemini.models._
 import sttp.ai.gemini.requests.InteractionRequest
 import sttp.ai.gemini.responses._
@@ -11,18 +12,55 @@ import GeminiManualCodecs._
 object GeminiDerivedCodecs {
 
   implicit val usageCodec: Codec[Usage] = deriveConfiguredCodec
-  implicit val contentCodec: Codec[Content] = deriveConfiguredCodec
   implicit val generationConfigCodec: Codec[GenerationConfig] = deriveConfiguredCodec
   implicit val safetySettingCodec: Codec[SafetySetting] = deriveConfiguredCodec
 
-  // Derived codec for the known Step discriminators only; unrecognized `type` values fall back to Step.Unknown so that
-  // decoding a response never fails just because the API introduced a new step type.
+  // NOTE: keep this block in lockstep with its scala-2/scala-3 sibling file. The wrappers are duplicated here (not shared) deliberately:
+  // GeminiManualCodecs must never reference this object, so class initialization is strictly one-way (this object -> manual codecs),
+  // preventing the mutual <clinit> deadlock fixed for OpenAI in commit 55da3fc.
+
+  private val KnownContentTypes = Set("text", "image", "audio", "video", "document")
+
+  private val contentBaseCodec: Codec[Content] = deriveConfiguredCodec
+  implicit val contentCodec: Codec[Content] = Codec.from(
+    Decoder.instance { c =>
+      c.get[Option[Json]]("type").map(_.flatMap(_.asString)).flatMap {
+        case Some(t) if KnownContentTypes.contains(t) => contentBaseCodec(c)
+        case _                                        => Right(Content.Unknown(c.value))
+      }
+    },
+    Encoder.instance {
+      case Content.Unknown(raw) => raw
+      case other                => contentBaseCodec(other)
+    }
+  )
+
+  private val KnownStepTypes = Set("user_input", "model_output", "function_call", "function_result", "thought")
+
   private val stepBaseCodec: Codec[Step] = deriveConfiguredCodec
   implicit val stepCodec: Codec[Step] = Codec.from(
-    stepBaseCodec.or(Decoder[Json].map(Step.Unknown.apply)),
+    Decoder.instance { c =>
+      c.get[Option[Json]]("type").map(_.flatMap(_.asString)).flatMap {
+        case Some(t) if KnownStepTypes.contains(t) => stepBaseCodec(c) // real field-level failures propagate loudly
+        case _                                     => Right(Step.Unknown(c.value))
+      }
+    },
     Encoder.instance {
       case Step.Unknown(raw) => raw
       case other             => stepBaseCodec(other)
+    }
+  )
+
+  implicit val interactionInputCodec: Codec[InteractionInput] = Codec.from(
+    Decoder.instance { c =>
+      c.value.asString match {
+        case Some(text) => Right(InteractionInput.TextInput(text))
+        case None       => c.as[List[Step]].map(InteractionInput.StepsInput.apply)
+      }
+    },
+    Encoder.instance {
+      case InteractionInput.TextInput(text)   => Json.fromString(text)
+      case InteractionInput.StepsInput(steps) => Json.fromValues(steps.map(_.asJson(stepCodec)))
     }
   )
 

--- a/gemini/src/main/scala-3/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
+++ b/gemini/src/main/scala-3/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
@@ -4,6 +4,7 @@ import io.circe.Codec
 import io.circe.derivation.ConfiguredCodec
 import sttp.ai.gemini.models._
 import sttp.ai.gemini.requests.InteractionRequest
+import sttp.ai.gemini.responses._
 import sttp.ai.core.json.CirceConfiguration.jsonConfiguration
 import GeminiManualCodecs._
 
@@ -15,4 +16,11 @@ object GeminiDerivedCodecs {
   implicit val safetySettingCodec: Codec[SafetySetting] = ConfiguredCodec.derived
   implicit val stepCodec: Codec[Step] = ConfiguredCodec.derived
   implicit val interactionRequestCodec: Codec[InteractionRequest] = ConfiguredCodec.derived
+
+  implicit val interactionResponseCodec: Codec[InteractionResponse] = ConfiguredCodec.derived
+  implicit val errorDetailCodec: Codec[ErrorDetail] = ConfiguredCodec.derived
+  implicit val errorResponseCodec: Codec[ErrorResponse] = ConfiguredCodec.derived
+  implicit val streamErrorCodec: Codec[StreamError] = ConfiguredCodec.derived
+  implicit val streamMetadataCodec: Codec[StreamMetadata] = ConfiguredCodec.derived
+  implicit val interactionStreamEventCodec: Codec[InteractionStreamEvent] = ConfiguredCodec.derived
 }

--- a/gemini/src/main/scala-3/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
+++ b/gemini/src/main/scala-3/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
@@ -4,10 +4,11 @@ import io.circe.Codec
 import io.circe.derivation.ConfiguredCodec
 import sttp.ai.gemini.models._
 import sttp.ai.core.json.CirceConfiguration.jsonConfiguration
-import GeminiManualCodecs._
 
 object GeminiDerivedCodecs {
 
   implicit val usageCodec: Codec[Usage] = ConfiguredCodec.derived
   implicit val contentCodec: Codec[Content] = ConfiguredCodec.derived
+  implicit val generationConfigCodec: Codec[GenerationConfig] = ConfiguredCodec.derived
+  implicit val safetySettingCodec: Codec[SafetySetting] = ConfiguredCodec.derived
 }

--- a/gemini/src/main/scala-3/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
+++ b/gemini/src/main/scala-3/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
@@ -1,6 +1,6 @@
 package sttp.ai.gemini.json
 
-import io.circe.Codec
+import io.circe.{Codec, Decoder, Encoder, Json}
 import io.circe.derivation.ConfiguredCodec
 import sttp.ai.gemini.models._
 import sttp.ai.gemini.requests.InteractionRequest
@@ -14,11 +14,21 @@ object GeminiDerivedCodecs {
   implicit val contentCodec: Codec[Content] = ConfiguredCodec.derived
   implicit val generationConfigCodec: Codec[GenerationConfig] = ConfiguredCodec.derived
   implicit val safetySettingCodec: Codec[SafetySetting] = ConfiguredCodec.derived
-  implicit val stepCodec: Codec[Step] = ConfiguredCodec.derived
+
+  // Derived codec for the known Step discriminators only; unrecognized `type` values fall back to Step.Unknown so that
+  // decoding a response never fails just because the API introduced a new step type.
+  private val stepBaseCodec: Codec[Step] = ConfiguredCodec.derived
+  implicit val stepCodec: Codec[Step] = Codec.from(
+    stepBaseCodec.or(Decoder[Json].map(Step.Unknown.apply)),
+    Encoder.instance {
+      case Step.Unknown(raw) => raw
+      case other             => stepBaseCodec(other)
+    }
+  )
+
   implicit val interactionRequestCodec: Codec[InteractionRequest] = ConfiguredCodec.derived
 
   implicit val interactionResponseCodec: Codec[InteractionResponse] = ConfiguredCodec.derived
-  implicit val errorDetailCodec: Codec[ErrorDetail] = ConfiguredCodec.derived
   implicit val errorResponseCodec: Codec[ErrorResponse] = ConfiguredCodec.derived
   implicit val streamErrorCodec: Codec[StreamError] = ConfiguredCodec.derived
   implicit val streamMetadataCodec: Codec[StreamMetadata] = ConfiguredCodec.derived

--- a/gemini/src/main/scala-3/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
+++ b/gemini/src/main/scala-3/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
@@ -1,0 +1,13 @@
+package sttp.ai.gemini.json
+
+import io.circe.Codec
+import io.circe.derivation.ConfiguredCodec
+import sttp.ai.gemini.models._
+import sttp.ai.core.json.CirceConfiguration.jsonConfiguration
+import GeminiManualCodecs._
+
+object GeminiDerivedCodecs {
+
+  implicit val usageCodec: Codec[Usage] = ConfiguredCodec.derived
+  implicit val contentCodec: Codec[Content] = ConfiguredCodec.derived
+}

--- a/gemini/src/main/scala-3/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
+++ b/gemini/src/main/scala-3/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
@@ -3,7 +3,9 @@ package sttp.ai.gemini.json
 import io.circe.Codec
 import io.circe.derivation.ConfiguredCodec
 import sttp.ai.gemini.models._
+import sttp.ai.gemini.requests.InteractionRequest
 import sttp.ai.core.json.CirceConfiguration.jsonConfiguration
+import GeminiManualCodecs._
 
 object GeminiDerivedCodecs {
 
@@ -11,4 +13,6 @@ object GeminiDerivedCodecs {
   implicit val contentCodec: Codec[Content] = ConfiguredCodec.derived
   implicit val generationConfigCodec: Codec[GenerationConfig] = ConfiguredCodec.derived
   implicit val safetySettingCodec: Codec[SafetySetting] = ConfiguredCodec.derived
+  implicit val stepCodec: Codec[Step] = ConfiguredCodec.derived
+  implicit val interactionRequestCodec: Codec[InteractionRequest] = ConfiguredCodec.derived
 }

--- a/gemini/src/main/scala-3/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
+++ b/gemini/src/main/scala-3/sttp/ai/gemini/json/GeminiDerivedCodecs.scala
@@ -2,6 +2,7 @@ package sttp.ai.gemini.json
 
 import io.circe.{Codec, Decoder, Encoder, Json}
 import io.circe.derivation.ConfiguredCodec
+import io.circe.syntax._
 import sttp.ai.gemini.models._
 import sttp.ai.gemini.requests.InteractionRequest
 import sttp.ai.gemini.responses._
@@ -11,18 +12,55 @@ import GeminiManualCodecs._
 object GeminiDerivedCodecs {
 
   implicit val usageCodec: Codec[Usage] = ConfiguredCodec.derived
-  implicit val contentCodec: Codec[Content] = ConfiguredCodec.derived
   implicit val generationConfigCodec: Codec[GenerationConfig] = ConfiguredCodec.derived
   implicit val safetySettingCodec: Codec[SafetySetting] = ConfiguredCodec.derived
 
-  // Derived codec for the known Step discriminators only; unrecognized `type` values fall back to Step.Unknown so that
-  // decoding a response never fails just because the API introduced a new step type.
+  // NOTE: keep this block in lockstep with its scala-2/scala-3 sibling file. The wrappers are duplicated here (not shared) deliberately:
+  // GeminiManualCodecs must never reference this object, so class initialization is strictly one-way (this object -> manual codecs),
+  // preventing the mutual <clinit> deadlock fixed for OpenAI in commit 55da3fc.
+
+  private val KnownContentTypes = Set("text", "image", "audio", "video", "document")
+
+  private val contentBaseCodec: Codec[Content] = ConfiguredCodec.derived
+  implicit val contentCodec: Codec[Content] = Codec.from(
+    Decoder.instance { c =>
+      c.get[Option[Json]]("type").map(_.flatMap(_.asString)).flatMap {
+        case Some(t) if KnownContentTypes.contains(t) => contentBaseCodec(c)
+        case _                                        => Right(Content.Unknown(c.value))
+      }
+    },
+    Encoder.instance {
+      case Content.Unknown(raw) => raw
+      case other                => contentBaseCodec(other)
+    }
+  )
+
+  private val KnownStepTypes = Set("user_input", "model_output", "function_call", "function_result", "thought")
+
   private val stepBaseCodec: Codec[Step] = ConfiguredCodec.derived
   implicit val stepCodec: Codec[Step] = Codec.from(
-    stepBaseCodec.or(Decoder[Json].map(Step.Unknown.apply)),
+    Decoder.instance { c =>
+      c.get[Option[Json]]("type").map(_.flatMap(_.asString)).flatMap {
+        case Some(t) if KnownStepTypes.contains(t) => stepBaseCodec(c) // real field-level failures propagate loudly
+        case _                                     => Right(Step.Unknown(c.value))
+      }
+    },
     Encoder.instance {
       case Step.Unknown(raw) => raw
       case other             => stepBaseCodec(other)
+    }
+  )
+
+  implicit val interactionInputCodec: Codec[InteractionInput] = Codec.from(
+    Decoder.instance { c =>
+      c.value.asString match {
+        case Some(text) => Right(InteractionInput.TextInput(text))
+        case None       => c.as[List[Step]].map(InteractionInput.StepsInput.apply)
+      }
+    },
+    Encoder.instance {
+      case InteractionInput.TextInput(text)   => Json.fromString(text)
+      case InteractionInput.StepsInput(steps) => Json.fromValues(steps.map(_.asJson(stepCodec)))
     }
   )
 

--- a/gemini/src/main/scala/sttp/ai/gemini/config/GeminiConfig.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/config/GeminiConfig.scala
@@ -1,0 +1,53 @@
+package sttp.ai.gemini.config
+
+import sttp.ai.core.config.AIClientConfig
+import sttp.model.Uri
+
+import scala.concurrent.duration.{Duration, DurationInt}
+
+/** Configuration for the Google Gemini (Interactions API) client.
+  *
+  * @param apiKey
+  *   Gemini API key for authentication
+  * @param baseUrl
+  *   Base URL for the Gemini API (defaults to the official endpoint; the `v1beta` version path is appended by the client)
+  * @param timeout
+  *   Request timeout duration (defaults to 60 seconds)
+  * @param maxRetries
+  *   Maximum number of retry attempts (defaults to 3)
+  * @param organization
+  *   Optional organization identifier (unused by the Gemini API, present for [[AIClientConfig]] parity)
+  */
+case class GeminiConfig(
+    apiKey: String,
+    baseUrl: Uri = GeminiConfig.DefaultBaseUrl,
+    timeout: Duration = 60.seconds,
+    maxRetries: Int = 3,
+    organization: Option[String] = None
+) extends AIClientConfig {
+
+  override def authHeaders: Map[String, String] = Map(
+    "x-goog-api-key" -> apiKey,
+    "content-type" -> "application/json"
+  )
+}
+
+object GeminiConfig {
+  val DefaultBaseUrl: Uri = Uri.unsafeParse("https://generativelanguage.googleapis.com")
+
+  /** Creates GeminiConfig from environment variables.
+    *
+    * Required environment variables:
+    *   - GEMINI_API_KEY: Gemini API key
+    *
+    * Optional environment variables:
+    *   - GEMINI_BASE_URL: Custom base URL (defaults to the official endpoint)
+    */
+  def fromEnv: GeminiConfig = {
+    val apiKey =
+      sys.env.getOrElse("GEMINI_API_KEY", throw new IllegalArgumentException("GEMINI_API_KEY environment variable is required"))
+    val baseUrl = sys.env.get("GEMINI_BASE_URL").map(Uri.unsafeParse).getOrElse(DefaultBaseUrl)
+
+    GeminiConfig(apiKey = apiKey, baseUrl = baseUrl)
+  }
+}

--- a/gemini/src/main/scala/sttp/ai/gemini/json/GeminiManualCodecs.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/json/GeminiManualCodecs.scala
@@ -60,4 +60,17 @@ object GeminiManualCodecs {
         Json.obj("type" := "json_schema", "json_schema" -> inner)
     }
   )
+
+  implicit val interactionInputCodec: Codec[InteractionInput] = Codec.from(
+    Decoder.instance { c =>
+      c.value.asString match {
+        case Some(text) => Right(InteractionInput.TextInput(text))
+        case None       => c.as[List[Step]](Decoder.decodeList(GeminiDerivedCodecs.stepCodec)).map(InteractionInput.StepsInput.apply)
+      }
+    },
+    Encoder.instance {
+      case InteractionInput.TextInput(text)   => Json.fromString(text)
+      case InteractionInput.StepsInput(steps) => Json.fromValues(steps.map(_.asJson(GeminiDerivedCodecs.stepCodec)))
+    }
+  )
 }

--- a/gemini/src/main/scala/sttp/ai/gemini/json/GeminiManualCodecs.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/json/GeminiManualCodecs.scala
@@ -59,7 +59,7 @@ object GeminiManualCodecs {
   /** `response_format` is either `{"type": "text"}` or a JSON schema object sent verbatim (no `json_schema` envelope). */
   implicit val responseFormatCodec: Codec[ResponseFormat] = Codec.from(
     Decoder.instance(c =>
-      c.get[Option[String]]("type").flatMap {
+      c.get[Option[Json]]("type").map(_.flatMap(_.asString)).flatMap {
         case Some("text") => Right(ResponseFormat.Text)
         case _            => c.as[Json].map(ResponseFormat.JsonSchema.apply)
       }
@@ -70,16 +70,4 @@ object GeminiManualCodecs {
     }
   )
 
-  implicit val interactionInputCodec: Codec[InteractionInput] = Codec.from(
-    Decoder.instance { c =>
-      c.value.asString match {
-        case Some(text) => Right(InteractionInput.TextInput(text))
-        case None       => c.as[List[Step]](Decoder.decodeList(GeminiDerivedCodecs.stepCodec)).map(InteractionInput.StepsInput.apply)
-      }
-    },
-    Encoder.instance {
-      case InteractionInput.TextInput(text)   => Json.fromString(text)
-      case InteractionInput.StepsInput(steps) => Json.fromValues(steps.map(_.asJson(GeminiDerivedCodecs.stepCodec)))
-    }
-  )
 }

--- a/gemini/src/main/scala/sttp/ai/gemini/json/GeminiManualCodecs.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/json/GeminiManualCodecs.scala
@@ -3,12 +3,33 @@ package sttp.ai.gemini.json
 import io.circe.{Codec, Decoder, DecodingFailure, Encoder, Json}
 import io.circe.syntax._
 import sttp.ai.gemini.models._
+import sttp.ai.gemini.responses.ErrorDetail
 
 object GeminiManualCodecs {
 
   implicit val interactionStatusCodec: Codec[InteractionStatus] = Codec.from(
     Decoder.decodeString.map(InteractionStatus.fromString),
     Encoder.encodeString.contramap(_.value)
+  )
+
+  /** `code` can be a JSON string or a JSON number on the wire; it is normalized to a String. */
+  implicit val errorDetailCodec: Codec[ErrorDetail] = Codec.from(
+    Decoder.instance { c =>
+      for {
+        codeJson <- c.get[Option[Json]]("code")
+        message <- c.get[String]("message")
+        status <- c.get[Option[String]]("status")
+      } yield {
+        val code = codeJson.flatMap(j => j.asString.orElse(j.asNumber.map(_.toString)))
+        ErrorDetail(code, message, status)
+      }
+    },
+    Encoder.instance { detail =>
+      Json
+        .obj("message" := detail.message)
+        .mapObject(obj => detail.code.fold(obj)(c => obj.add("code", Json.fromString(c))))
+        .mapObject(obj => detail.status.fold(obj)(s => obj.add("status", Json.fromString(s))))
+    }
   )
 
   implicit val toolCodec: Codec[Tool] = Codec.from(
@@ -35,29 +56,17 @@ object GeminiManualCodecs {
     }
   )
 
+  /** `response_format` is either `{"type": "text"}` or a JSON schema object sent verbatim (no `json_schema` envelope). */
   implicit val responseFormatCodec: Codec[ResponseFormat] = Codec.from(
     Decoder.instance(c =>
-      c.get[String]("type").flatMap {
-        case "text"        => Right(ResponseFormat.Text)
-        case "json_schema" =>
-          val js = c.downField("json_schema")
-          for {
-            name <- js.get[String]("name")
-            schema <- js.get[Json]("schema")
-            description <- js.get[Option[String]]("description")
-            strict <- js.get[Option[Boolean]]("strict")
-          } yield ResponseFormat.JsonSchema(name, schema, description, strict)
-        case other => Left(DecodingFailure(s"Unknown ResponseFormat type: $other", c.history))
+      c.get[Option[String]]("type").flatMap {
+        case Some("text") => Right(ResponseFormat.Text)
+        case _            => c.as[Json].map(ResponseFormat.JsonSchema.apply)
       }
     ),
     Encoder.instance {
-      case ResponseFormat.Text                                          => Json.obj("type" := "text")
-      case ResponseFormat.JsonSchema(name, schema, description, strict) =>
-        val inner = Json
-          .obj("name" := name, "schema" -> schema)
-          .mapObject(obj => description.fold(obj)(d => obj.add("description", Json.fromString(d))))
-          .mapObject(obj => strict.fold(obj)(s => obj.add("strict", Json.fromBoolean(s))))
-        Json.obj("type" := "json_schema", "json_schema" -> inner)
+      case ResponseFormat.Text               => Json.obj("type" := "text")
+      case ResponseFormat.JsonSchema(schema) => schema
     }
   )
 

--- a/gemini/src/main/scala/sttp/ai/gemini/json/GeminiManualCodecs.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/json/GeminiManualCodecs.scala
@@ -1,6 +1,7 @@
 package sttp.ai.gemini.json
 
-import io.circe.{Codec, Decoder, Encoder}
+import io.circe.{Codec, Decoder, DecodingFailure, Encoder, Json}
+import io.circe.syntax._
 import sttp.ai.gemini.models._
 
 object GeminiManualCodecs {
@@ -8,5 +9,55 @@ object GeminiManualCodecs {
   implicit val interactionStatusCodec: Codec[InteractionStatus] = Codec.from(
     Decoder.decodeString.map(InteractionStatus.fromString),
     Encoder.encodeString.contramap(_.value)
+  )
+
+  implicit val toolCodec: Codec[Tool] = Codec.from(
+    Decoder.instance(c =>
+      c.get[String]("type").flatMap {
+        case "function" =>
+          for {
+            name <- c.get[String]("name")
+            description <- c.get[Option[String]]("description")
+            parameters <- c.getOrElse[Json]("parameters")(Json.obj())
+          } yield Tool.Function(name, description, parameters)
+        case "google_search"  => Right(Tool.GoogleSearch)
+        case "code_execution" => Right(Tool.CodeExecution)
+        case other            => Left(DecodingFailure(s"Unknown Tool type: $other", c.history))
+      }
+    ),
+    Encoder.instance {
+      case Tool.Function(name, description, parameters) =>
+        Json
+          .obj("type" := "function", "name" := name, "parameters" -> parameters)
+          .mapObject(obj => description.fold(obj)(d => obj.add("description", Json.fromString(d))))
+      case Tool.GoogleSearch  => Json.obj("type" := "google_search")
+      case Tool.CodeExecution => Json.obj("type" := "code_execution")
+    }
+  )
+
+  implicit val responseFormatCodec: Codec[ResponseFormat] = Codec.from(
+    Decoder.instance(c =>
+      c.get[String]("type").flatMap {
+        case "text"        => Right(ResponseFormat.Text)
+        case "json_schema" =>
+          val js = c.downField("json_schema")
+          for {
+            name <- js.get[String]("name")
+            schema <- js.get[Json]("schema")
+            description <- js.get[Option[String]]("description")
+            strict <- js.get[Option[Boolean]]("strict")
+          } yield ResponseFormat.JsonSchema(name, schema, description, strict)
+        case other => Left(DecodingFailure(s"Unknown ResponseFormat type: $other", c.history))
+      }
+    ),
+    Encoder.instance {
+      case ResponseFormat.Text                                          => Json.obj("type" := "text")
+      case ResponseFormat.JsonSchema(name, schema, description, strict) =>
+        val inner = Json
+          .obj("name" := name, "schema" -> schema)
+          .mapObject(obj => description.fold(obj)(d => obj.add("description", Json.fromString(d))))
+          .mapObject(obj => strict.fold(obj)(s => obj.add("strict", Json.fromBoolean(s))))
+        Json.obj("type" := "json_schema", "json_schema" -> inner)
+    }
   )
 }

--- a/gemini/src/main/scala/sttp/ai/gemini/json/GeminiManualCodecs.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/json/GeminiManualCodecs.scala
@@ -1,0 +1,12 @@
+package sttp.ai.gemini.json
+
+import io.circe.{Codec, Decoder, Encoder}
+import sttp.ai.gemini.models._
+
+object GeminiManualCodecs {
+
+  implicit val interactionStatusCodec: Codec[InteractionStatus] = Codec.from(
+    Decoder.decodeString.map(InteractionStatus.fromString),
+    Encoder.encodeString.contramap(_.value)
+  )
+}

--- a/gemini/src/main/scala/sttp/ai/gemini/models/Content.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/Content.scala
@@ -1,0 +1,32 @@
+package sttp.ai.gemini.models
+
+/** A single content item within an interaction step. Discriminated on the wire by a `type` field. */
+sealed trait Content
+
+object Content {
+  case class Text(text: String) extends Content
+
+  case class Image(
+      data: Option[String] = None,
+      uri: Option[String] = None,
+      mimeType: Option[String] = None
+  ) extends Content
+
+  case class Audio(
+      data: Option[String] = None,
+      uri: Option[String] = None,
+      mimeType: Option[String] = None
+  ) extends Content
+
+  case class Video(
+      data: Option[String] = None,
+      uri: Option[String] = None,
+      mimeType: Option[String] = None
+  ) extends Content
+
+  case class Document(
+      data: Option[String] = None,
+      uri: Option[String] = None,
+      mimeType: Option[String] = None
+  ) extends Content
+}

--- a/gemini/src/main/scala/sttp/ai/gemini/models/Content.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/Content.scala
@@ -29,4 +29,9 @@ object Content {
       uri: Option[String] = None,
       mimeType: Option[String] = None
   ) extends Content
+
+  /** Fallback for content types this client does not know yet (e.g. `executable_code` from the code-execution tool); carries the raw JSON
+    * so decoding a response never fails on a new content type.
+    */
+  case class Unknown(raw: io.circe.Json) extends Content
 }

--- a/gemini/src/main/scala/sttp/ai/gemini/models/GeminiModel.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/GeminiModel.scala
@@ -4,12 +4,17 @@ package sttp.ai.gemini.models
 sealed abstract class GeminiModel(val value: String)
 
 object GeminiModel {
+  case object Gemini36Flash extends GeminiModel("gemini-3.6-flash")
+  case object Gemini35Flash extends GeminiModel("gemini-3.5-flash")
+  case object Gemini35FlashLite extends GeminiModel("gemini-3.5-flash-lite")
+  case object Gemini31FlashLite extends GeminiModel("gemini-3.1-flash-lite")
   case object Gemini25Pro extends GeminiModel("gemini-2.5-pro")
   case object Gemini25Flash extends GeminiModel("gemini-2.5-flash")
   case object Gemini25FlashLite extends GeminiModel("gemini-2.5-flash-lite")
   case class CustomModel(override val value: String) extends GeminiModel(value)
 
-  val values: List[GeminiModel] = List(Gemini25Pro, Gemini25Flash, Gemini25FlashLite)
+  val values: List[GeminiModel] =
+    List(Gemini36Flash, Gemini35Flash, Gemini35FlashLite, Gemini31FlashLite, Gemini25Pro, Gemini25Flash, Gemini25FlashLite)
 
   def fromString(s: String): GeminiModel =
     values.find(_.value == s).getOrElse(CustomModel(s))

--- a/gemini/src/main/scala/sttp/ai/gemini/models/GeminiModel.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/GeminiModel.scala
@@ -1,0 +1,16 @@
+package sttp.ai.gemini.models
+
+/** Well-known Gemini model identifiers. Use [[GeminiModel.CustomModel]] for models not listed here. */
+sealed abstract class GeminiModel(val value: String)
+
+object GeminiModel {
+  case object Gemini25Pro extends GeminiModel("gemini-2.5-pro")
+  case object Gemini25Flash extends GeminiModel("gemini-2.5-flash")
+  case object Gemini25FlashLite extends GeminiModel("gemini-2.5-flash-lite")
+  case class CustomModel(override val value: String) extends GeminiModel(value)
+
+  val values: List[GeminiModel] = List(Gemini25Pro, Gemini25Flash, Gemini25FlashLite)
+
+  def fromString(s: String): GeminiModel =
+    values.find(_.value == s).getOrElse(CustomModel(s))
+}

--- a/gemini/src/main/scala/sttp/ai/gemini/models/GenerationConfig.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/GenerationConfig.scala
@@ -1,0 +1,10 @@
+package sttp.ai.gemini.models
+
+case class GenerationConfig(
+    maxOutputTokens: Option[Int] = None,
+    temperature: Option[Double] = None,
+    seed: Option[Int] = None,
+    stopSequences: Option[List[String]] = None,
+    thinkingLevel: Option[String] = None,
+    toolChoice: Option[String] = None
+)

--- a/gemini/src/main/scala/sttp/ai/gemini/models/InteractionInput.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/InteractionInput.scala
@@ -1,0 +1,11 @@
+package sttp.ai.gemini.models
+
+/** The `input` field of an interaction request: a plain string for simple prompts, or a list of steps for full conversation replay
+  * (stateless mode, `store = false`).
+  */
+sealed trait InteractionInput
+
+object InteractionInput {
+  case class TextInput(value: String) extends InteractionInput
+  case class StepsInput(steps: List[Step]) extends InteractionInput
+}

--- a/gemini/src/main/scala/sttp/ai/gemini/models/InteractionStatus.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/InteractionStatus.scala
@@ -1,0 +1,22 @@
+package sttp.ai.gemini.models
+
+/** Status of an interaction. Unknown values decode as [[InteractionStatus.Other]] so new API statuses don't break deserialization. */
+sealed abstract class InteractionStatus(val value: String)
+
+object InteractionStatus {
+  case object Completed extends InteractionStatus("completed")
+  case object RequiresAction extends InteractionStatus("requires_action")
+  case object InProgress extends InteractionStatus("in_progress")
+  case object Failed extends InteractionStatus("failed")
+  case object Cancelled extends InteractionStatus("cancelled")
+  case object Incomplete extends InteractionStatus("incomplete")
+  case object BudgetExceeded extends InteractionStatus("budget_exceeded")
+  case object Queued extends InteractionStatus("queued")
+  case class Other(raw: String) extends InteractionStatus(raw)
+
+  val values: List[InteractionStatus] =
+    List(Completed, RequiresAction, InProgress, Failed, Cancelled, Incomplete, BudgetExceeded, Queued)
+
+  def fromString(s: String): InteractionStatus =
+    values.find(_.value == s).getOrElse(Other(s))
+}

--- a/gemini/src/main/scala/sttp/ai/gemini/models/ResponseFormat.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/ResponseFormat.scala
@@ -1,0 +1,17 @@
+package sttp.ai.gemini.models
+
+import io.circe.Json
+
+/** Structured-output configuration: `{"type": "json_schema", "json_schema": {...}}` or `{"type": "text"}` on the wire. */
+sealed trait ResponseFormat
+
+object ResponseFormat {
+  case object Text extends ResponseFormat
+
+  case class JsonSchema(
+      name: String,
+      schema: Json,
+      description: Option[String] = None,
+      strict: Option[Boolean] = None
+  ) extends ResponseFormat
+}

--- a/gemini/src/main/scala/sttp/ai/gemini/models/ResponseFormat.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/ResponseFormat.scala
@@ -2,16 +2,15 @@ package sttp.ai.gemini.models
 
 import io.circe.Json
 
-/** Structured-output configuration: `{"type": "json_schema", "json_schema": {...}}` or `{"type": "text"}` on the wire. */
+/** Structured-output configuration. On the wire this is either `{"type": "text"}`, or a JSON schema object sent verbatim (e.g.
+  * `{"type": "object", "properties": {...}, "required": [...]}`) — Gemini's Interactions API does not wrap the schema in a `json_schema`
+  * envelope.
+  */
 sealed trait ResponseFormat
 
 object ResponseFormat {
   case object Text extends ResponseFormat
 
-  case class JsonSchema(
-      name: String,
-      schema: Json,
-      description: Option[String] = None,
-      strict: Option[Boolean] = None
-  ) extends ResponseFormat
+  /** @param schema the JSON schema, sent to the API exactly as given (no wrapping envelope). */
+  case class JsonSchema(schema: Json) extends ResponseFormat
 }

--- a/gemini/src/main/scala/sttp/ai/gemini/models/SafetySetting.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/SafetySetting.scala
@@ -1,0 +1,7 @@
+package sttp.ai.gemini.models
+
+case class SafetySetting(
+    `type`: String,
+    threshold: String,
+    method: Option[String] = None
+)

--- a/gemini/src/main/scala/sttp/ai/gemini/models/Step.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/Step.scala
@@ -1,0 +1,17 @@
+package sttp.ai.gemini.models
+
+import io.circe.Json
+
+/** A single execution step of an interaction — both in request `input` (conversation replay) and response `steps`. Discriminated on the
+  * wire by a `type` field (`user_input`, `model_output`, `function_call`, `function_result`).
+  */
+sealed trait Step
+
+object Step {
+  case class UserInput(content: List[Content]) extends Step
+  case class ModelOutput(content: List[Content]) extends Step
+  case class FunctionCall(id: String, name: String, arguments: Json) extends Step
+  case class FunctionResult(callId: String, name: String, result: Json) extends Step
+
+  def userText(text: String): Step = UserInput(List(Content.Text(text)))
+}

--- a/gemini/src/main/scala/sttp/ai/gemini/models/Step.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/Step.scala
@@ -13,5 +13,11 @@ object Step {
   case class FunctionCall(id: String, name: String, arguments: Json) extends Step
   case class FunctionResult(callId: String, name: String, result: Json) extends Step
 
+  /** A model reasoning step. `signature` is an opaque server token; `content` may carry thought summaries. */
+  case class Thought(signature: Option[String] = None, content: Option[List[Content]] = None) extends Step
+
+  /** Fallback for step types this client does not know yet; carries the raw JSON so decoding a response never fails on a new step type. */
+  case class Unknown(raw: io.circe.Json) extends Step
+
   def userText(text: String): Step = UserInput(List(Content.Text(text)))
 }

--- a/gemini/src/main/scala/sttp/ai/gemini/models/Tool.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/Tool.scala
@@ -1,0 +1,26 @@
+package sttp.ai.gemini.models
+
+import io.circe.Json
+
+sealed trait Tool
+
+object Tool {
+
+  /** A custom function tool. `parameters` is a raw JSON Schema, passed to the API verbatim (never re-encoded or null-stripped), so schemas
+    * loaded from MCP servers survive byte-faithful.
+    */
+  case class Function(
+      name: String,
+      description: Option[String] = None,
+      parameters: Json = Json.obj()
+  ) extends Tool
+
+  /** Google-hosted web search tool. */
+  case object GoogleSearch extends Tool
+
+  /** Google-hosted code execution tool. */
+  case object CodeExecution extends Tool
+
+  def function(name: String, description: String, parameters: Json): Function =
+    Function(name, Some(description), parameters)
+}

--- a/gemini/src/main/scala/sttp/ai/gemini/models/Usage.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/Usage.scala
@@ -1,0 +1,10 @@
+package sttp.ai.gemini.models
+
+case class Usage(
+    totalInputTokens: Option[Long] = None,
+    totalOutputTokens: Option[Long] = None,
+    totalTokens: Option[Long] = None,
+    totalCachedTokens: Option[Long] = None,
+    totalThoughtTokens: Option[Long] = None,
+    totalToolUseTokens: Option[Long] = None
+)

--- a/gemini/src/main/scala/sttp/ai/gemini/requests/InteractionRequest.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/requests/InteractionRequest.scala
@@ -1,0 +1,33 @@
+package sttp.ai.gemini.requests
+
+import sttp.ai.gemini.models.{GenerationConfig, InteractionInput, ResponseFormat, SafetySetting, Tool}
+
+case class InteractionRequest(
+    model: String,
+    input: InteractionInput,
+    systemInstruction: Option[String] = None,
+    tools: Option[List[Tool]] = None,
+    responseFormat: Option[ResponseFormat] = None,
+    generationConfig: Option[GenerationConfig] = None,
+    previousInteractionId: Option[String] = None,
+    store: Option[Boolean] = None,
+    stream: Option[Boolean] = None,
+    background: Option[Boolean] = None,
+    safetySettings: Option[List[SafetySetting]] = None
+) {
+  def usesStructuredOutput: Boolean = responseFormat.exists(_.isInstanceOf[ResponseFormat.JsonSchema])
+
+  def withStructuredOutput(format: ResponseFormat): InteractionRequest =
+    this.copy(responseFormat = Some(format))
+}
+
+object InteractionRequest {
+  def simple(model: String, text: String): InteractionRequest =
+    InteractionRequest(model = model, input = InteractionInput.TextInput(text))
+
+  def withSystem(model: String, system: String, text: String): InteractionRequest =
+    InteractionRequest(model = model, input = InteractionInput.TextInput(text), systemInstruction = Some(system))
+
+  def withTools(model: String, input: InteractionInput, tools: List[Tool]): InteractionRequest =
+    InteractionRequest(model = model, input = input, tools = Some(tools))
+}

--- a/gemini/src/main/scala/sttp/ai/gemini/requests/InteractionRequest.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/requests/InteractionRequest.scala
@@ -15,7 +15,10 @@ case class InteractionRequest(
     background: Option[Boolean] = None,
     safetySettings: Option[List[SafetySetting]] = None
 ) {
-  def usesStructuredOutput: Boolean = responseFormat.exists(_.isInstanceOf[ResponseFormat.JsonSchema])
+  def usesStructuredOutput: Boolean = responseFormat.exists {
+    case ResponseFormat.JsonSchema(_) => true
+    case ResponseFormat.Text          => false
+  }
 
   def withStructuredOutput(format: ResponseFormat): InteractionRequest =
     this.copy(responseFormat = Some(format))

--- a/gemini/src/main/scala/sttp/ai/gemini/responses/ErrorResponse.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/responses/ErrorResponse.scala
@@ -1,0 +1,10 @@
+package sttp.ai.gemini.responses
+
+/** Error body returned by the Gemini API, e.g. {"error": {"code": 400, "message": "...", "status": "INVALID_ARGUMENT"}}. */
+case class ErrorResponse(error: ErrorDetail)
+
+case class ErrorDetail(
+    code: Option[Int] = None,
+    message: String,
+    status: Option[String] = None
+)

--- a/gemini/src/main/scala/sttp/ai/gemini/responses/ErrorResponse.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/responses/ErrorResponse.scala
@@ -1,10 +1,13 @@
 package sttp.ai.gemini.responses
 
-/** Error body returned by the Gemini API, e.g. {"error": {"code": 400, "message": "...", "status": "INVALID_ARGUMENT"}}. */
+/** Error body returned by the Gemini API, e.g. {"error": {"code": 400, "message": "...", "status": "INVALID_ARGUMENT"}}. `code` can be a
+  * JSON string (e.g. "not_found") or a JSON number depending on the endpoint; it is normalized to a String here. `status` is not always
+  * present.
+  */
 case class ErrorResponse(error: ErrorDetail)
 
 case class ErrorDetail(
-    code: Option[Int] = None,
+    code: Option[String] = None,
     message: String,
     status: Option[String] = None
 )

--- a/gemini/src/main/scala/sttp/ai/gemini/responses/InteractionResponse.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/responses/InteractionResponse.scala
@@ -3,7 +3,7 @@ package sttp.ai.gemini.responses
 import sttp.ai.gemini.models.{Content, InteractionStatus, Step, Usage}
 
 case class InteractionResponse(
-    id: String,
+    id: Option[String] = None,
     status: InteractionStatus,
     model: Option[String] = None,
     steps: List[Step] = List.empty,

--- a/gemini/src/main/scala/sttp/ai/gemini/responses/InteractionResponse.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/responses/InteractionResponse.scala
@@ -1,0 +1,26 @@
+package sttp.ai.gemini.responses
+
+import sttp.ai.gemini.models.{Content, InteractionStatus, Step, Usage}
+
+case class InteractionResponse(
+    id: String,
+    status: InteractionStatus,
+    model: Option[String] = None,
+    steps: List[Step] = List.empty,
+    usage: Option[Usage] = None,
+    created: Option[String] = None,
+    updated: Option[String] = None
+) {
+
+  /** All text content of the last model_output step, concatenated. Empty string if the interaction produced no model output. */
+  def outputText: String =
+    steps.reverse
+      .collectFirst { case Step.ModelOutput(content) =>
+        content.collect { case Content.Text(text) => text }.mkString
+      }
+      .getOrElse("")
+
+  /** All function calls the model requested, in order. */
+  def functionCalls: List[Step.FunctionCall] =
+    steps.collect { case fc: Step.FunctionCall => fc }
+}

--- a/gemini/src/main/scala/sttp/ai/gemini/responses/InteractionStreamEvent.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/responses/InteractionStreamEvent.scala
@@ -1,0 +1,20 @@
+package sttp.ai.gemini.responses
+
+import sttp.ai.gemini.models.Usage
+
+/** SSE event envelope for streamed interactions.
+  *
+  * `eventType` is deliberately an open String, not an enum: the API documents `interaction.completed` and `error`, but emits additional
+  * incremental event types; unknown types must not fail deserialization. Match on the value and ignore what you don't handle.
+  */
+case class InteractionStreamEvent(
+    eventType: String,
+    eventId: Option[String] = None,
+    interaction: Option[InteractionResponse] = None,
+    error: Option[StreamError] = None,
+    metadata: Option[StreamMetadata] = None
+)
+
+case class StreamError(code: Option[String] = None, message: Option[String] = None)
+
+case class StreamMetadata(totalUsage: Option[Usage] = None)

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/config/GeminiConfigSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/config/GeminiConfigSpec.scala
@@ -1,0 +1,33 @@
+package sttp.ai.gemini.unit.config
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.gemini.config.GeminiConfig
+import sttp.model.Uri
+
+class GeminiConfigSpec extends AnyFlatSpec with Matchers {
+
+  "GeminiConfig" should "create config with minimal parameters" in {
+    val config = GeminiConfig("test-api-key")
+
+    config.apiKey shouldBe "test-api-key"
+    config.baseUrl shouldBe Uri.unsafeParse("https://generativelanguage.googleapis.com")
+    config.maxRetries shouldBe 3
+    config.organization shouldBe None
+  }
+
+  it should "provide Gemini auth headers" in {
+    val config = GeminiConfig("test-api-key")
+
+    config.authHeaders shouldBe Map(
+      "x-goog-api-key" -> "test-api-key",
+      "content-type" -> "application/json"
+    )
+  }
+
+  it should "accept a custom base URL" in {
+    val config = GeminiConfig("test-api-key", baseUrl = Uri.unsafeParse("http://localhost:8080"))
+
+    config.baseUrl shouldBe Uri.unsafeParse("http://localhost:8080")
+  }
+}

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/models/ContentSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/models/ContentSpec.scala
@@ -1,0 +1,28 @@
+package sttp.ai.gemini.unit.models
+
+import io.circe.parser.{decode, parse}
+import io.circe.syntax._
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.gemini.json.GeminiDerivedCodecs._
+import sttp.ai.gemini.models.Content
+
+class ContentSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  "Content.Text" should "encode with a type discriminator and snake_case fields" in {
+    val json = (Content.Text("hello"): Content).asJson.deepDropNullValues
+    json shouldBe parse("""{"type":"text","text":"hello"}""").value
+  }
+
+  it should "decode from discriminated JSON" in {
+    decode[Content]("""{"type":"text","text":"hi"}""").value shouldBe Content.Text("hi")
+  }
+
+  "Content.Image" should "round-trip with mime_type in snake_case" in {
+    val image: Content = Content.Image(data = Some("base64data"), mimeType = Some("image/png"))
+    val json = image.asJson.deepDropNullValues
+    json shouldBe parse("""{"type":"image","data":"base64data","mime_type":"image/png"}""").value
+    decode[Content](json.noSpaces).value shouldBe image
+  }
+}

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/models/GeminiModelSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/models/GeminiModelSpec.scala
@@ -1,0 +1,24 @@
+package sttp.ai.gemini.unit.models
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.gemini.models.GeminiModel
+
+class GeminiModelSpec extends AnyFlatSpec with Matchers {
+
+  "GeminiModel.fromString" should "resolve each known model value to itself" in
+    GeminiModel.values.foreach { model =>
+      GeminiModel.fromString(model.value) shouldBe model
+    }
+
+  it should "resolve an unrecognized model id to CustomModel" in {
+    GeminiModel.fromString("some-new-model") shouldBe GeminiModel.CustomModel("some-new-model")
+  }
+
+  "GeminiModel.values" should "contain no duplicates" in {
+    GeminiModel.values.distinct shouldBe GeminiModel.values
+  }
+
+  it should "have a non-empty value for every model" in
+    GeminiModel.values.foreach(_.value should not be empty)
+}

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/models/InteractionStatusSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/models/InteractionStatusSpec.scala
@@ -1,0 +1,32 @@
+package sttp.ai.gemini.unit.models
+
+import io.circe.parser.decode
+import io.circe.syntax._
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.gemini.json.GeminiManualCodecs._
+import sttp.ai.gemini.models.InteractionStatus
+
+class InteractionStatusSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  "InteractionStatus" should "decode all known status values" in {
+    decode[InteractionStatus]("\"completed\"").value shouldBe InteractionStatus.Completed
+    decode[InteractionStatus]("\"requires_action\"").value shouldBe InteractionStatus.RequiresAction
+    decode[InteractionStatus]("\"in_progress\"").value shouldBe InteractionStatus.InProgress
+    decode[InteractionStatus]("\"failed\"").value shouldBe InteractionStatus.Failed
+    decode[InteractionStatus]("\"cancelled\"").value shouldBe InteractionStatus.Cancelled
+    decode[InteractionStatus]("\"incomplete\"").value shouldBe InteractionStatus.Incomplete
+    decode[InteractionStatus]("\"budget_exceeded\"").value shouldBe InteractionStatus.BudgetExceeded
+    decode[InteractionStatus]("\"queued\"").value shouldBe InteractionStatus.Queued
+  }
+
+  it should "decode an unknown status as Other instead of failing" in {
+    decode[InteractionStatus]("\"some_future_status\"").value shouldBe InteractionStatus.Other("some_future_status")
+  }
+
+  it should "encode back to the raw string value" in {
+    (InteractionStatus.Completed: InteractionStatus).asJson.noSpaces shouldBe "\"completed\""
+    (InteractionStatus.Other("x"): InteractionStatus).asJson.noSpaces shouldBe "\"x\""
+  }
+}

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/models/ResponseFormatSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/models/ResponseFormatSpec.scala
@@ -14,18 +14,28 @@ class ResponseFormatSpec extends AnyFlatSpec with Matchers with EitherValues {
     (ResponseFormat.Text: ResponseFormat).asJson shouldBe parse("""{"type":"text"}""").value
   }
 
-  "ResponseFormat.JsonSchema" should "encode with a nested json_schema object" in {
-    val schema = parse("""{"type":"object","properties":{"name":{"type":"string"}}}""").value
-    val format: ResponseFormat = ResponseFormat.JsonSchema(name = "person", schema = schema)
-
-    format.asJson shouldBe parse(
-      """{"type":"json_schema","json_schema":{"name":"person","schema":{"type":"object","properties":{"name":{"type":"string"}}}}}"""
-    ).value
+  it should "round-trip" in {
+    val format: ResponseFormat = ResponseFormat.Text
+    decode[ResponseFormat](format.asJson.noSpaces).value shouldBe format
   }
 
-  it should "round-trip with description and strict" in {
+  "ResponseFormat.JsonSchema" should "encode the schema verbatim, without a json_schema envelope" in {
+    val schema = parse("""{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}""").value
+    val format: ResponseFormat = ResponseFormat.JsonSchema(schema)
+
+    format.asJson shouldBe schema
+  }
+
+  it should "decode a schema object (no type=text) as JsonSchema" in {
+    val schemaJson = """{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}"""
+    val schema = parse(schemaJson).value
+
+    decode[ResponseFormat](schemaJson).value shouldBe ResponseFormat.JsonSchema(schema)
+  }
+
+  it should "round-trip through encode/decode" in {
     val schema = parse("""{"type":"object"}""").value
-    val format: ResponseFormat = ResponseFormat.JsonSchema("p", schema, description = Some("d"), strict = Some(true))
+    val format: ResponseFormat = ResponseFormat.JsonSchema(schema)
     decode[ResponseFormat](format.asJson.noSpaces).value shouldBe format
   }
 }

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/models/ResponseFormatSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/models/ResponseFormatSpec.scala
@@ -1,0 +1,31 @@
+package sttp.ai.gemini.unit.models
+
+import io.circe.parser.{decode, parse}
+import io.circe.syntax._
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.gemini.json.GeminiManualCodecs._
+import sttp.ai.gemini.models.ResponseFormat
+
+class ResponseFormatSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  "ResponseFormat.Text" should "encode as bare type object" in {
+    (ResponseFormat.Text: ResponseFormat).asJson shouldBe parse("""{"type":"text"}""").value
+  }
+
+  "ResponseFormat.JsonSchema" should "encode with a nested json_schema object" in {
+    val schema = parse("""{"type":"object","properties":{"name":{"type":"string"}}}""").value
+    val format: ResponseFormat = ResponseFormat.JsonSchema(name = "person", schema = schema)
+
+    format.asJson shouldBe parse(
+      """{"type":"json_schema","json_schema":{"name":"person","schema":{"type":"object","properties":{"name":{"type":"string"}}}}}"""
+    ).value
+  }
+
+  it should "round-trip with description and strict" in {
+    val schema = parse("""{"type":"object"}""").value
+    val format: ResponseFormat = ResponseFormat.JsonSchema("p", schema, description = Some("d"), strict = Some(true))
+    decode[ResponseFormat](format.asJson.noSpaces).value shouldBe format
+  }
+}

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/models/ResponseFormatSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/models/ResponseFormatSpec.scala
@@ -38,4 +38,12 @@ class ResponseFormatSpec extends AnyFlatSpec with Matchers with EitherValues {
     val format: ResponseFormat = ResponseFormat.JsonSchema(schema)
     decode[ResponseFormat](format.asJson.noSpaces).value shouldBe format
   }
+
+  it should "decode a schema with a non-string type array (e.g. nullable) as JsonSchema and encode it back verbatim" in {
+    val schemaJson = """{"type":["object","null"]}"""
+    val schema = parse(schemaJson).value
+
+    decode[ResponseFormat](schemaJson).value shouldBe ResponseFormat.JsonSchema(schema)
+    (ResponseFormat.JsonSchema(schema): ResponseFormat).asJson shouldBe schema
+  }
 }

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/models/ToolSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/models/ToolSpec.scala
@@ -1,0 +1,41 @@
+package sttp.ai.gemini.unit.models
+
+import io.circe.parser.{decode, parse}
+import io.circe.syntax._
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.gemini.json.GeminiManualCodecs._
+import sttp.ai.gemini.models.Tool
+
+class ToolSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  "Tool.Function" should "encode with type function and verbatim parameters" in {
+    val params = parse("""{"type":"object","properties":{"level":{"enum":["low","high",null],"default":null}}}""").value
+    val tool: Tool = Tool.Function("set-level", Some("Sets the level"), params)
+
+    val json = tool.asJson
+    json.hcursor.get[String]("type").value shouldBe "function"
+    json.hcursor.get[String]("name").value shouldBe "set-level"
+    json.hcursor.get[String]("description").value shouldBe "Sets the level"
+    // parameters must be preserved verbatim, including legitimate nulls
+    json.hcursor.downField("parameters").focus shouldBe Some(params)
+  }
+
+  it should "omit description when absent" in {
+    val tool: Tool = Tool.Function("t", None, io.circe.Json.obj())
+    tool.asJson.hcursor.downField("description").focus shouldBe None
+  }
+
+  it should "decode from JSON" in {
+    val decoded = decode[Tool]("""{"type":"function","name":"t","parameters":{"type":"object"}}""").value
+    decoded shouldBe Tool.Function("t", None, parse("""{"type":"object"}""").value)
+  }
+
+  "built-in tools" should "encode as bare type objects and round-trip" in {
+    (Tool.GoogleSearch: Tool).asJson shouldBe parse("""{"type":"google_search"}""").value
+    (Tool.CodeExecution: Tool).asJson shouldBe parse("""{"type":"code_execution"}""").value
+    decode[Tool]("""{"type":"google_search"}""").value shouldBe Tool.GoogleSearch
+    decode[Tool]("""{"type":"code_execution"}""").value shouldBe Tool.CodeExecution
+  }
+}

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/models/ToolSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/models/ToolSpec.scala
@@ -18,7 +18,7 @@ class ToolSpec extends AnyFlatSpec with Matchers with EitherValues {
     json.hcursor.get[String]("type").value shouldBe "function"
     json.hcursor.get[String]("name").value shouldBe "set-level"
     json.hcursor.get[String]("description").value shouldBe "Sets the level"
-    // parameters must be preserved verbatim, including legitimate nulls
+    // the encoder embeds parameters verbatim; null-preservation through request serialization is covered by GeminiClientSerializationSpec
     json.hcursor.downField("parameters").focus shouldBe Some(params)
   }
 

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/requests/InteractionRequestSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/requests/InteractionRequestSpec.scala
@@ -1,0 +1,57 @@
+package sttp.ai.gemini.unit.requests
+
+import io.circe.parser.{decode, parse}
+import io.circe.syntax._
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.gemini.json.GeminiDerivedCodecs._
+import sttp.ai.gemini.json.GeminiManualCodecs._
+import sttp.ai.gemini.models._
+import sttp.ai.gemini.requests.InteractionRequest
+
+class InteractionRequestSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  "InteractionInput" should "encode a text input as a plain JSON string" in {
+    (InteractionInput.TextInput("hello"): InteractionInput).asJson shouldBe io.circe.Json.fromString("hello")
+  }
+
+  it should "encode a steps input as a JSON array of discriminated steps" in {
+    val input: InteractionInput = InteractionInput.StepsInput(
+      List(
+        Step.userText("hi"),
+        Step.FunctionCall("call_1", "get_weather", parse("""{"city":"Warsaw"}""").value),
+        Step.FunctionResult("call_1", "get_weather", io.circe.Json.fromString("sunny"))
+      )
+    )
+    val json = input.asJson.deepDropNullValues
+    json shouldBe parse(
+      """[
+        |{"type":"user_input","content":[{"type":"text","text":"hi"}]},
+        |{"type":"function_call","id":"call_1","name":"get_weather","arguments":{"city":"Warsaw"}},
+        |{"type":"function_result","call_id":"call_1","name":"get_weather","result":"sunny"}
+        |]""".stripMargin
+    ).value
+  }
+
+  it should "decode a string back to TextInput and an array back to StepsInput" in {
+    decode[InteractionInput]("\"hello\"").value shouldBe InteractionInput.TextInput("hello")
+    decode[InteractionInput]("""[{"type":"user_input","content":[{"type":"text","text":"hi"}]}]""").value shouldBe
+      InteractionInput.StepsInput(List(Step.UserInput(List(Content.Text("hi")))))
+  }
+
+  "InteractionRequest" should "serialize with snake_case fields" in {
+    val request = InteractionRequest
+      .simple("gemini-2.5-flash-lite", "hello")
+      .copy(
+        systemInstruction = Some("be brief"),
+        previousInteractionId = Some("int_123"),
+        store = Some(false)
+      )
+    val json = request.asJson.deepDropNullValues
+    json shouldBe parse(
+      """{"model":"gemini-2.5-flash-lite","input":"hello","system_instruction":"be brief",
+        |"previous_interaction_id":"int_123","store":false}""".stripMargin
+    ).value
+  }
+}

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/requests/InteractionRequestSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/requests/InteractionRequestSpec.scala
@@ -6,7 +6,6 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.ai.gemini.json.GeminiDerivedCodecs._
-import sttp.ai.gemini.json.GeminiManualCodecs._
 import sttp.ai.gemini.models._
 import sttp.ai.gemini.requests.InteractionRequest
 

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/responses/InteractionResponseSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/responses/InteractionResponseSpec.scala
@@ -1,0 +1,49 @@
+package sttp.ai.gemini.unit.responses
+
+import io.circe.parser.decode
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.gemini.json.GeminiDerivedCodecs._
+import sttp.ai.gemini.models._
+import sttp.ai.gemini.responses.InteractionResponse
+
+class InteractionResponseSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  private val responseJson =
+    """{
+      |  "id": "int_abc",
+      |  "object": "interaction",
+      |  "status": "completed",
+      |  "model": "gemini-2.5-flash-lite",
+      |  "steps": [
+      |    {"type": "model_output", "content": [{"type": "text", "text": "It is "}, {"type": "text", "text": "sunny."}]},
+      |    {"type": "function_call", "id": "call_1", "name": "get_weather", "arguments": {"city": "Warsaw"}}
+      |  ],
+      |  "usage": {"total_input_tokens": 10, "total_output_tokens": 5, "total_tokens": 15},
+      |  "created": "2026-07-27T10:00:00Z"
+      |}""".stripMargin
+
+  "InteractionResponse" should "decode from API JSON, ignoring unknown fields like object" in {
+    val response = decode[InteractionResponse](responseJson).value
+
+    response.id shouldBe "int_abc"
+    response.status shouldBe InteractionStatus.Completed
+    response.model shouldBe Some("gemini-2.5-flash-lite")
+    response.steps should have size 2
+    response.usage.flatMap(_.totalTokens) shouldBe Some(15L)
+  }
+
+  it should "expose concatenated model output text and collected function calls" in {
+    val response = decode[InteractionResponse](responseJson).value
+
+    response.outputText shouldBe "It is sunny."
+    response.functionCalls.map(_.name) shouldBe List("get_weather")
+  }
+
+  it should "decode when steps are absent" in {
+    val response = decode[InteractionResponse]("""{"id":"int_x","status":"queued"}""").value
+    response.steps shouldBe empty
+    response.outputText shouldBe ""
+  }
+}

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/responses/InteractionResponseSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/responses/InteractionResponseSpec.scala
@@ -27,7 +27,7 @@ class InteractionResponseSpec extends AnyFlatSpec with Matchers with EitherValue
   "InteractionResponse" should "decode from API JSON, ignoring unknown fields like object" in {
     val response = decode[InteractionResponse](responseJson).value
 
-    response.id shouldBe "int_abc"
+    response.id shouldBe Some("int_abc")
     response.status shouldBe InteractionStatus.Completed
     response.model shouldBe Some("gemini-2.5-flash-lite")
     response.steps should have size 2
@@ -45,5 +45,30 @@ class InteractionResponseSpec extends AnyFlatSpec with Matchers with EitherValue
     val response = decode[InteractionResponse]("""{"id":"int_x","status":"queued"}""").value
     response.steps shouldBe empty
     response.outputText shouldBe ""
+  }
+
+  // Verbatim live fixture from a real store=false Interactions API call: no `id` (stateless response), and a
+  // `{"type":"thought", "signature":...}` step preceding the model_output step.
+  private val liveFixture =
+    """{"status":"completed","usage":{"total_tokens":23,"total_input_tokens":12,"input_tokens_by_modality":[{"modality":"text","tokens":12}],"total_cached_tokens":0,"total_output_tokens":11,"total_tool_use_tokens":0,"total_thought_tokens":0},"created":"2026-07-28T07:51:28Z","updated":"2026-07-28T07:51:28Z","service_tier":"standard","steps":[{"signature":"EjQKMgERTTIPUzlM4o4F/05UJ0vCCNg4Vd+GMV47cIlVpIevfAKyVhBjafSKil/2rhl4muYY","type":"thought"},{"content":[{"text":"{\n  \"city\": \"Paris\"\n}","type":"text"}],"type":"model_output"}],"object":"interaction","model":"gemini-3.5-flash-lite"}"""
+
+  it should "decode a live store=false response with no id and a thought step" in {
+    val response = decode[InteractionResponse](liveFixture).value
+
+    response.status shouldBe InteractionStatus.Completed
+    response.id shouldBe None
+    response.outputText shouldBe "{\n  \"city\": \"Paris\"\n}"
+    response.steps.collectFirst { case t: Step.Thought => t } shouldBe Some(
+      Step.Thought(signature = Some("EjQKMgERTTIPUzlM4o4F/05UJ0vCCNg4Vd+GMV47cIlVpIevfAKyVhBjafSKil/2rhl4muYY"))
+    )
+    response.usage.flatMap(_.totalTokens) shouldBe Some(23L)
+  }
+
+  it should "decode an unrecognized step type as Step.Unknown instead of failing" in {
+    val json = """{"id":"int_y","status":"completed","steps":[{"type":"some_future_step","x":1}]}"""
+    val response = decode[InteractionResponse](json).value
+
+    response.steps should have size 1
+    response.steps.head shouldBe a[Step.Unknown]
   }
 }

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/responses/InteractionResponseSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/responses/InteractionResponseSpec.scala
@@ -71,4 +71,23 @@ class InteractionResponseSpec extends AnyFlatSpec with Matchers with EitherValue
     response.steps should have size 1
     response.steps.head shouldBe a[Step.Unknown]
   }
+
+  it should "decode unknown content types as Content.Unknown without losing sibling text" in {
+    val response = decode[InteractionResponse](
+      """{"status":"completed","steps":[{"type":"model_output","content":[
+        |{"type":"text","text":"hi"},{"type":"executable_code","code":"x=1"}]}]}""".stripMargin
+    ).value
+
+    response.outputText shouldBe "hi"
+    response.steps.head match {
+      case Step.ModelOutput(content) => content.collect { case u: Content.Unknown => u } should have size 1
+      case other                     => fail(s"expected ModelOutput, got $other")
+    }
+  }
+
+  it should "fail loudly when a known step type is malformed instead of degrading to Unknown" in {
+    decode[InteractionResponse](
+      """{"status":"completed","steps":[{"type":"function_call","name":"get_weather","arguments":{}}]}"""
+    ).isLeft shouldBe true
+  }
 }

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/responses/InteractionStreamEventSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/responses/InteractionStreamEventSpec.scala
@@ -1,0 +1,36 @@
+package sttp.ai.gemini.unit.responses
+
+import io.circe.parser.decode
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.gemini.json.GeminiDerivedCodecs._
+import sttp.ai.gemini.responses.InteractionStreamEvent
+
+class InteractionStreamEventSpec extends AnyFlatSpec with Matchers with EitherValues {
+
+  "InteractionStreamEvent" should "decode a completed event with an interaction snapshot" in {
+    val event = decode[InteractionStreamEvent](
+      """{"event_type":"interaction.completed","event_id":"ev_1",
+        |"interaction":{"id":"int_1","status":"completed","steps":[{"type":"model_output","content":[{"type":"text","text":"hi"}]}]}}""".stripMargin
+    ).value
+
+    event.eventType shouldBe "interaction.completed"
+    event.interaction.map(_.id) shouldBe Some("int_1")
+  }
+
+  it should "decode an error event" in {
+    val event = decode[InteractionStreamEvent](
+      """{"event_type":"error","error":{"code":"internal","message":"boom"}}"""
+    ).value
+
+    event.eventType shouldBe "error"
+    event.error.flatMap(_.message) shouldBe Some("boom")
+  }
+
+  it should "decode an unknown event type without failing (open envelope)" in {
+    val event = decode[InteractionStreamEvent]("""{"event_type":"interaction.step.delta","event_id":"ev_2"}""").value
+    event.eventType shouldBe "interaction.step.delta"
+    event.interaction shouldBe None
+  }
+}

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/responses/InteractionStreamEventSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/responses/InteractionStreamEventSpec.scala
@@ -16,7 +16,7 @@ class InteractionStreamEventSpec extends AnyFlatSpec with Matchers with EitherVa
     ).value
 
     event.eventType shouldBe "interaction.completed"
-    event.interaction.map(_.id) shouldBe Some("int_1")
+    event.interaction.flatMap(_.id) shouldBe Some("int_1")
   }
 
   it should "decode an error event" in {


### PR DESCRIPTION
First PR of a 6-PR stack adding a native Google Gemini client module targeting the [Interactions API](https://ai.google.dev/gemini-api/docs/interactions-overview) — Google's recommended surface for new projects (`generateContent` is now legacy). The module mirrors the existing `claude` module's architecture.

Until now Gemini was only reachable through the OpenAI-compatible endpoint, which exposes just the chat-completions surface. This stack gives it first-class treatment: dedicated client, sync wrapper, agent-loop backend, streaming for all five effect systems, and docs.

## This PR: module skeleton + full data model (no HTTP client yet)

**Build wiring**
- `gemini` projectMatrix cloned from `claude`'s: JVM rows for Scala 3 + 2.13, Native row for Scala 3, `dependsOn(core % "compile->compile;test->test")`, added to aggregates.

**Config**
- `GeminiConfig` extending core's `AIClientConfig`: `x-goog-api-key` auth header, `GEMINI_API_KEY` / `GEMINI_BASE_URL` env vars, default base URL `https://generativelanguage.googleapis.com`.

**Models** (package `sttp.ai.gemini.models`)
- `Content` (text/image/audio/video/document), `Step` (`user_input` / `model_output` / `function_call` / `function_result` / `thought`, plus an `Unknown` fallback so new server-side step types can never break deserialization)
- `InteractionInput` — the request `input` union: plain string or a list of steps (stateless conversation replay)
- `Tool` — `Function` with a **verbatim raw JSON-schema `parameters`** (so MCP-sourced schemas survive byte-faithful, incl. legitimate `null`s), plus `GoogleSearch` / `CodeExecution` built-ins
- `ResponseFormat` — `Text` or `JsonSchema(schema)` for structured output
- `GenerationConfig`, `SafetySetting`, `Usage`, `InteractionStatus` (open enum: unknown statuses decode as `Other`), `GeminiModel`
- `InteractionRequest` / `InteractionResponse` / `ErrorResponse` / `InteractionStreamEvent` (open SSE envelope — unknown `event_type`s decode fine)

**JSON**
- circe with core's shared `CirceConfiguration` (snake_case + `type` discriminator); derived codecs per Scala version (`io.circe.derivation` on 3, `circe-generic-extras` on 2.13), hand-written codecs where derivation can't express the wire shape (`Tool`, `ResponseFormat`, `InteractionInput`, `InteractionStatus`, `ErrorDetail`).

**Tests:** wire-format round-trips asserted against literal JSON (not just structural equality), unknown-status/step/event tolerance, verbatim tool-schema preservation.

## Validated against the live API

The whole stack was exercised end-to-end with a real `GEMINI_API_KEY` (10/10 integration tests in PR 5 pass). Several contract facts in this PR come from live responses rather than the docs, which turned out to be wrong or incomplete:
- `response_format` takes the JSON schema **directly** (the documented `{"type":"json_schema", ...}` wrapper is rejected)
- `store=false` responses carry **no `id`** → `InteractionResponse.id: Option[String]`
- responses contain a `thought` step type; error bodies can carry `code` as a string (`"not_found"`) or a number — the decoder accepts both