### PR TITLE
Azure OpenAI support

### DIFF
--- a/INTEGRATION_TESTING.md
+++ b/INTEGRATION_TESTING.md
@@ -23,6 +23,25 @@ export OPENAI_API_KEY=your-openai-api-key-here
 export ANTHROPIC_API_KEY=your-anthropic-api-key-here
 ```
 
+### Azure OpenAI
+
+To run the Azure OpenAI integration tests, set:
+
+```bash
+export AZURE_OPENAI_API_KEY=your-azure-api-key
+export AZURE_OPENAI_ENDPOINT="https://my-resource.openai.azure.com/openai/deployments/gpt-4o-mini?api-version=2024-10-21"
+# optional - deployment name sent in the request body (defaults to gpt-4o-mini)
+export AZURE_OPENAI_DEPLOYMENT=gpt-4o-mini
+```
+
+`AZURE_OPENAI_ENDPOINT` must be the full base URL including the deployment path and `api-version` query. Then run:
+
+```bash
+sbt "testOnly *AzureOpenAIIntegrationSpec"
+```
+
+If the variables are not set, the tests are skipped (not failed).
+
 ### Running Tests
 
 #### Run all integration tests:

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,14 +4,14 @@ sttp is a family of Scala HTTP-related projects, and currently includes:
 
 * [sttp client](https://github.com/softwaremill/sttp): the Scala HTTP client you always wanted!
 * [sttp tapir](https://github.com/softwaremill/tapir): typed API descriptions
-* sttp ai: this project. Non-official Scala client wrapper for OpenAI, Claude (Anthropic), Gemini (Google), and OpenAI-compatible APIs (e.g. Ollama, Grok, Groq, OpenRouter). Use the power of ChatGPT, Claude, and Gemini inside your code!
+* sttp ai: this project. Non-official Scala client wrapper for OpenAI, Claude (Anthropic), Gemini (Google), and OpenAI-compatible APIs (e.g. Azure OpenAI, Ollama, Grok, Groq, OpenRouter). Use the power of ChatGPT, Claude, and Gemini inside your code!
 
 sttp-ai uses [sttp client](https://github.com/softwaremill/sttp) to describe requests and responses as plain, type-safe Scala values — request bodies, response models, JSON schemas, and tool definitions are all derived from case classes via [Tapir](https://tapir.softwaremill.com) and [circe](https://circe.github.io/circe/), with minimal ceremony and no hand-written JSON.
 
 ## What can you do with sttp-ai?
 
 * **Call model APIs directly** — [OpenAI](openai/basics.md) (chat completions, embeddings, audio, images, and more), [Claude](claude/basics.md) (Messages API), and [Gemini](gemini/basics.md) (Interactions API); each provider has a blocking sync client and a raw-request async client that works with any effect system
-* **Use OpenAI-compatible providers** — [Ollama, Grok, Groq, OpenRouter, vLLM and others](openai/compatible-apis.md) via the OpenAI client with a custom base URL
+* **Use OpenAI-compatible providers** — [Azure OpenAI, Ollama, Grok, Groq, OpenRouter, vLLM and others](openai/compatible-apis.md) via the OpenAI client with a custom base URL
 * **Stream responses** — [server-sent events streaming](openai/streaming.md) for fs2, ZIO, Akka Streams, Pekko Streams, and Ox
 * **Get structured outputs** — [JSON-schema-constrained responses](other/json-schemas.md) parsed straight into your case classes ([OpenAI](openai/structured-outputs.md), [Claude](claude/structured-outputs.md), [Gemini](gemini/structured-outputs.md))
 * **Call tools** — let the model invoke functions in your code ([OpenAI](openai/tool-calling.md), [Claude](claude/tool-calling.md), [Gemini](gemini/tool-calling.md))

--- a/docs/openai/compatible-apis.md
+++ b/docs/openai/compatible-apis.md
@@ -1,6 +1,44 @@
-# OpenAI-compatible APIs: Ollama, Grok, Groq, OpenRouter
+# OpenAI-compatible APIs: Azure OpenAI, Ollama, Grok, Groq, OpenRouter
 
 Any provider exposing an OpenAI-compatible endpoint works with the OpenAI client — pass the provider's base URL as the second argument. Named examples below; the same pattern applies to any other compatible provider.
+
+## Azure OpenAI
+
+Azure OpenAI's API-key authentication uses an `api-key: <key>` header instead of the standard `Authorization: Bearer <key>`. Pass `AuthScheme.AzureApiKey` together with your deployment's endpoint URL (including the `api-version` query parameter — it is preserved on every request):
+
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::openai:@VERSION@
+
+import sttp.model.Uri.*
+import sttp.ai.openai.{AuthScheme, OpenAISyncClient}
+import sttp.ai.openai.requests.completions.chat.ChatRequestResponseData.ChatResponse
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.{ChatBody, ChatCompletionModel}
+import sttp.ai.openai.requests.completions.chat.message.*
+
+object Main:
+  def main(args: Array[String]): Unit =
+    val openAI: OpenAISyncClient = OpenAISyncClient(
+      System.getenv("AZURE_OPENAI_API_KEY"),
+      uri"https://my-resource.openai.azure.com/openai/deployments/gpt-4o?api-version=2024-10-21",
+      AuthScheme.AzureApiKey
+    )
+
+    val chatRequestBody: ChatBody = ChatBody(
+      // for deployment-scoped endpoints the model is selected by the URL's deployment path;
+      // the body's model field is ignored by Azure but required by the API shape
+      model = ChatCompletionModel.CustomChatCompletionModel("gpt-4o"),
+      messages = Seq(
+        Message.User(
+          content = Content.TextContent("Hello!")
+        )
+      )
+    )
+
+    val chatResponse: ChatResponse = openAI.createChatCompletion(chatRequestBody)
+    println(chatResponse)
+```
+
+The newer Azure `/openai/v1/` endpoint also accepts standard Bearer authentication with the API key, so it works like any other OpenAI-compatible provider — pass `uri"https://my-resource.openai.azure.com/openai/v1"` as the base URL and keep the default auth scheme.
 
 ## Ollama
 

