### PR TITLE
Docs/02 schemas

### DIFF
--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -1,8 +1,13 @@
 # Agent tools and results
 
+## Defining tools
+
 Tools are defined using type-safe case classes with the `derives` syntax:
 
-```scala
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::openai:@VERSION@
+
+import sttp.ai.core.agent.*
 import sttp.tapir.Schema
 
 case class CalculatorInput(
@@ -27,6 +32,8 @@ val calculatorTool = AgentTool.fromFunction(
 ```
 
 The `derives io.circe.Codec.AsObject, Schema` clause automatically generates the necessary serialization and schema information for the tool.
+
+See [JSON Schemas: structured outputs & tools](../other/json-schemas.md) for how schema derivation works and how to customise it.
 
 ## Agent Result
 

--- a/docs/claude/structured-outputs.md
+++ b/docs/claude/structured-outputs.md
@@ -2,6 +2,8 @@
 
 Claude's structured output feature (currently in beta) allows you to enforce that the model's response follows a specific JSON schema. This is useful for getting consistently formatted responses for data extraction, API responses, and structured data processing.
 
+A structured output request needs a JSON Schema. The easiest way is to have it derived from a case class — see [JSON Schemas: structured outputs & tools](../other/json-schemas.md) for all the options.
+
 **Model Support:**
 - ✅ **Supported models**: Claude 4.1+ models (`claude-sonnet-4-1-20250514`, `claude-opus-4-1-20250514`, etc.)
 - ❌ **Legacy models**: Claude 3.x series don't support structured outputs
@@ -40,7 +42,9 @@ object Main:
 
 `T` must have both a `sttp.tapir.Schema[T]` (for schema generation) and a circe `Codec[T]` (for parsing) — the `derives` clause supplies both in Scala 3.
 
-## Basic Structured Output Example
+## Lower-level: setting `OutputFormat.JsonSchema` yourself
+
+If you need finer control — a hand-built schema or custom parsing — derive or build the `sttp.apispec.Schema` yourself and set it via `withStructuredOutput`:
 
 ```scala mdoc:compile-only
 //> using dep com.softwaremill.sttp.ai::claude:@VERSION@
@@ -115,19 +119,24 @@ object StructuredOutputExample:
 
 If you prefer not to use Tapir, you can define schemas manually:
 
-```scala
-import sttp.apispec.{Schema => ASchema, SchemaType}
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::claude:@VERSION@
+
 import scala.collection.immutable.ListMap
