### PR TITLE
Docs/03 OpenAI

### DIFF
--- a/docs/openai/basics.md
+++ b/docs/openai/basics.md
@@ -1,10 +1,24 @@
-# OpenAI API
+# OpenAI API basics
 
-OpenAI API Official Documentation: https://platform.openai.com/docs/api-reference/completions
+This module provides direct access to the [OpenAI API](https://platform.openai.com/docs/api-reference). Examples are runnable using [scala-cli](https://scala-cli.virtuslab.org).
 
-Examples are runnable using [scala-cli](https://scala-cli.virtuslab.org).
+## Available features
 
-## Basic Usage (OpenAI)
+- ✅ **Chat completions** — see basic usage below
+- ✅ **Streaming** — [server-sent events streaming](streaming.md) for fs2, ZIO, Akka/Pekko Streams, and Ox
+- ✅ **Structured outputs** — [JSON-schema-constrained responses](structured-outputs.md) parsed into case classes
+- ✅ **Tool calling** — [function tools](tool-calling.md) with derived parameter schemas
+- ✅ **OpenAI-compatible providers** — [Ollama, Groq, OpenRouter, vLLM and others](compatible-apis.md)
+- ✅ **Agent loop** — [autonomous tool-calling agents](../agents/quickstart.md)
+- ✅ **Full API surface** — completions, embeddings, audio, images, files, fine-tuning, batches, assistants, moderations, and more
+- ✅ **Cross-platform** — Scala 2.13 and Scala 3
+
+## Sync and async clients
+
+- `OpenAISyncClient` — high-level and blocking: methods return the response directly and throw an `OpenAIException` subclass on error. The recommended default, used in most examples in these docs.
+- `OpenAI` — returns raw sttp-client4 `Request`s and parses responses as `Either[OpenAIException, A]`. Pair it with the sttp backend of your choice (cats-effect, ZIO, Akka/Pekko, Ox) — see [streaming](streaming.md) for effectful examples.
+
+## Basic usage
 
 ```scala mdoc:compile-only
 //> using dep com.softwaremill.sttp.ai::openai:@VERSION@
@@ -52,14 +66,19 @@ object Main:
     */
 ```
 
-> **Token limits on GPT-5 / reasoning models:** newer OpenAI reasoning models (GPT-5, o1, o3, ...) reject the `max_tokens`
-> parameter with `Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.`
-> For these models leave `maxTokens = None` and set `maxCompletionTokens`:
->
-> ```scala
-> val chatRequestBody = ChatBody(
->   model = ChatCompletionModel.GPT5,
->   messages = bodyMessages,
->   maxCompletionTokens = Some(1000)
-> )
-> ```
+## Token limits on reasoning models (GPT-5, o-series)
+
+Newer OpenAI reasoning models (GPT-5, o1, o3, ...) reject the `max_tokens` parameter with `Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.` For these models leave `maxTokens = None` and set `maxCompletionTokens`:
+
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::openai:@VERSION@
+
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.{ChatBody, ChatCompletionModel}
+import sttp.ai.openai.requests.completions.chat.message.*
+
+val chatRequestBody = ChatBody(
+  model = ChatCompletionModel.GPT5,
+  messages = Seq(Message.User(Content.TextContent("Hello!"))),
+  maxCompletionTokens = Some(1000)
+)
+```

--- a/docs/openai/compatible-apis.md
+++ b/docs/openai/compatible-apis.md
@@ -1,8 +1,8 @@
-# OpenAI-compatible APIs
+# OpenAI-compatible APIs: Ollama, Groq, OpenRouter
 
-## To use Ollama, Grok, or OpenRouter (OpenAI-compatible APIs)
+Any provider exposing an OpenAI-compatible endpoint works with the OpenAI client — pass the provider's base URL as the second argument. Named examples below; the same pattern applies to any other compatible provider.
 
-Ollama with sync backend:
+## Ollama
 
 ```scala mdoc:compile-only
 //> using dep com.softwaremill.sttp.ai::openai:@VERSION@
@@ -56,6 +56,78 @@ object Main:
   */
 ```
 
+## Groq
+
+Groq with cats-effect based backend:
+
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::openai:@VERSION@
+//> using dep com.softwaremill.sttp.client4::cats:4.0.0-M17
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import sttp.client4.httpclient.cats.HttpClientCatsBackend
+import sttp.model.Uri.*
+import sttp.ai.openai.OpenAI
+import sttp.ai.openai.OpenAIExceptions.OpenAIException
+import sttp.ai.openai.requests.completions.chat.ChatRequestResponseData.ChatResponse
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.{ChatBody, ChatCompletionModel}
+import sttp.ai.openai.requests.completions.chat.message.*
+
+object Main:
+  def main(args: Array[String]): Unit =
+    val apiKey = System.getenv("GROQ_API_KEY")
+    val openAI = new OpenAI(apiKey, uri"https://api.groq.com/openai/v1")
+
+    val bodyMessages: Seq[Message] = Seq(
+      Message.User(
+        content = Content.TextContent("Hello!"),
+      )
+    )
+
+    val chatRequestBody: ChatBody = ChatBody(
+      model = ChatCompletionModel.CustomChatCompletionModel("llama-3.1-8b-instant"),
+      messages = bodyMessages
+    )
+
+    val program = HttpClientCatsBackend.resource[IO]().use { backend =>
+      val response: IO[Either[OpenAIException, ChatResponse]] =
+        openAI
+          .createChatCompletion(chatRequestBody)
+          .send(backend)
+          .map(_.body)
+      val rethrownResponse: IO[ChatResponse] = response.rethrow
+      val redeemedResponse: IO[String] = rethrownResponse.redeem(
+        error => error.getMessage,
+        chatResponse => chatResponse.toString
+      )
+      redeemedResponse.flatMap(IO.println)
+    }
+
+    program.unsafeRunSync()
+  /*
+    ChatResponse(
+      "chatcmpl-e0f9f78c-5e74-494c-9599-da02fa495ff8",
+      List(
+        Choices(
+          Message(Assistant, "Hello! 👋 It's great to hear from you. What can I do for you today? 😊", List(), None),
+          "stop",
+          0
+        )
+      ),
+      1714667435,
+      "llama-3.1-8b-instant",
+      "chat.completion",
+      Usage(16, 21, 37),
+      Some("fp_f0c35fc854")
+    )
+  */
+```
+
+Grok (x.ai) works the same way — use `uri"https://api.x.ai/v1"` and a Grok model name.
+
+## OpenRouter
+
 OpenRouter with sync backend:
 
 ```scala mdoc:compile-only
@@ -108,7 +180,7 @@ object Main:
   */
 ```
 
-### Extra body parameters (vLLM, etc.)
+## Extra body parameters (vLLM and other extensions)
 
 Some OpenAI-compatible backends — vLLM in particular — accept request parameters that aren't part of the official OpenAI API and have no
 typed field on `ChatBody`, `CompletionsBody`, or `EmbeddingsBody` (e.g. vLLM's `guided_json` or `top_k`). Use `extraBody` to merge arbitrary
@@ -152,73 +224,7 @@ object Main:
     println(chatResponse)
 ```
 
-Grok with cats-effect based backend:
-
-```scala mdoc:compile-only
-//> using dep com.softwaremill.sttp.ai::openai:@VERSION@
-//> using dep com.softwaremill.sttp.client4::cats:4.0.0-M17
-
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
-import sttp.client4.httpclient.cats.HttpClientCatsBackend
-import sttp.model.Uri.*
-import sttp.ai.openai.OpenAI
-import sttp.ai.openai.OpenAIExceptions.OpenAIException
-import sttp.ai.openai.requests.completions.chat.ChatRequestResponseData.ChatResponse
-import sttp.ai.openai.requests.completions.chat.ChatRequestBody.{ChatBody, ChatCompletionModel}
-import sttp.ai.openai.requests.completions.chat.message.*
-
-object Main:
-  def main(args: Array[String]): Unit =
-    val apiKey = System.getenv("OPENAI_KEY")
-    val openAI = new OpenAI(apiKey, uri"https://api.groq.com/openai/v1")
-
-    val bodyMessages: Seq[Message] = Seq(
-      Message.User(
-        content = Content.TextContent("Hello!"),
-      )
-    )
-
-    val chatRequestBody: ChatBody = ChatBody(
-      model = ChatCompletionModel.CustomChatCompletionModel("gemma-7b-it"),
-      messages = bodyMessages
-    )
-
-    val program = HttpClientCatsBackend.resource[IO]().use { backend =>
-      val response: IO[Either[OpenAIException, ChatResponse]] =
-        openAI
-          .createChatCompletion(chatRequestBody)
-          .send(backend)
-          .map(_.body)
-      val rethrownResponse: IO[ChatResponse] = response.rethrow
-      val redeemedResponse: IO[String] = rethrownResponse.redeem(
-        error => error.getMessage,
-        chatResponse => chatResponse.toString
-      )
-      redeemedResponse.flatMap(IO.println)
-    }
-
-    program.unsafeRunSync()
-  /*
-    ChatResponse(
-      "chatcmpl-e0f9f78c-5e74-494c-9599-da02fa495ff8",
-      List(
-        Choices(
-          Message(Assistant, "Hello! 👋 It's great to hear from you. What can I do for you today? 😊", List(), None),
-          "stop",
-          0
-        )
-      ),
-      1714667435,
-      "gemma-7b-it",
-      "chat.completion",
-      Usage(16, 21, 37),
-      Some("fp_f0c35fc854")
-    )
-  */
-```
-
-### Available client implementations:
+## Client implementations
 
 * `OpenAISyncClient` which provides high-level methods to interact with OpenAI. All the methods send requests synchronously and are blocking, might throw `OpenAIException`
 * `OpenAI` which provides raw sttp-client4 `Request`s and parses `Response`s as `Either[OpenAIException, A]`

--- a/docs/openai/compatible-apis.md
+++ b/docs/openai/compatible-apis.md
@@ -1,4 +1,4 @@
-# OpenAI-compatible APIs: Ollama, Groq, OpenRouter
+# OpenAI-compatible APIs: Ollama, Grok, Groq, OpenRouter
 
 Any provider exposing an OpenAI-compatible endpoint works with the OpenAI client — pass the provider's base URL as the second argument. Named examples below; the same pattern applies to any other compatible provider.
 
@@ -56,7 +56,44 @@ object Main:
   */
 ```
 
+## Grok
+
+[Grok](https://x.ai) is xAI's model family, served from an OpenAI-compatible endpoint:
+
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::openai:@VERSION@
+
+import sttp.model.Uri.*
+import sttp.ai.openai.OpenAISyncClient
+import sttp.ai.openai.requests.completions.chat.ChatRequestResponseData.ChatResponse
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.{ChatBody, ChatCompletionModel}
+import sttp.ai.openai.requests.completions.chat.message.*
+
+object Main:
+  def main(args: Array[String]): Unit =
+    val openAI: OpenAISyncClient = OpenAISyncClient(System.getenv("XAI_API_KEY"), uri"https://api.x.ai/v1")
+
+    val bodyMessages: Seq[Message] = Seq(
+      Message.User(
+        content = Content.TextContent("Hello!"),
+      )
+    )
+
+    val chatRequestBody: ChatBody = ChatBody(
+      model = ChatCompletionModel.CustomChatCompletionModel("grok-4"),
+      messages = bodyMessages
+    )
+
+    // be aware that calling `createChatCompletion` may throw an OpenAIException
+    // e.g. AuthenticationException, RateLimitException and many more
+    val chatResponse: ChatResponse = openAI.createChatCompletion(chatRequestBody)
+
+    println(chatResponse)
+```
+
 ## Groq
+
+[Groq](https://groq.com) runs open models (Llama, Gemma, ...) on its LPU hardware, exposed via an OpenAI-compatible endpoint:
 
 Groq with cats-effect based backend:
 
@@ -123,8 +160,6 @@ object Main:
     )
   */
 ```
-
-Grok (x.ai) works the same way — use `uri"https://api.x.ai/v1"` and a Grok model name.
 
 ## OpenRouter
 

--- a/docs/openai/streaming.md
+++ b/docs/openai/streaming.md
@@ -1,21 +1,18 @@
 # Streaming
 
-## Create completion with streaming:
+The Chat Completions API can stream responses as server-sent events. Add the streaming module for your chosen library — [fs2](https://fs2.io), [ZIO](https://zio.dev), [Akka Streams](https://doc.akka.io/libraries/akka-core/current/stream/) / [Pekko Streams](https://pekko.apache.org/docs/pekko/current/stream/), or [Ox](https://github.com/softwaremill/ox) — and an extension method `createStreamedChatCompletion` becomes available on the `OpenAI` client, returning a stream of `ChatChunkResponse` events.
 
-To enable streaming support for the Chat Completion API using server-sent events, you must include the appropriate
-dependency for your chosen streaming library. We provide support for the following libraries: _fs2_, _ZIO_, _Akka / Pekko Streams_ and _Ox_.
-
-For example, to use `fs2` add the following dependency & import:
+## Using fs2 (cats-effect)
 
 ```scala
 // sbt dependency
 "com.softwaremill.sttp.ai" %% "fs2" % "@VERSION@"
 
-// import 
+// import
 import sttp.ai.openai.streaming.fs2.*
 ```
 
-Example below uses `HttpClientFs2Backend` as a backend:
+The example below uses `HttpClientFs2Backend` as a backend:
 
 ```scala mdoc:compile-only
 //> using dep com.softwaremill.sttp.ai::fs2:@VERSION@
@@ -95,19 +92,82 @@ object Main:
    */
 ```
 
-To use direct-style streaming (requires Scala 3) add the following dependency & import:
+## Using ZIO
+
+```scala
+// sbt dependency
+"com.softwaremill.sttp.ai" %% "zio" % "@VERSION@"
+
+// import
+import sttp.ai.openai.streaming.zio.*
+```
+
+The example below uses `HttpClientZioBackend` as a backend:
+
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::zio:@VERSION@
+
+import sttp.ai.openai.OpenAI
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.{ChatBody, ChatCompletionModel}
+import sttp.ai.openai.requests.completions.chat.message.*
+import sttp.ai.openai.streaming.zio.*
+import sttp.client4.httpclient.zio.HttpClientZioBackend
+import zio.*
+
+object Main extends ZIOAppDefault:
+  override def run =
+    val openAI = new OpenAI(java.lang.System.getenv("OPENAI_KEY"))
+
+    val chatRequestBody: ChatBody = ChatBody(
+      model = ChatCompletionModel.GPT4oMini,
+      messages = Seq(Message.User(Content.TextContent("Hello!")))
+    )
+
+    ZIO.scoped {
+      for {
+        backend <- HttpClientZioBackend.scoped()
+        response <- openAI.createStreamedChatCompletion(chatRequestBody).send(backend)
+        _ <- response.body match {
+          case Left(exception) => Console.printLine(exception.getMessage)
+          case Right(stream)   => stream.tap(chunk => Console.printLine(chunk.toString)).runDrain
+        }
+      } yield ()
+    }
+```
+
+## Using Akka / Pekko Streams
+
+Both are supported with the same extension method; add the module and import for the one you use (Akka is Scala 2.13 only):
+
+```scala
+// sbt dependency — Akka Streams (Scala 2.13 only):
+"com.softwaremill.sttp.ai" %% "akka" % "@VERSION@"
+// import
+import sttp.ai.openai.streaming.akka.*
+
+// sbt dependency — Pekko Streams:
+"com.softwaremill.sttp.ai" %% "pekko" % "@VERSION@"
+// import
+import sttp.ai.openai.streaming.pekko.*
+```
+
+Use `AkkaHttpBackend` / `PekkoHttpBackend` and consume the resulting `Source[ChatChunkResponse, _]` as in the fs2 and ZIO examples above.
+
+## Using Ox (Scala 3)
+
+Direct-style streaming, without an effect system:
 
 ```scala
 // sbt dependency
 "com.softwaremill.sttp.ai" %% "ox" % "@VERSION@"
 
-// import 
+// import
 import sttp.ai.openai.streaming.ox.*
 ```
 
 Example code:
 
-```scala
+```scala mdoc:compile-only
 //> using dep com.softwaremill.sttp.ai::ox:@VERSION@
 
 import ox.*


### PR DESCRIPTION
Brings the OpenAI pages up to the structure the Claude/Gemini pages already have.

- Rework `openai/basics.md`: retitle to "OpenAI API basics", add a linkified "Available features" list (matching Claude/Gemini), a short sync-vs-async clients section establishing `OpenAISyncClient` as the recommended default, hyperlink the previously-bare official-docs URL, and promote the GPT-5/reasoning-models token-limit note from a blockquote into a proper (now compile-checked) section
- Restructure `openai/streaming.md` into per-effect-system sections: fs2, ZIO (new, compile-checked example), Akka/Pekko (deps + imports; Akka is Scala 2.13-only and not on the docs classpath), and Ox — the Ox example is now mdoc-verified for the first time. First mentions of fs2/ZIO/Akka/Pekko/Ox link to their project sites
- Restructure `openai/compatible-apis.md`: providers named in the title, flat top-level sections (Ollama, Groq, OpenRouter, extra body parameters, client implementations), and fix the Grok/Groq mixup — the example targets `api.groq.com`, so the section is named Groq, with a note that Grok (x.ai) works the same way via its base URL