--- a/openai/src/main/scala/sttp/ai/openai/AuthScheme.scala
+++ b/openai/src/main/scala/sttp/ai/openai/AuthScheme.scala
@@ -5,9 +5,17 @@ package sttp.ai.openai
   *   - [[AuthScheme.Bearer]] sends `Authorization: Bearer <key>` — OpenAI and most compatible providers (default).
   *   - [[AuthScheme.AzureApiKey]] sends `api-key: <key>` — Azure OpenAI deployment endpoints.
   */
-sealed trait AuthScheme
+sealed trait AuthScheme {
+
+  /** The header (name -> value) carrying the given API key under this scheme. */
+  def authHeader(apiKey: String): (String, String)
+}
 
 object AuthScheme {
-  case object Bearer extends AuthScheme
-  case object AzureApiKey extends AuthScheme
+  case object Bearer extends AuthScheme {
+    override def authHeader(apiKey: String): (String, String) = "Authorization" -> s"Bearer $apiKey"
+  }
+  case object AzureApiKey extends AuthScheme {
+    override def authHeader(apiKey: String): (String, String) = "api-key" -> apiKey
+  }
 }

--- a/openai/src/main/scala/sttp/ai/openai/AuthScheme.scala
+++ b/openai/src/main/scala/sttp/ai/openai/AuthScheme.scala
@@ -1,0 +1,13 @@
+package sttp.ai.openai
+
+/** Controls how the API key is attached to outgoing requests.
+  *
+  *   - [[AuthScheme.Bearer]] sends `Authorization: Bearer <key>` — OpenAI and most compatible providers (default).
+  *   - [[AuthScheme.AzureApiKey]] sends `api-key: <key>` — Azure OpenAI deployment endpoints.
+  */
+sealed trait AuthScheme
+
+object AuthScheme {
+  case object Bearer extends AuthScheme
+  case object AzureApiKey extends AuthScheme
+}