+import sttp.ai.claude.models.OutputFormat
+import sttp.apispec.{Schema => ASchema, SchemaType}
 
 val schema: ASchema = ASchema(SchemaType.Object).copy(
   properties = ListMap(
     "summary" -> ASchema(SchemaType.String),
-    "confidence" -> ASchema(SchemaType.Number).copy(minimum = Some(0), maximum = Some(1))
+    "confidence" -> ASchema(SchemaType.Number).copy(minimum = Some(BigDecimal(0)), maximum = Some(BigDecimal(1)))
   ),
   required = List("summary", "confidence")
 )
 val outputFormat = OutputFormat.JsonSchema(schema)
 ```
+
+See [JSON Schemas: structured outputs & tools](../other/json-schemas.md) for deriving schemas with Tapir instead of writing them by hand.
 
 **Important Notes:**
 - Structured outputs require Claude 4.1+ models (`claude-sonnet-4-1-*`, `claude-opus-4-1-*`, etc.)

--- a/docs/gemini/structured-outputs.md
+++ b/docs/gemini/structured-outputs.md
@@ -2,6 +2,8 @@
 
 Gemini's structured output feature lets you force the model's response to conform to a JSON Schema — useful for data extraction, populating a typed model, or any case where you need a guaranteed shape back instead of free-form text.
 
+See [JSON Schemas: structured outputs & tools](../other/json-schemas.md) for all the ways to produce a schema, from automatic derivation to hand-built.
+
 ## Typed responses with `createInteractionAs[T]`
 
 For the shortest path, use `GeminiSyncClient.createInteractionAs[T]` — the JSON Schema is derived from `T` via Tapir and set on the request automatically (unless the request already carries a `ResponseFormat.JsonSchema`), and the model's output text is parsed back into `T` via circe.

--- a/docs/gemini/tool-calling.md
+++ b/docs/gemini/tool-calling.md
@@ -2,7 +2,7 @@
 
 ## Custom Tools
 
-Define your own tools with `Tool.Function`. `parameters` is a raw JSON Schema (`io.circe.Json`), passed to the API byte-for-byte — handy when the schema comes from an MCP server or another source you don't want re-encoded.
+Define your own tools with `Tool.Function`. `parameters` is a raw JSON Schema (`io.circe.Json`), passed to the API byte-for-byte — handy when the schema comes from an MCP server or another source you don't want re-encoded. See [JSON Schemas: structured outputs & tools](../other/json-schemas.md) for ways to produce a schema.
 
 ```scala mdoc:compile-only
 //> using dep com.softwaremill.sttp.ai::gemini:@VERSION@

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ sttp-ai uses [sttp client](https://github.com/softwaremill/sttp) to describe req
 * **Use OpenAI-compatible providers** — [Ollama, Groq, OpenRouter, vLLM and others](openai/compatible-apis.md) via the OpenAI client with a custom base URL
 * **Stream responses** — [server-sent events streaming](openai/streaming.md) for fs2, ZIO, Akka Streams, Pekko Streams, and Ox
 * **Get structured outputs** — [JSON-schema-constrained responses](other/json-schemas.md) parsed straight into your case classes ([OpenAI](openai/structured-outputs.md), [Claude](claude/structured-outputs.md), [Gemini](gemini/structured-outputs.md))
-* **Call tools** — let the model invoke functions in your code ([Claude](claude/tool-calling.md), [Gemini](gemini/tool-calling.md))
+* **Call tools** — let the model invoke functions in your code ([OpenAI](openai/tool-calling.md), [Claude](claude/tool-calling.md), [Gemini](gemini/tool-calling.md))
 * **Run an agent loop** — [autonomous tool-calling agents](agents/quickstart.md) with typed tools and typed results, working across all three providers, with tools loadable from [MCP servers](agents/mcp.md)
 
 ```{eval-rst}
@@ -31,6 +31,7 @@ sttp-ai uses [sttp client](https://github.com/softwaremill/sttp) to describe req
    openai/basics
    openai/streaming
    openai/structured-outputs
+   openai/tool-calling
    openai/compatible-apis
 
 .. toctree::

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ sttp-ai uses [sttp client](https://github.com/softwaremill/sttp) to describe req
 * **Call model APIs directly** — [OpenAI](openai/basics.md) (chat completions, embeddings, audio, images, and more), [Claude](claude/basics.md) (Messages API), and [Gemini](gemini/basics.md) (Interactions API); each provider has a blocking sync client and a raw-request async client that works with any effect system
 * **Use OpenAI-compatible providers** — [Ollama, Groq, OpenRouter, vLLM and others](openai/compatible-apis.md) via the OpenAI client with a custom base URL
 * **Stream responses** — [server-sent events streaming](openai/streaming.md) for fs2, ZIO, Akka Streams, Pekko Streams, and Ox
-* **Get structured outputs** — JSON-schema-constrained responses parsed straight into your case classes ([OpenAI](openai/structured-outputs.md), [Claude](claude/structured-outputs.md), [Gemini](gemini/structured-outputs.md))
+* **Get structured outputs** — [JSON-schema-constrained responses](other/json-schemas.md) parsed straight into your case classes ([OpenAI](openai/structured-outputs.md), [Claude](claude/structured-outputs.md), [Gemini](gemini/structured-outputs.md))
 * **Call tools** — let the model invoke functions in your code ([Claude](claude/tool-calling.md), [Gemini](gemini/tool-calling.md))
 * **Run an agent loop** — [autonomous tool-calling agents](agents/quickstart.md) with typed tools and typed results, working across all three providers, with tools loadable from [MCP servers](agents/mcp.md)
 
@@ -68,6 +68,7 @@ sttp-ai uses [sttp client](https://github.com/softwaremill/sttp) to describe req
    :maxdepth: 2
    :caption: Other
 
+   other/json-schemas
    other/backends
    other/examples
 ```

--- a/docs/openai/structured-outputs.md
+++ b/docs/openai/structured-outputs.md
@@ -2,6 +2,10 @@
 
 [OpenAI's Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs/introduction) constrain the model to produce JSON matching a given JSON Schema. The simplest way to use them is `OpenAISyncClient.createChatCompletionAs[T]` — the response schema is derived from a Scala case class via Tapir, set as `responseFormat` automatically, and the model's response is parsed back into `T` via circe:
 
+A structured output request needs a JSON Schema. The easiest way is to have it derived from a case class — see [JSON Schemas: structured outputs & tools](../other/json-schemas.md) for all the options, from automatic derivation to hand-built schemas.
+
+## Typed responses with createChatCompletionAs[T]
+
 ```scala mdoc:compile-only
 //> using dep com.softwaremill.sttp.ai::openai:@VERSION@
 
@@ -29,6 +33,15 @@ object Main:
 ```
 
 `T` must have both a `sttp.tapir.Schema[T]` (for schema generation) and a circe `Codec[T]` (for parsing). For custom parsing, the parser-based `createChatCompletion[T](body, name)(parseFunction)` overload remains available.
+
+## Strict mode and schema normalization
+
+normalization is applied only when `strict = true` is requested; otherwise the schema is encoded
+faithfully, unchanged. When a schema *is* normalized for strict mode, `additionalProperties: false` is set on every
+object, all properties are listed as `required`, and properties that were optional in the source schema (absent
+from its original `required` list) are made nullable — the model returns `null` for them instead of inventing a
+value. If you decode structured outputs into classes with non-`Option` fields, mark optional fields as `Option` or
+list them as required in your schema.
 
 ## Lower-level: building `ResponseFormat.JsonSchema` yourself
 
@@ -111,182 +124,3 @@ object Main:
     )
   */
 ```
-
-## Deriving a JSON Schema with tapir
-
-To derive the same math reasoning schema used above, you can use
-[Tapir's support for generating a JSON schema from a Tapir schema](https://tapir.softwaremill.com/en/latest/docs/json-schema.html):
-
-```scala mdoc:compile-only
-//> using dep com.softwaremill.sttp.tapir::tapir-apispec-docs:1.11.7
-
-import sttp.apispec.{Schema => ASchema}
-import sttp.tapir.Schema
-import sttp.tapir.docs.apispec.schema.TapirSchemaToJsonSchema
-import sttp.tapir.generic.auto.*
-
-case class Step(
-  explanation: String,
-  output: String
-)
-
-case class MathReasoning(
-  steps: List[Step],
-  finalAnswer: String
-)
-
-val tSchema = implicitly[Schema[MathReasoning]]
-
-val jsonSchema: ASchema = TapirSchemaToJsonSchema(
-  tSchema,
-  markOptionsAsNullable = true
-)
-```
-
-## Generating JSON Schema from case class
-
-We can also generate JSON Schema directly from case class, without defining the schema manually.
-
-In the example below I define such use case. User tries to book a flight, using function tool. The flow looks as follows:
-- User sends a message with the request to book a flight and provides function tool, which means that there is a function on a client side which 'knows' how to book a flight. Within this call it is necessary to provide Json Schema to define function arguments.
-- Assistant sends a message with arguments created based on Json Schema provided in the first step.
-- User calls custom function with arguments sent by Assistant before.
-- User sends result from the function call to Assistant.
-- Assistant sends a final result to User.
-
-The key point here is using `Tool.Function.withSchema[T]` method. With this method, Json Schema can be automatically generated using TapirSchemaToJsonSchema functionality. All we need to do is to define case class with [Tapir Schema](https://tapir.softwaremill.com/en/latest/endpoint/schemas.html) defined for it.
-
-Another helpful feature is adding possibility to create `Message.Tool` object passing object instead of String, which will be automatically serialized to Json. All you have to do is just define a circe `Encoder` for the specific class.
-
-With all this in mind please remember that it is still required to deserialized arguments, which are sent back by Assistant to call our function.
-
-```scala mdoc:compile-only
-//> using dep com.softwaremill.sttp.ai::openai:@VERSION@
-
-import sttp.ai.openai.OpenAISyncClient
-import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatBody
-import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel.GPT4oMini
-import sttp.ai.openai.requests.completions.chat.ToolCall.FunctionToolCall
-import sttp.ai.openai.requests.completions.chat.message.Content.TextContent
-import sttp.ai.openai.requests.completions.chat.message.Message.{Assistant, Tool, User}
-import sttp.ai.openai.requests.completions.chat.message.Tool.Function
-import sttp.tapir.generic.auto.*
-
-case class Passenger(name: String, age: Int)
-
-object Passenger:
-  given io.circe.Decoder[Passenger] = io.circe.generic.semiauto.deriveDecoder[Passenger]
-
-case class FlightDetails(passenger: Passenger, departureCity: String, destinationCity: String)
-
-object FlightDetails:
-  given io.circe.Decoder[FlightDetails] = io.circe.generic.semiauto.deriveDecoder[FlightDetails]
-
-case class BookedFlight(confirmationNumber: String, status: String)
-
-object BookedFlight:
-  given io.circe.Encoder[BookedFlight] = io.circe.generic.semiauto.deriveEncoder[BookedFlight]
-
-object Main:
-  def main(args: Array[String]): Unit =
-    val apiKey = System.getenv("OPENAI_KEY")
-    val openAI = OpenAISyncClient(apiKey)
-
-    val initialRequestMessage = Seq(User(content = TextContent("I want to book a flight from London to Tokyo for Jane Doe, age 34")))
-
-    // Request created using Tool.Function.withSchema, all we need to do here is just define the type. The schema is automatically generated using a macro, available via the `sttp.tapir.generic.auto.*` import.
-    val givenRequest = ChatBody(
-      model = GPT4oMini,
-      messages = initialRequestMessage,
-      tools = Some(Seq(
-        Function.withSchema[FlightDetails](
-          name = "book_flight",
-          description = Some("Books a flight for a passenger with full details")))
-      )
-    )
-
-    val initialRequestResult = openAI.createChatCompletion(givenRequest)
-
-    println(initialRequestResult.choices)
-    /*
-      List(
-        Choices(
-          Message(
-            null,
-            None,
-            List(
-              FunctionToolCall(
-                Some(call_XZNvfldLQTa1f7aMInswpTMS),
-                FunctionCall(
-                  {
-                    "passenger": {
-                      "name": "Jane Doe",
-                      "age": 34
-                    },
-                    "departureCity": "London",
-                    "destinationCity": "Tokyo"
-                  },
-                  Some(book_flight)
-                )
-              )
-            ),
-            Assistant,
-            None,
-            None
-          ),
-          tool_calls,
-          0,
-          None
-        )
-      )
-      */
-
-    // Helper function that mimics external function definition
-    def bookFlight(flightDetails: FlightDetails): BookedFlight =
-      println(flightDetails)
-      BookedFlight(confirmationNumber = "123456", status = "confirmed")
-
-    // Tool calls list (in this example it is just single tool call, but there may be multiple), which is necessary to build message list for second request.
-    val toolCalls = initialRequestResult.choices.head.message.toolCalls
-
-    val functionToolCall = toolCalls.head match
-      case functionToolCall: FunctionToolCall => functionToolCall
-
-    // Function arguments are manually deserialized, 'bookFlight' function mimic external function definition.
-    val bookedFlight = bookFlight(io.circe.parser.decode[FlightDetails](functionToolCall.function.arguments).toTry.get)
-
-    val secondRequest = givenRequest.copy(
-      messages = initialRequestMessage
-        :+ Assistant(content = "", toolCalls = toolCalls)
-        // Tool message created using object instead of String with Json representation of object.
-        :+ Tool(toolCallId = functionToolCall.id.get, content = bookedFlight)
-    )
-
-    val finalResult = openAI.createChatCompletion(secondRequest)
-
-    println(finalResult.choices)
-    /*
-      List(
-        Choices(
-          Message(
-            "The flight from London to Tokyo for Jane Doe, age 34, has been successfully booked. The confirmation number is **123456** and the status is **confirmed**.",
-            None,
-            List(),
-            Assistant,
-            None,
-            None
-          ),
-          stop,
-          0,
-          None
-        )
-      )
-      */
-```
-
-> **Note:** normalization is applied only when `strict = true` is requested; otherwise the schema is encoded
-> faithfully, unchanged. When a schema *is* normalized for strict mode, `additionalProperties: false` is set on every
-> object, all properties are listed as `required`, and properties that were optional in the source schema (absent
-> from its original `required` list) are made nullable — the model returns `null` for them instead of inventing a
-> value. If you decode structured outputs into classes with non-`Option` fields, mark optional fields as `Option` or
-> list them as required in your schema.

--- a/docs/openai/tool-calling.md
+++ b/docs/openai/tool-calling.md
@@ -1,0 +1,144 @@
+# Tool calling
+
+Tools (also called function calling) let the model request that your application execute a function and report its result back. Each tool is described to the model by a name, a description, and a JSON Schema for its parameters — see [JSON Schemas: structured outputs & tools](../other/json-schemas.md) for all the ways to produce one.
+
+## Calling a tool with `Tool.Function.withSchema[T]`
+
+The example below books a flight using a function tool. The flow:
+
+- The user sends a message asking to book a flight, together with a function tool definition — meaning there is a function on the client side which knows how to book a flight. The tool definition carries a JSON Schema describing the function's arguments.
+- The assistant responds with a tool call: arguments matching that schema.
+- The application decodes the arguments, calls the actual function, and sends its result back to the assistant.
+- The assistant produces the final answer.
+
+The key point is `Tool.Function.withSchema[T]`: the JSON Schema for the arguments is generated automatically from the case class `T`, which only needs a [Tapir Schema](https://tapir.softwaremill.com/en/latest/endpoint/schemas.html). A related convenience is creating the `Message.Tool` reply from an object rather than a JSON string — it is serialized automatically given a circe `Encoder`.
+
+Note that the arguments sent back by the assistant still need to be deserialized manually before calling the function.
+
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::openai:@VERSION@
+
+import sttp.ai.openai.OpenAISyncClient
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatBody
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel.GPT4oMini
+import sttp.ai.openai.requests.completions.chat.ToolCall.FunctionToolCall
+import sttp.ai.openai.requests.completions.chat.message.Content.TextContent
+import sttp.ai.openai.requests.completions.chat.message.Message.{Assistant, Tool, User}
+import sttp.ai.openai.requests.completions.chat.message.Tool.Function
+import sttp.tapir.generic.auto.*
+
+case class Passenger(name: String, age: Int)
+
+object Passenger:
+  given io.circe.Decoder[Passenger] = io.circe.generic.semiauto.deriveDecoder[Passenger]
+
+case class FlightDetails(passenger: Passenger, departureCity: String, destinationCity: String)
+
+object FlightDetails:
+  given io.circe.Decoder[FlightDetails] = io.circe.generic.semiauto.deriveDecoder[FlightDetails]
+
+case class BookedFlight(confirmationNumber: String, status: String)
+
+object BookedFlight:
+  given io.circe.Encoder[BookedFlight] = io.circe.generic.semiauto.deriveEncoder[BookedFlight]
+
+object Main:
+  def main(args: Array[String]): Unit =
+    val apiKey = System.getenv("OPENAI_KEY")
+    val openAI = OpenAISyncClient(apiKey)
+
+    val initialRequestMessage = Seq(User(content = TextContent("I want to book a flight from London to Tokyo for Jane Doe, age 34")))
+
+    // Request created using Tool.Function.withSchema, all we need to do here is just define the type. The schema is automatically generated using a macro, available via the `sttp.tapir.generic.auto.*` import.
+    val givenRequest = ChatBody(
+      model = GPT4oMini,
+      messages = initialRequestMessage,
+      tools = Some(Seq(
+        Function.withSchema[FlightDetails](
+          name = "book_flight",
+          description = Some("Books a flight for a passenger with full details")))
+      )
+    )
+
+    val initialRequestResult = openAI.createChatCompletion(givenRequest)
+
+    println(initialRequestResult.choices)
+    /*
+      List(
+        Choices(
+          Message(
+            null,
+            None,
+            List(
+              FunctionToolCall(
+                Some(call_XZNvfldLQTa1f7aMInswpTMS),
+                FunctionCall(
+                  {
+                    "passenger": {
+                      "name": "Jane Doe",
+                      "age": 34
+                    },
+                    "departureCity": "London",
+                    "destinationCity": "Tokyo"
+                  },
+                  Some(book_flight)
+                )
+              )
+            ),
+            Assistant,
+            None,
+            None
+          ),
+          tool_calls,
+          0,
+          None
+        )
+      )
+      */
+
+    // Helper function that mimics external function definition
+    def bookFlight(flightDetails: FlightDetails): BookedFlight =
+      println(flightDetails)
+      BookedFlight(confirmationNumber = "123456", status = "confirmed")
+
+    // Tool calls list (in this example it is just single tool call, but there may be multiple), which is necessary to build message list for second request.
+    val toolCalls = initialRequestResult.choices.head.message.toolCalls
+
+    val functionToolCall = toolCalls.head match
+      case functionToolCall: FunctionToolCall => functionToolCall
+
+    // Function arguments are manually deserialized, 'bookFlight' function mimic external function definition.
+    val bookedFlight = bookFlight(io.circe.parser.decode[FlightDetails](functionToolCall.function.arguments).toTry.get)
+
+    val secondRequest = givenRequest.copy(
+      messages = initialRequestMessage
+        :+ Assistant(content = "", toolCalls = toolCalls)
+        // Tool message created using object instead of String with Json representation of object.
+        :+ Tool(toolCallId = functionToolCall.id.get, content = bookedFlight)
+    )
+
+    val finalResult = openAI.createChatCompletion(secondRequest)
+
+    println(finalResult.choices)
+    /*
+      List(
+        Choices(
+          Message(
+            "The flight from London to Tokyo for Jane Doe, age 34, has been successfully booked. The confirmation number is **123456** and the status is **confirmed**.",
+            None,
+            List(),
+            Assistant,
+            None,
+            None
+          ),
+          stop,
+          0,
+          None
+        )
+      )
+      */
+```
+
+## Using the agent loop
+
+For a full automatic tool-calling loop — the model calls a tool, your code runs it, the result is fed back, repeat until the model produces a final answer — use `OpenAIAgent` instead of driving `createChatCompletion` by hand: see the [agent loop](../agents/quickstart.md).

--- a/docs/other/json-schemas.md
+++ b/docs/other/json-schemas.md
@@ -1,0 +1,85 @@
+# JSON Schemas: structured outputs & tools
+
+Two features, available for all providers, need a [JSON Schema](https://json-schema.org):
+
+* **Structured outputs** — constraining the model's response to a given shape, then parsing it into a case class ([OpenAI](../openai/structured-outputs.md), [Claude](../claude/structured-outputs.md), [Gemini](../gemini/structured-outputs.md))
+* **Tool calling** — describing the parameters of a tool the model may call ([OpenAI](../openai/tool-calling.md), [Claude](../claude/tool-calling.md), [Gemini](../gemini/tool-calling.md)), including [agent-loop tools](../agents/tools.md)
+
+This page covers the ways to produce such a schema, from fully automatic to fully manual. The provider pages show where to plug the schema in.
+
+## What's needed
+
+Most schema-accepting APIs in this library take a `sttp.apispec.Schema` — the JSON Schema model shared with [Tapir](https://tapir.softwaremill.com). A few take raw `io.circe.Json` instead (Gemini's `Tool.Function`, Claude's `Tool.CustomRaw`). In both cases a Tapir `Schema[T]` derived from a case class is the usual source. Parsing the model's response back into `T` additionally needs a [circe](https://circe.github.io/circe/) `Decoder[T]`.
+
+## The easiest way: derive from a case class
+
+In Scala 3, a `derives` clause supplies both the Tapir schema and the circe codec:
+
+```scala mdoc:compile-only
+import sttp.tapir.Schema
+
+case class Step(explanation: String, output: String) derives io.circe.Codec.AsObject, Schema
+case class MathReasoning(steps: List[Step], finalAnswer: String) derives io.circe.Codec.AsObject, Schema
+```
+
+In Scala 2, use `implicit val schema: Schema[MathReasoning] = Schema.derived` (or `import sttp.tapir.generic.auto.*`) together with circe's semi-automatic derivation.
+
+With these instances in scope, the high-level entry points derive and attach the schema automatically — you never build a schema value yourself:
+
+* `createChatCompletionAs[T]` (OpenAI), `createMessageAs[T]` (Claude), `createInteractionAs[T]` (Gemini) — structured outputs
+* `Tool.Function.withSchema[T]` (OpenAI) — tool parameter schemas
+* `AgentTool.fromFunction` and `deriveResponseSchema[T]` — [agent loop](../agents/tools.md) tool inputs and typed results
+
+## Customising the derived schema
+
+Underneath, the Tapir schema is converted to JSON Schema with [Tapir's `TapirSchemaToJsonSchema`](https://tapir.softwaremill.com/en/latest/docs/json-schema.html). You can run the conversion yourself to inspect or post-process the result:
+
+```scala mdoc:compile-only
+import sttp.apispec.{Schema => ASchema}
+import sttp.tapir.Schema
+import sttp.tapir.docs.apispec.schema.TapirSchemaToJsonSchema
+import sttp.tapir.generic.auto.*
+
+case class Step(explanation: String, output: String)
+case class MathReasoning(steps: List[Step], finalAnswer: String)
+
+val tSchema = implicitly[Schema[MathReasoning]]
+
+val jsonSchema: ASchema = TapirSchemaToJsonSchema(
+  tSchema,
+  markOptionsAsNullable = true
+)
+```
+
+To adjust what gets derived, customise the Tapir schema itself — field descriptions, encoded names, validators, and more, via annotations or explicit `Schema` instances; see [Tapir's schema documentation](https://tapir.softwaremill.com/en/latest/endpoint/schemas.html). `markOptionsAsNullable = true` renders `Option` fields as nullable in the JSON Schema.
+
+Note: when OpenAI structured outputs run in strict mode, the schema is additionally normalized by this library — see [strict mode and schema normalization](../openai/structured-outputs.md) for the details and caveats.
+
+## Building a schema manually
+
+If you prefer not to use Tapir derivation — or the schema doesn't correspond to any case class — build the `sttp.apispec.Schema` by hand:
+
+```scala mdoc:compile-only
+import scala.collection.immutable.ListMap
+import sttp.apispec.{Schema, SchemaType}
+
+val jsonSchema: Schema =
+  Schema(SchemaType.Object).copy(
+    properties = ListMap(
+      "steps" -> Schema(SchemaType.Array).copy(items =
+        Some(
+          Schema(SchemaType.Object).copy(properties =
+            ListMap(
+              "explanation" -> Schema(SchemaType.String),
+              "output" -> Schema(SchemaType.String)
+            )
+          )
+        )
+      ),
+      "finalAnswer" -> Schema(SchemaType.String)
+    ),
+    required = List("steps", "finalAnswer")
+  )
+```
+
+Where raw JSON is expected instead (Gemini's `Tool.Function` parameters, Claude's `Tool.CustomRaw`), build the `io.circe.Json` value directly — see the [Gemini structured-outputs page](../gemini/structured-outputs.md) for an example.


### PR DESCRIPTION
Schema derivation was explained (differently) in three structured-outputs pages and the agent-tools page. This PR gives it a single home and untangles the OpenAI structured-outputs page.

- Add a shared page `other/json-schemas.md`: what problem a JSON Schema solves → the easiest way (`derives` from a case class) → customising the derived schema (Tapir) → building one manually. All provider pages link here instead of re-explaining derivation
- Restructure `openai/structured-outputs.md` to a clear flow (typed `createChatCompletionAs[T]` → strict-mode normalization → lower-level `ResponseFormat.JsonSchema`) and extract the flight-booking function-tool walkthrough into a new dedicated `openai/tool-calling.md` — OpenAI previously was the only provider without a tool-calling page
- Align `claude/structured-outputs.md` with the same flow (the section titled "Basic" was actually the lower-level path) and compile-check its manual-schema snippet
- Link the Gemini structured-outputs and tool-calling pages to the shared schema page
- Give the tool-definition preamble in `agents/tools.md` a proper heading and compile-check its example