### PR TITLE
Docs/01 foundation

### DIFF
--- a/docs/agents/quickstart.md
+++ b/docs/agents/quickstart.md
@@ -48,6 +48,6 @@ object BasicExample extends App {
 }
 ```
 
-**For Claude:** Use `ClaudeAgent.synchronous(ClaudeConfig.fromEnv, "claude-3-haiku-20240307")` instead.
+**For Claude:** Use `ClaudeAgent.synchronous(ClaudeConfig.fromEnv, "claude-haiku-4-5-20251001")` instead.
 
 **For effect systems:** use `OpenAIAgent.builder[F]` / `ClaudeAgent.builder[F]` (e.g. `builder[IO]`), then add configuration and `.build`.

--- a/docs/claude/basics.md
+++ b/docs/claude/basics.md
@@ -1,6 +1,6 @@
 # Claude API
 
-This module provides **native support for Anthropic's Claude API** within the sttp-openai library. Unlike OpenAI compatibility layers, this provides direct access to Claude's unique features and API structure.
+This module provides **native support for Anthropic's Claude API** within the sttp-ai library. Unlike OpenAI compatibility layers, this provides direct access to Claude's unique features and API structure.
 
 ## Claude Features
 
@@ -42,7 +42,7 @@ object Main:
     )
 
     val request = MessageRequest.simple(
-      model = "claude-3-haiku-20240307",  // Fast, cost-effective model
+      model = "claude-haiku-4-5-20251001",  // Fast, cost-effective model
       messages = messages,
       maxTokens = 500
     )
@@ -68,7 +68,7 @@ object Main:
 - Uses `ContentBlock` instead of simple strings for rich content (text, images)
 - Separate system parameter instead of system role messages
 - Different authentication headers (`x-api-key` + `anthropic-version`)
-- Native Claude model names (e.g., `claude-3-haiku-20240307`)
+- Native Claude model names (e.g., `claude-haiku-4-5-20251001`)
 
 ## Claude Configuration
 

--- a/docs/claude/messages.md
+++ b/docs/claude/messages.md
@@ -10,7 +10,7 @@ val messages = List(
 )
 
 val request = MessageRequest.simple(
-  model = "claude-3-sonnet-20240229",
+  model = "claude-sonnet-4-5-20250514",
   messages = messages,
   maxTokens = 1000
 )
@@ -22,7 +22,7 @@ Unlike OpenAI, Claude uses a separate `system` parameter instead of system role 
 
 ```scala
 val request = MessageRequest.withSystem(
-  model = "claude-3-sonnet-20240229",
+  model = "claude-sonnet-4-5-20250514",
   system = "You are a helpful assistant that always responds in French.",
   messages = List(Message.user(List(ContentBlock.text("Hello!")))),
   maxTokens = 1000
@@ -50,7 +50,7 @@ val messages = List(
 )
 
 val request = MessageRequest.simple(
-  model = "claude-3-sonnet-20240229",
+  model = "claude-sonnet-4-5-20250514",
   messages = messages,
   maxTokens = 1000
 )
@@ -62,7 +62,7 @@ val request = MessageRequest.simple(
 import sttp.ai.claude.models.CacheControl
 
 val request = MessageRequest(
-  model = "claude-3-sonnet-20240229",
+  model = "claude-sonnet-4-5-20250514",
   messages = messages,
   maxTokens = 4000,
   temperature = Some(0.7),           // Creativity (0.0 - 1.0)

--- a/docs/claude/messages.md
+++ b/docs/claude/messages.md
@@ -10,7 +10,7 @@ val messages = List(
 )
 
 val request = MessageRequest.simple(
-  model = "claude-sonnet-4-5-20250514",
+  model = "claude-sonnet-4-5-20250929",
   messages = messages,
   maxTokens = 1000
 )
@@ -22,7 +22,7 @@ Unlike OpenAI, Claude uses a separate `system` parameter instead of system role 
 
 ```scala
 val request = MessageRequest.withSystem(
-  model = "claude-sonnet-4-5-20250514",
+  model = "claude-sonnet-4-5-20250929",
   system = "You are a helpful assistant that always responds in French.",
   messages = List(Message.user(List(ContentBlock.text("Hello!")))),
   maxTokens = 1000
@@ -50,7 +50,7 @@ val messages = List(
 )
 
 val request = MessageRequest.simple(
-  model = "claude-sonnet-4-5-20250514",
+  model = "claude-sonnet-4-5-20250929",
   messages = messages,
   maxTokens = 1000
 )
@@ -62,7 +62,7 @@ val request = MessageRequest.simple(
 import sttp.ai.claude.models.CacheControl
 
 val request = MessageRequest(
-  model = "claude-sonnet-4-5-20250514",
+  model = "claude-sonnet-4-5-20250929",
   messages = messages,
   maxTokens = 4000,
   temperature = Some(0.7),           // Creativity (0.0 - 1.0)

--- a/docs/claude/structured-outputs.md
+++ b/docs/claude/structured-outputs.md
@@ -86,7 +86,7 @@ object StructuredOutputExample:
     )
 
     val request = MessageRequest
-      .simple("claude-sonnet-4-5-20250514", messages, 500)
+      .simple("claude-sonnet-4-5-20250929", messages, 500)
       .withStructuredOutput(outputFormat)
 
     val response = client.createMessage(request).send(backend)

--- a/docs/claude/tool-calling.md
+++ b/docs/claude/tool-calling.md
@@ -21,7 +21,7 @@ val weatherTool = Tool(
 )
 
 val request = MessageRequest.withTools(
-  model = "claude-3-sonnet-20240229",
+  model = "claude-sonnet-4-5-20250514",
   messages = List(Message.user(List(ContentBlock.text("What's the weather in Paris?")))),
   maxTokens = 1000,
   tools = List(weatherTool)

--- a/docs/claude/tool-calling.md
+++ b/docs/claude/tool-calling.md
@@ -21,7 +21,7 @@ val weatherTool = Tool(
 )
 
 val request = MessageRequest.withTools(
-  model = "claude-sonnet-4-5-20250514",
+  model = "claude-sonnet-4-5-20250929",
   messages = List(Message.user(List(ContentBlock.text("What's the weather in Paris?")))),
   maxTokens = 1000,
   tools = List(weatherTool)
@@ -39,7 +39,7 @@ import sttp.ai.claude.models.{ContentBlock, Message, Tool}
 import sttp.ai.claude.requests.MessageRequest
 
 val request = MessageRequest.withTools(
-  model = "claude-sonnet-4-5-20250514",
+  model = "claude-sonnet-4-5-20250929",
   messages = List(Message.user(List(ContentBlock.text("What was the most recent SpaceX launch?")))),
   maxTokens = 1024,
   tools = List(Tool.WebSearch.default)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,14 +4,14 @@ sttp is a family of Scala HTTP-related projects, and currently includes:
 
 * [sttp client](https://github.com/softwaremill/sttp): the Scala HTTP client you always wanted!
 * [sttp tapir](https://github.com/softwaremill/tapir): typed API descriptions
-* sttp ai: this project. Non-official Scala client wrapper for OpenAI, Claude (Anthropic), Gemini (Google), and OpenAI-compatible APIs (e.g. Ollama, Groq, OpenRouter). Use the power of ChatGPT, Claude, and Gemini inside your code!
+* sttp ai: this project. Non-official Scala client wrapper for OpenAI, Claude (Anthropic), Gemini (Google), and OpenAI-compatible APIs (e.g. Ollama, Grok, Groq, OpenRouter). Use the power of ChatGPT, Claude, and Gemini inside your code!
 
 sttp-ai uses [sttp client](https://github.com/softwaremill/sttp) to describe requests and responses as plain, type-safe Scala values — request bodies, response models, JSON schemas, and tool definitions are all derived from case classes via [Tapir](https://tapir.softwaremill.com) and [circe](https://circe.github.io/circe/), with minimal ceremony and no hand-written JSON.
 
 ## What can you do with sttp-ai?
 
 * **Call model APIs directly** — [OpenAI](openai/basics.md) (chat completions, embeddings, audio, images, and more), [Claude](claude/basics.md) (Messages API), and [Gemini](gemini/basics.md) (Interactions API); each provider has a blocking sync client and a raw-request async client that works with any effect system
-* **Use OpenAI-compatible providers** — [Ollama, Groq, OpenRouter, vLLM and others](openai/compatible-apis.md) via the OpenAI client with a custom base URL
+* **Use OpenAI-compatible providers** — [Ollama, Grok, Groq, OpenRouter, vLLM and others](openai/compatible-apis.md) via the OpenAI client with a custom base URL
 * **Stream responses** — [server-sent events streaming](openai/streaming.md) for fs2, ZIO, Akka Streams, Pekko Streams, and Ox
 * **Get structured outputs** — JSON-schema-constrained responses parsed straight into your case classes ([OpenAI](openai/structured-outputs.md), [Claude](claude/structured-outputs.md), [Gemini](gemini/structured-outputs.md))
 * **Call tools** — let the model invoke functions in your code ([Claude](claude/tool-calling.md), [Gemini](gemini/tool-calling.md))

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ sttp is a family of Scala HTTP-related projects, and currently includes:
 * [sttp tapir](https://github.com/softwaremill/tapir): typed API descriptions
 * sttp ai: this project. Non-official Scala client wrapper for OpenAI, Claude (Anthropic), Gemini (Google), and OpenAI-compatible APIs (e.g. Ollama, Groq, OpenRouter). Use the power of ChatGPT, Claude, and Gemini inside your code!
 
-sttp-ai uses [sttp client](https://github.com/softwaremill/sttp) to describe requests and responses used in OpenAI, Claude (Anthropic), Gemini (Google), and OpenAI-compatible endpoints.
+sttp-ai uses [sttp client](https://github.com/softwaremill/sttp) to describe requests and responses as plain, type-safe Scala values — request bodies, response models, JSON schemas, and tool definitions are all derived from case classes via [Tapir](https://tapir.softwaremill.com) and [circe](https://circe.github.io/circe/), with minimal ceremony and no hand-written JSON.
 
 ## What can you do with sttp-ai?
 
@@ -16,6 +16,10 @@ sttp-ai uses [sttp client](https://github.com/softwaremill/sttp) to describe req
 * **Get structured outputs** — JSON-schema-constrained responses parsed straight into your case classes ([OpenAI](openai/structured-outputs.md), [Claude](claude/structured-outputs.md), [Gemini](gemini/structured-outputs.md))
 * **Call tools** — let the model invoke functions in your code ([Claude](claude/tool-calling.md), [Gemini](gemini/tool-calling.md))
 * **Run an agent loop** — [autonomous tool-calling agents](agents/quickstart.md) with typed tools and typed results, working across all three providers, with tools loadable from [MCP servers](agents/mcp.md)
+
+## Why sttp-ai?
+
+sttp-ai implements the native APIs of all three major providers — OpenAI, Claude, and Gemini — in one library, rather than funnelling everything through an OpenAI-compatibility shim. You bring your own effect system: cats-effect, ZIO, Akka/Pekko Streams, direct-style [Ox](https://github.com/softwaremill/ox), or plain blocking calls. Structured-output schemas and tool definitions are derived from case classes instead of written by hand, and the built-in agent loop gives you typed tools and typed results, with tools loadable from MCP servers. Cross-built for Scala 2.13 and Scala 3 (plus Scala Native for Gemini).
 
 ```{eval-rst}
 .. toctree::

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ sttp-ai uses [sttp client](https://github.com/softwaremill/sttp) to describe req
 
 ## Why sttp-ai?
 
-sttp-ai implements the native APIs of all three major providers — OpenAI, Claude, and Gemini — in one library, rather than funnelling everything through an OpenAI-compatibility shim. You bring your own effect system: cats-effect, ZIO, Akka/Pekko Streams, direct-style [Ox](https://github.com/softwaremill/ox), or plain blocking calls. Structured-output schemas and tool definitions are derived from case classes instead of written by hand, and the built-in agent loop gives you typed tools and typed results, with tools loadable from MCP servers. Cross-built for Scala 2.13 and Scala 3 (plus Scala Native for Gemini).
+sttp-ai implements the native APIs of all three major providers — OpenAI, Claude, and Gemini — in one library, rather than funnelling everything through an OpenAI-compatibility shim. You bring your own effect system: cats-effect, ZIO, Akka/Pekko Streams, direct-style [Ox](https://github.com/softwaremill/ox), or plain blocking calls. Structured-output schemas and tool definitions are derived from case classes instead of written by hand, and the built-in agent loop gives you typed tools and typed results, with tools loadable from MCP servers. Cross-built for Scala 2.13 and Scala 3, with Scala Native support (Scala 3) for the core and provider modules.
 
 ```{eval-rst}
 .. toctree::

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,11 +2,20 @@
 
 sttp is a family of Scala HTTP-related projects, and currently includes:
 
-* [sttp client](https://github.com/softwaremill/sttp): The Scala HTTP client you always wanted!
-* [sttp tapir](https://github.com/softwaremill/tapir): Typed API descRiptions
-* sttp ai: this project. Non-official Scala client wrapper for OpenAI, Claude (Anthropic), Gemini (Google), and OpenAI-compatible APIs (e.g. Ollama, Grok, OpenRouter). Use the power of ChatGPT, Claude, and Gemini inside your code!
+* [sttp client](https://github.com/softwaremill/sttp): the Scala HTTP client you always wanted!
+* [sttp tapir](https://github.com/softwaremill/tapir): typed API descriptions
+* sttp ai: this project. Non-official Scala client wrapper for OpenAI, Claude (Anthropic), Gemini (Google), and OpenAI-compatible APIs (e.g. Ollama, Groq, OpenRouter). Use the power of ChatGPT, Claude, and Gemini inside your code!
 
-sttp-ai uses sttp client to describe requests and responses used in OpenAI, Claude (Anthropic), Gemini (Google), and OpenAI-compatible endpoints.
+sttp-ai uses [sttp client](https://github.com/softwaremill/sttp) to describe requests and responses used in OpenAI, Claude (Anthropic), Gemini (Google), and OpenAI-compatible endpoints.
+
+## What can you do with sttp-ai?
+
+* **Call model APIs directly** — [OpenAI](openai/basics.md) (chat completions, embeddings, audio, images, and more), [Claude](claude/basics.md) (Messages API), and [Gemini](gemini/basics.md) (Interactions API); each provider has a blocking sync client and a raw-request async client that works with any effect system
+* **Use OpenAI-compatible providers** — [Ollama, Groq, OpenRouter, vLLM and others](openai/compatible-apis.md) via the OpenAI client with a custom base URL
+* **Stream responses** — [server-sent events streaming](openai/streaming.md) for fs2, ZIO, Akka Streams, Pekko Streams, and Ox
+* **Get structured outputs** — JSON-schema-constrained responses parsed straight into your case classes ([OpenAI](openai/structured-outputs.md), [Claude](claude/structured-outputs.md), [Gemini](gemini/structured-outputs.md))
+* **Call tools** — let the model invoke functions in your code ([Claude](claude/tool-calling.md), [Gemini](gemini/tool-calling.md))
+* **Run an agent loop** — [autonomous tool-calling agents](agents/quickstart.md) with typed tools and typed results, working across all three providers, with tools loadable from [MCP servers](agents/mcp.md)
 
 ```{eval-rst}
 .. toctree::

--- a/docs/openai/streaming.md
+++ b/docs/openai/streaming.md
@@ -145,4 +145,4 @@ object Main extends OxApp:
     ExitCode.Success
 ```
 
-See also the [ChatProxy](https://github.com/softwaremill/sttp-openai/blob/master/examples/src/main/scala/examples/ChatProxy.scala) example application.
+See also the [ChatProxy](https://github.com/softwaremill/sttp-ai/blob/master/examples/src/main/scala/examples/ChatProxy.scala) example application.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,35 @@ Add the following dependency:
 
 ```sbt
 "com.softwaremill.sttp.ai" %% "openai" % "@VERSION@"
+
+// For streaming support, add one or more (these modules are shared across OpenAI, Claude, and Gemini):
+"com.softwaremill.sttp.ai" %% "fs2" % "@VERSION@"    // cats-effect/fs2
+"com.softwaremill.sttp.ai" %% "zio" % "@VERSION@"    // ZIO
+"com.softwaremill.sttp.ai" %% "akka" % "@VERSION@"   // Akka Streams (Scala 2.13 only)
+"com.softwaremill.sttp.ai" %% "pekko" % "@VERSION@"  // Pekko Streams
+"com.softwaremill.sttp.ai" %% "ox" % "@VERSION@"     // Ox direct-style (Scala 3 only)
 ```
+
+Then send your first request (reads the `OPENAI_KEY` environment variable):
+
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::openai:@VERSION@
+
+import sttp.ai.openai.OpenAISyncClient
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.{ChatBody, ChatCompletionModel}
+import sttp.ai.openai.requests.completions.chat.message.*
+
+object OpenAIHello:
+  def main(args: Array[String]): Unit =
+    val openAI = OpenAISyncClient(System.getenv("OPENAI_KEY"))
+    val chatBody = ChatBody(
+      model = ChatCompletionModel.GPT4oMini,
+      messages = Seq(Message.User(Content.TextContent("Hello!")))
+    )
+    println(openAI.createChatCompletion(chatBody))
+```
+
+See [OpenAI API basics](openai/basics.md) for more.
 
 ## For Claude (Anthropic) API
 
@@ -20,8 +48,32 @@ Add the following dependency:
 "com.softwaremill.sttp.ai" %% "zio" % "@VERSION@"    // ZIO
 "com.softwaremill.sttp.ai" %% "akka" % "@VERSION@"   // Akka Streams (Scala 2.13 only)
 "com.softwaremill.sttp.ai" %% "pekko" % "@VERSION@"  // Pekko Streams
-"com.softwaremill.sttp.ai" %% "ox" % "@VERSION@"    // Ox direct-style (Scala 3 only)
+"com.softwaremill.sttp.ai" %% "ox" % "@VERSION@"     // Ox direct-style (Scala 3 only)
 ```
+
+Then send your first request (reads the `ANTHROPIC_API_KEY` environment variable):
+
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::claude:@VERSION@
+
+import sttp.ai.claude.ClaudeSyncClient
+import sttp.ai.claude.models.Message
+import sttp.ai.claude.requests.MessageRequest
+
+object ClaudeHello:
+  def main(args: Array[String]): Unit =
+    val claude = ClaudeSyncClient.fromEnv
+    try {
+      val request = MessageRequest.simple(
+        model = "claude-haiku-4-5-20251001",
+        messages = List(Message.user("Hello!")),
+        maxTokens = 100
+      )
+      println(claude.createMessage(request).content)
+    } finally claude.close()
+```
+
+See [Claude API basics](claude/basics.md) for more.
 
 ## For Gemini (Google) API
 
@@ -35,7 +87,26 @@ Add the following dependency:
 "com.softwaremill.sttp.ai" %% "zio" % "@VERSION@"    // ZIO
 "com.softwaremill.sttp.ai" %% "akka" % "@VERSION@"   // Akka Streams (Scala 2.13 only)
 "com.softwaremill.sttp.ai" %% "pekko" % "@VERSION@"  // Pekko Streams
-"com.softwaremill.sttp.ai" %% "ox" % "@VERSION@"    // Ox direct-style (Scala 3 only)
+"com.softwaremill.sttp.ai" %% "ox" % "@VERSION@"     // Ox direct-style (Scala 3 only)
 ```
 
-sttp-openai is available for Scala 2.13 and Scala 3
+Then send your first request (reads the `GEMINI_API_KEY` environment variable):
+
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::gemini:@VERSION@
+
+import sttp.ai.gemini.GeminiSyncClient
+import sttp.ai.gemini.requests.InteractionRequest
+
+object GeminiHello:
+  def main(args: Array[String]): Unit =
+    val gemini = GeminiSyncClient.fromEnv
+    try {
+      val response = gemini.createInteraction(InteractionRequest.simple("gemini-2.5-flash", "Hello!"))
+      println(response.outputText)
+    } finally gemini.close()
+```
+
+See [Gemini API basics](gemini/basics.md) for more.
+
+sttp-ai is available for Scala 2.13 and Scala 3.


### PR DESCRIPTION
- Add a "What can you do with sttp-ai?" feature overview to the main docs page (`index.md`), linking each capability (direct API access, compatible providers, streaming, structured outputs, tool calling, agent loop) to the page documenting it
- Add starting code snippets to the quickstart: a minimal, mdoc-verified sync-client "hello" example for each provider (OpenAI, Claude, Gemini), and add the streaming-modules dependency list to the OpenAI section (previously only Claude/Gemini had it)
- Sweep stale content: `sttp-openai` → `sttp-ai` project-name references, the ChatProxy example link (old repo name), and outdated Claude model ids (`claude-3-*` → current 4.5 ids) across `agents/quickstart.md`, `claude/basics.md`, `claude/messages.md`, `claude/tool-calling.md`, and `openai/streaming.md`