--- a/openai/src/main/scala/sttp/ai/openai/OpenAI.scala
+++ b/openai/src/main/scala/sttp/ai/openai/OpenAI.scala
@@ -1633,7 +1633,7 @@ class OpenAI(
 object OpenAI {
 
   def apply(config: OpenAIConfig): OpenAI =
-    new OpenAI(config.apiKey, config.baseUrl, config.organization)
+    new OpenAI(config.apiKey, config.baseUrl, config.organization, config.authScheme)
 
   def fromEnv: OpenAI = apply(OpenAIConfig.fromEnv)
 }

--- a/openai/src/main/scala/sttp/ai/openai/OpenAI.scala
+++ b/openai/src/main/scala/sttp/ai/openai/OpenAI.scala
@@ -1616,10 +1616,8 @@ class OpenAI(
       .response(asJson_parseErrors[DeleteAdminApiKeyResponse])
 
   protected def openAIAuthRequest: PartialRequest[Either[String, String]] = {
-    val baseReq = authScheme match {
-      case AuthScheme.Bearer      => basicRequest.auth.bearer(authToken)
-      case AuthScheme.AzureApiKey => basicRequest.header("api-key", authToken)
-    }
+    val (authHeaderName, authHeaderValue) = authScheme.authHeader(authToken)
+    val baseReq = basicRequest.header(authHeaderName, authHeaderValue)
     organization match {
       case Some(org) => baseReq.header("OpenAI-Organization", org)
       case None      => baseReq

--- a/openai/src/main/scala/sttp/ai/openai/OpenAI.scala
+++ b/openai/src/main/scala/sttp/ai/openai/OpenAI.scala
@@ -61,7 +61,12 @@ import java.io.{File, InputStream}
 import java.nio.file.Paths
 import sttp.ai.openai.config.OpenAIConfig
 
-class OpenAI(authToken: String, baseUri: Uri = OpenAIUris.OpenAIBaseUri, organization: Option[String] = None) {
+class OpenAI(
+    authToken: String,
+    baseUri: Uri = OpenAIUris.OpenAIBaseUri,
+    organization: Option[String] = None,
+    authScheme: AuthScheme = AuthScheme.Bearer
+) {
 
   private val openAIUris = new OpenAIUris(baseUri)
 
@@ -1611,7 +1616,10 @@ class OpenAI(authToken: String, baseUri: Uri = OpenAIUris.OpenAIBaseUri, organiz
       .response(asJson_parseErrors[DeleteAdminApiKeyResponse])
 
   protected def openAIAuthRequest: PartialRequest[Either[String, String]] = {
-    val baseReq = basicRequest.auth.bearer(authToken)
+    val baseReq = authScheme match {
+      case AuthScheme.Bearer      => basicRequest.auth.bearer(authToken)
+      case AuthScheme.AzureApiKey => basicRequest.header("api-key", authToken)
+    }
     organization match {
       case Some(org) => baseReq.header("OpenAI-Organization", org)
       case None      => baseReq

--- a/openai/src/main/scala/sttp/ai/openai/OpenAISyncClient.scala
+++ b/openai/src/main/scala/sttp/ai/openai/OpenAISyncClient.scala
@@ -64,10 +64,11 @@ class OpenAISyncClient private (
     closeClient: Boolean,
     baseUri: Uri,
     customizeRequest: CustomizeOpenAIRequest,
-    organization: Option[String] = None
+    organization: Option[String] = None,
+    authScheme: AuthScheme = AuthScheme.Bearer
 ) {
 
-  private val openAI = new OpenAI(authToken, baseUri, organization)
+  private val openAI = new OpenAI(authToken, baseUri, organization, authScheme)
 
   /** Lists the currently available models, and provides basic information about each one such as the owner and availability.
     *
@@ -1217,7 +1218,7 @@ class OpenAISyncClient private (
     * will be applied before the given one.
     */
   def customizeRequest(customize: CustomizeOpenAIRequest): OpenAISyncClient =
-    new OpenAISyncClient(authToken, backend, closeClient, baseUri, customizeRequest.andThen(customize))
+    new OpenAISyncClient(authToken, backend, closeClient, baseUri, customizeRequest.andThen(customize), organization, authScheme)
 
   private def sendOrThrow[A](request: Request[Either[OpenAIException, A]]): A =
     customizeRequest.apply(request).send(backend).body match {
@@ -1236,6 +1237,11 @@ object OpenAISyncClient {
   def apply(authToken: String, baseUrl: Uri) =
     new OpenAISyncClient(authToken, DefaultSyncBackend(), true, baseUrl, CustomizeOpenAIRequest.Identity)
 
+  def apply(authToken: String, backend: SyncBackend, baseUrl: Uri, authScheme: AuthScheme) =
+    new OpenAISyncClient(authToken, backend, false, baseUrl, CustomizeOpenAIRequest.Identity, None, authScheme)
+  def apply(authToken: String, baseUrl: Uri, authScheme: AuthScheme) =
+    new OpenAISyncClient(authToken, DefaultSyncBackend(), true, baseUrl, CustomizeOpenAIRequest.Identity, None, authScheme)
+
   def apply(config: OpenAIConfig): OpenAISyncClient =
     new OpenAISyncClient(
       config.apiKey,
@@ -1243,11 +1249,20 @@ object OpenAISyncClient {
       true,
       config.baseUrl,
       CustomizeOpenAIRequest.Identity,
-      config.organization
+      config.organization,
+      config.authScheme
     )
 
   def apply(config: OpenAIConfig, backend: SyncBackend): OpenAISyncClient =
-    new OpenAISyncClient(config.apiKey, backend, false, config.baseUrl, CustomizeOpenAIRequest.Identity, config.organization)
+    new OpenAISyncClient(
+      config.apiKey,
+      backend,
+      false,
+      config.baseUrl,
+      CustomizeOpenAIRequest.Identity,
+      config.organization,
+      config.authScheme
+    )
 
   def fromEnv: OpenAISyncClient = apply(OpenAIConfig.fromEnv)
 

--- a/openai/src/main/scala/sttp/ai/openai/config/OpenAIConfig.scala
+++ b/openai/src/main/scala/sttp/ai/openai/config/OpenAIConfig.scala
@@ -1,6 +1,7 @@
 package sttp.ai.openai.config
 
 import sttp.ai.core.config.AIClientConfig
+import sttp.ai.openai.AuthScheme
 import sttp.model.Uri
 
 import scala.concurrent.duration.{Duration, DurationInt}
@@ -17,18 +18,25 @@ import scala.concurrent.duration.{Duration, DurationInt}
   *   Maximum number of retry attempts (defaults to 3)
   * @param organization
   *   Optional organization identifier for OpenAI API
+  * @param authScheme
+  *   How the API key is attached to requests (Bearer by default; AzureApiKey for Azure OpenAI)
   */
 case class OpenAIConfig(
     apiKey: String,
     baseUrl: Uri = OpenAIConfig.DefaultBaseUrl,
     timeout: Duration = 60.seconds,
     maxRetries: Int = 3,
-    organization: Option[String] = None
+    organization: Option[String] = None,
+    authScheme: AuthScheme = AuthScheme.Bearer
 ) extends AIClientConfig {
 
   override def authHeaders: Map[String, String] = {
+    val authHeader = authScheme match {
+      case AuthScheme.Bearer      => "Authorization" -> s"Bearer $apiKey"
+      case AuthScheme.AzureApiKey => "api-key" -> apiKey
+    }
     val baseHeaders = Map(
-      "Authorization" -> s"Bearer $apiKey",
+      authHeader,
       "content-type" -> "application/json"
     )
     organization match {

--- a/openai/src/main/scala/sttp/ai/openai/config/OpenAIConfig.scala
+++ b/openai/src/main/scala/sttp/ai/openai/config/OpenAIConfig.scala
@@ -31,12 +31,8 @@ case class OpenAIConfig(
 ) extends AIClientConfig {
 
   override def authHeaders: Map[String, String] = {
-    val authHeader = authScheme match {
-      case AuthScheme.Bearer      => "Authorization" -> s"Bearer $apiKey"
-      case AuthScheme.AzureApiKey => "api-key" -> apiKey
-    }
     val baseHeaders = Map(
-      authHeader,
+      authScheme.authHeader(apiKey),
       "content-type" -> "application/json"
     )
     organization match {

--- a/openai/src/test/scala/sttp/ai/openai/openai/AuthSchemeSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/AuthSchemeSpec.scala
@@ -1,0 +1,28 @@
+package sttp.ai.openai
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.client4._
+import sttp.model.Uri
+
+class AuthSchemeSpec extends AnyFlatSpec with Matchers {
+  private val azureBase: Uri = uri"https://my-res.openai.azure.com/openai/deployments/gpt-4o?api-version=2024-10-21"
+
+  "OpenAI with the default auth scheme" should "send an Authorization: Bearer header" in {
+    val request = new OpenAI("test-token").getModels
+    request.headers.find(_.name.equalsIgnoreCase("Authorization")).map(_.value) shouldBe Some("Bearer test-token"): Unit
+    request.headers.exists(_.name.equalsIgnoreCase("api-key")) shouldBe false
+  }
+
+  "OpenAI with AuthScheme.AzureApiKey" should "send an api-key header and no Authorization header" in {
+    val request = new OpenAI("azure-key", azureBase, None, AuthScheme.AzureApiKey).getModels
+    request.headers.find(_.name.equalsIgnoreCase("api-key")).map(_.value) shouldBe Some("azure-key"): Unit
+    request.headers.exists(_.name.equalsIgnoreCase("Authorization")) shouldBe false
+  }
+
+  it should "still send the OpenAI-Organization header when organization is set" in {
+    val request = new OpenAI("azure-key", azureBase, Some("my-org"), AuthScheme.AzureApiKey).getModels
+    request.headers.find(_.name.equalsIgnoreCase("OpenAI-Organization")).map(_.value) shouldBe Some("my-org"): Unit
+    request.headers.find(_.name.equalsIgnoreCase("api-key")).map(_.value) shouldBe Some("azure-key")
+  }
+}

--- a/openai/src/test/scala/sttp/ai/openai/openai/AuthSchemeSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/AuthSchemeSpec.scala
@@ -2,6 +2,7 @@ package sttp.ai.openai
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.ai.openai.config.OpenAIConfig
 import sttp.client4._
 import sttp.model.Uri
 
@@ -24,5 +25,24 @@ class AuthSchemeSpec extends AnyFlatSpec with Matchers {
     val request = new OpenAI("azure-key", azureBase, Some("my-org"), AuthScheme.AzureApiKey).getModels
     request.headers.find(_.name.equalsIgnoreCase("OpenAI-Organization")).map(_.value) shouldBe Some("my-org"): Unit
     request.headers.find(_.name.equalsIgnoreCase("api-key")).map(_.value) shouldBe Some("azure-key")
+  }
+
+  "OpenAIConfig.authHeaders" should "contain a bearer Authorization header by default" in {
+    val headers = OpenAIConfig(apiKey = "test-token").authHeaders
+    headers.get("Authorization") shouldBe Some("Bearer test-token"): Unit
+    headers.contains("api-key") shouldBe false
+  }
+
+  it should "contain an api-key header for the AzureApiKey scheme" in {
+    val headers = OpenAIConfig(apiKey = "azure-key", authScheme = AuthScheme.AzureApiKey).authHeaders
+    headers.get("api-key") shouldBe Some("azure-key"): Unit
+    headers.contains("Authorization") shouldBe false
+  }
+
+  "OpenAI built from a config with AzureApiKey" should "send the api-key header" in {
+    val config = OpenAIConfig(apiKey = "azure-key", baseUrl = azureBase, authScheme = AuthScheme.AzureApiKey)
+    val request = OpenAI(config).getModels
+    request.headers.find(_.name.equalsIgnoreCase("api-key")).map(_.value) shouldBe Some("azure-key"): Unit
+    request.headers.exists(_.name.equalsIgnoreCase("Authorization")) shouldBe false
   }
 }

--- a/openai/src/test/scala/sttp/ai/openai/openai/client/SyncClientSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/client/SyncClientSpec.scala
@@ -19,7 +19,7 @@ import sttp.ai.openai.json.OpenAIManualCodecs._
 import sttp.ai.openai.requests.completions.chat.ChatRequestBody.{ChatBody, ChatCompletionModel}
 import sttp.ai.openai.requests.models.ModelsResponseData._
 import sttp.ai.openai.requests.responses.ResponsesModel.GPT4oMini
-import sttp.ai.openai.{CustomizeOpenAIRequest, OpenAISyncClient}
+import sttp.ai.openai.{AuthScheme, CustomizeOpenAIRequest, OpenAISyncClient}
 import sttp.tapir.Schema
 
 import java.util.concurrent.atomic.AtomicReference
@@ -299,5 +299,24 @@ class SyncClientSpec extends AnyFlatSpec with Matchers with EitherValues {
     caught.code shouldBe expectedError.code: Unit
     caught.param shouldBe expectedError.param: Unit
     caught.`type` shouldBe expectedError.`type`
+  }
+
+  "OpenAISyncClient with AuthScheme.AzureApiKey" should "send the api-key header and no Authorization header" in {
+    // given
+    val azureBase = uri"https://my-res.openai.azure.com/openai/deployments/gpt-4o?api-version=2024-10-21"
+    val capturedRequest = new AtomicReference[GenericRequest[_, _]](null)
+    val syncBackendStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF { request =>
+      capturedRequest.set(request)
+      ResponseStub.adjust("""{"object":"list","data":[]}""", StatusCode.Ok)
+    }
+    val syncClient = OpenAISyncClient("azure-key", syncBackendStub, azureBase, AuthScheme.AzureApiKey)
+
+    // when (response body content is irrelevant - we only assert on the captured request)
+    scala.util.Try(syncClient.getModels): Unit
+
+    // then
+    val headers = capturedRequest.get().headers
+    headers.find(_.name.equalsIgnoreCase("api-key")).map(_.value) shouldBe Some("azure-key"): Unit
+    headers.exists(_.name.equalsIgnoreCase("Authorization")) shouldBe false
   }
 }

--- a/openai/src/test/scala/sttp/ai/openai/openai/integration/AzureOpenAIIntegrationSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/integration/AzureOpenAIIntegrationSpec.scala
@@ -54,7 +54,7 @@ class AzureOpenAIIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAn
       val chatBody = ChatBody(
         messages = Seq(Message.User(content = Content.TextContent("Say 'hello' and nothing else."))),
         model = ChatCompletionModel.CustomChatCompletionModel(sys.env.getOrElse("AZURE_OPENAI_DEPLOYMENT", "gpt-4o-mini")),
-        maxTokens = Some(10)
+        maxCompletionTokens = Some(50)
       )
 
       // when

--- a/openai/src/test/scala/sttp/ai/openai/openai/integration/AzureOpenAIIntegrationSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/openai/integration/AzureOpenAIIntegrationSpec.scala
@@ -1,0 +1,67 @@
+package sttp.ai.openai.integration
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.openai.{AuthScheme, OpenAISyncClient}
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.{ChatBody, ChatCompletionModel}
+import sttp.ai.openai.requests.completions.chat.message.{Content, Message}
+import sttp.model.Uri
+
+/** Integration tests for Azure OpenAI api-key authentication, run against a real Azure OpenAI deployment.
+  *
+  * To run these tests, set:
+  * {{{
+  * export AZURE_OPENAI_API_KEY=your-azure-api-key
+  * export AZURE_OPENAI_ENDPOINT="https://my-resource.openai.azure.com/openai/deployments/gpt-4o-mini?api-version=2024-10-21"
+  * sbt "testOnly *AzureOpenAIIntegrationSpec"
+  * }}}
+  *
+  * AZURE_OPENAI_ENDPOINT must be the full base URL including the deployment path and api-version query. Optionally set
+  * AZURE_OPENAI_DEPLOYMENT to the deployment name sent in the request body (defaults to gpt-4o-mini; classic deployment endpoints ignore
+  * it, the newer /openai/v1/ endpoint requires it to match your deployment).
+  *
+  * If AZURE_OPENAI_API_KEY or AZURE_OPENAI_ENDPOINT is not defined, all tests are skipped (not failed).
+  */
+class AzureOpenAIIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+
+  private val maybeApiKey: Option[String] = sys.env.get("AZURE_OPENAI_API_KEY")
+  private val maybeEndpoint: Option[String] = sys.env.get("AZURE_OPENAI_ENDPOINT")
+  private var clientOpt: Option[OpenAISyncClient] = None
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    for {
+      apiKey <- maybeApiKey
+      endpoint <- maybeEndpoint
+    } clientOpt = Some(OpenAISyncClient(apiKey, Uri.unsafeParse(endpoint), AuthScheme.AzureApiKey))
+  }
+
+  override def afterAll(): Unit = {
+    clientOpt.foreach(_.close())
+    super.afterAll()
+  }
+
+  private def withClient[T](test: OpenAISyncClient => T): T =
+    clientOpt match {
+      case Some(client) => test(client)
+      case None         => cancel("AZURE_OPENAI_API_KEY or AZURE_OPENAI_ENDPOINT not defined - skipping integration test")
+    }
+
+  "Azure OpenAI Chat API" should "create a chat completion using api-key authentication" in
+    withClient { client =>
+      // given
+      val chatBody = ChatBody(
+        messages = Seq(Message.User(content = Content.TextContent("Say 'hello' and nothing else."))),
+        model = ChatCompletionModel.CustomChatCompletionModel(sys.env.getOrElse("AZURE_OPENAI_DEPLOYMENT", "gpt-4o-mini")),
+        maxTokens = Some(10)
+      )
+
+      // when
+      val response = client.createChatCompletion(chatBody)
+
+      // then
+      response.choices should not be empty
+      ()
+    }
+}

--- a/run-integration-tests.sh
+++ b/run-integration-tests.sh
@@ -25,6 +25,7 @@ fi
 OPENAI_SET=false
 ANTHROPIC_SET=false
 GEMINI_SET=false
+AZURE_SET=false
 
 if [ -n "${OPENAI_API_KEY}" ]; then
     OPENAI_SET=true
@@ -47,7 +48,14 @@ else
     echo "⚠️  GEMINI_API_KEY is not set - Gemini tests will be skipped"
 fi
 
-if [ "$OPENAI_SET" = false ] && [ "$ANTHROPIC_SET" = false ] && [ "$GEMINI_SET" = false ]; then
+if [ -n "${AZURE_OPENAI_API_KEY}" ] && [ -n "${AZURE_OPENAI_ENDPOINT}" ]; then
+    AZURE_SET=true
+    echo "✓ AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT are set"
+else
+    echo "⚠️  AZURE_OPENAI_API_KEY/AZURE_OPENAI_ENDPOINT are not set - Azure OpenAI tests will be skipped"
+fi
+
+if [ "$OPENAI_SET" = false ] && [ "$ANTHROPIC_SET" = false ] && [ "$GEMINI_SET" = false ] && [ "$AZURE_SET" = false ]; then
     echo ""
     echo "Usage:"
     echo "  1. Create .env file with OPENAI_API_KEY, ANTHROPIC_API_KEY and GEMINI_API_KEY"
@@ -62,10 +70,10 @@ echo ""
 echo "🧪 Running integration tests..."
 
 # Run the integration tests (including agent tests)
-sbt "testOnly *OpenAIIntegrationSpec *ClaudeIntegrationSpec *GeminiIntegrationSpec *OpenAIAgentIntegrationSpec *ClaudeAgentIntegrationSpec *GeminiAgentIntegrationSpec"
+sbt "testOnly *OpenAIIntegrationSpec *ClaudeIntegrationSpec *GeminiIntegrationSpec *AzureOpenAIIntegrationSpec *OpenAIAgentIntegrationSpec *ClaudeAgentIntegrationSpec *GeminiAgentIntegrationSpec"
 
 echo ""
-if [ "$OPENAI_SET" = true ] || [ "$ANTHROPIC_SET" = true ] || [ "$GEMINI_SET" = true ]; then
+if [ "$OPENAI_SET" = true ] || [ "$ANTHROPIC_SET" = true ] || [ "$GEMINI_SET" = true ] || [ "$AZURE_SET" = true ]; then
     echo "✅ Integration tests completed!"
 else
     echo "✅ Integration tests skipped (no API keys provided)"

--- a/run-integration-tests.sh
+++ b/run-integration-tests.sh
@@ -58,8 +58,8 @@ fi
 if [ "$OPENAI_SET" = false ] && [ "$ANTHROPIC_SET" = false ] && [ "$GEMINI_SET" = false ] && [ "$AZURE_SET" = false ]; then
     echo ""
     echo "Usage:"
-    echo "  1. Create .env file with OPENAI_API_KEY, ANTHROPIC_API_KEY and GEMINI_API_KEY"
-    echo "  2. Or set environment variables: export OPENAI_API_KEY=... ANTHROPIC_API_KEY=... GEMINI_API_KEY=..."
+    echo "  1. Create .env file with OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY and AZURE_OPENAI_API_KEY/AZURE_OPENAI_ENDPOINT"
+    echo "  2. Or set environment variables: export OPENAI_API_KEY=... ANTHROPIC_API_KEY=... GEMINI_API_KEY=... AZURE_OPENAI_API_KEY=... AZURE_OPENAI_ENDPOINT=..."
     echo "  3. Or pass OpenAI key as argument: ./run-integration-tests.sh your-key-here"
     echo ""
     echo "📝 Note: Without API keys, all integration tests will be skipped (not failed)"


### PR DESCRIPTION
## What

Adds Azure OpenAI support to the `openai` module by making the authentication header configurable. Azure's API-key flow uses an `api-key: <key>` header instead of `Authorization: Bearer <key>`; combined with the already-supported custom base URL (query strings like `?api-version=...` are preserved), this is everything needed to use the client against Azure OpenAI deployment endpoints.

Closes the "Add Azure support by letting the user specify the endpoint and an api-key header" feature request.

## How

New `AuthScheme` ADT in `sttp.ai.openai`:

```scala
sealed trait AuthScheme
object AuthScheme {
  case object Bearer extends AuthScheme      // Authorization: Bearer <key> (default)
  case object AzureApiKey extends AuthScheme // api-key: <key>
}
```

Usage:

```scala
val client = OpenAISyncClient(
  authToken = azureKey,
  baseUrl = uri"https://my-resource.openai.azure.com/openai/deployments/gpt-4o?api-version=2024-10-21",
  authScheme = AuthScheme.AzureApiKey
)
```

- `OpenAI` gains a 4th defaulted constructor param `authScheme: AuthScheme = AuthScheme.Bearer`; the only behavioral branch is in `openAIAuthRequest`. Organization-header logic unchanged.
- `OpenAIConfig` gains an `authScheme` field (last position, defaulted); `authHeaders` and `OpenAI.apply(config)` honor it. `fromEnv` unchanged.
- `OpenAISyncClient` gains two new `apply` overloads taking `authScheme`. They take it as a **required** parameter (not defaulted) because Scala forbids default arguments on multiple overloaded alternatives — this is the one intentional deviation from "defaulted param" phrasing in the design.
- `customizeRequest` previously dropped `organization` when re-wrapping the client (latent bug); it now preserves all constructor state including `authScheme`.
- Streaming modules need no changes — they delegate to the `OpenAI` instance.
- Default behavior is fully backward compatible: all existing constructors/`apply`s keep sending `Authorization: Bearer`.

## Testing

- **Unit tests** (both Scala 2.13 and 3): header presence *and* absence pinned in both directions at three levels — raw request builder (`AuthSchemeSpec`), config-derived headers, and an end-to-end sync-client stub-backend test asserting on the actually-sent request headers (`SyncClientSpec`).
- **Integration test**: new `AzureOpenAIIntegrationSpec`, auto-skipped (canceled, not failed) unless `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_ENDPOINT` are set — same pattern as the OpenAI/Claude/Gemini specs. Wired into `run-integration-tests.sh` and documented in `INTEGRATION_TESTING.md`.
- `sbt compileDocumentation` compiles the new docs snippet.

## Docs

New "Azure OpenAI" section in `docs/openai/compatible-apis.md` covering the `api-key` scheme with a classic deployment URL, plus a note that Azure's newer `/openai/v1/` endpoint also works with the default Bearer scheme.