### PR TITLE
Feature/capability tagged models

### DIFF
--- a/agent-testkit/src/main/scala/sttp/ai/core/agent/testing/RecordedInteractions.scala
+++ b/agent-testkit/src/main/scala/sttp/ai/core/agent/testing/RecordedInteractions.scala
@@ -1,7 +1,7 @@
 package sttp.ai.core.agent.testing
 
 import io.circe.Json
-import sttp.ai.core.agent.{ConversationEntry, ConversationHistory, ResponseSchema}
+import sttp.ai.core.agent.{ConversationEntry, ConversationHistory, IterationInfo, ResponseSchema}
 
 /** A tool as it was offered to the (scripted) model: name, description, and the input JSON schema the model would see. */
 final case class OfferedTool(name: String, description: String, schema: Json)
@@ -18,13 +18,16 @@ final case class OfferedTool(name: String, description: String, schema: Json)
   *   the system prompt configured for the agent, as built from its [[sttp.ai.core.agent.AgentConfig]]
   * @param responseSchema
   *   the structured-output schema configured for the agent (e.g. via `deriveResponseSchema[T]`), if any
+  * @param iterationInfo
+  *   the position of this request within the agent loop (1-based iteration, and the configured maximum)
   */
 final case class RecordedRequest(
     history: ConversationHistory,
     includeTools: Boolean,
     toolsOffered: Seq[OfferedTool],
     systemPrompt: Option[String],
-    responseSchema: Option[ResponseSchema[_]]
+    responseSchema: Option[ResponseSchema[_]],
+    iterationInfo: IterationInfo
 )
 
 /** Framework-agnostic query API over the requests recorded by a scripted backend. Everything the scalatest matchers assert on is reachable

--- a/agent-testkit/src/main/scala/sttp/ai/core/agent/testing/ScriptedAgent.scala
+++ b/agent-testkit/src/main/scala/sttp/ai/core/agent/testing/ScriptedAgent.scala
@@ -26,7 +26,7 @@ final class ScriptedAgent[F[_]] private (script: Seq[AgentResponse])(implicit mo
   private var backends: Vector[ScriptedAgentBackend[F]] = Vector.empty
 
   /** A standard [[AgentBuilder]] wired to this script — a drop-in replacement for e.g. `OpenAIAgent.builder(...)`. */
-  def builder: AgentBuilder[F] = AgentBuilder[F] { config =>
+  def builder: AgentBuilder[F, ScriptedModel.type] = AgentBuilder[F, ScriptedModel.type] { config =>
     val backend = new ScriptedAgentBackend[F](script, config.userTools, config.systemPrompt, config.responseSchema)
     synchronized {
       backends = backends :+ backend

--- a/agent-testkit/src/main/scala/sttp/ai/core/agent/testing/ScriptedAgentBackend.scala
+++ b/agent-testkit/src/main/scala/sttp/ai/core/agent/testing/ScriptedAgentBackend.scala
@@ -1,6 +1,6 @@
 package sttp.ai.core.agent.testing
 
-import sttp.ai.core.agent.{AgentBackend, AgentResponse, AgentTool, ConversationHistory, ResponseSchema}
+import sttp.ai.core.agent.{AgentBackend, AgentResponse, AgentTool, ConversationHistory, IterationInfo, ResponseSchema}
 import sttp.client4.Backend
 import sttp.monad.MonadError
 
@@ -32,13 +32,14 @@ final class ScriptedAgentBackend[F[_]](
   override def sendRequest(
       history: ConversationHistory,
       backend: Backend[F],
-      includeTools: Boolean
+      includeTools: Boolean,
+      iterationInfo: IterationInfo
   ): F[AgentResponse] = monad.suspend {
     val toolsOffered =
       if (includeTools) tools.map(tool => OfferedTool(tool.name, tool.description, tool.rawJsonSchema))
       else Seq.empty
     val index = synchronized {
-      recorded = recorded :+ RecordedRequest(history, includeTools, toolsOffered, systemPrompt, responseSchema)
+      recorded = recorded :+ RecordedRequest(history, includeTools, toolsOffered, systemPrompt, responseSchema, iterationInfo)
       recorded.length - 1
     }
     if (index < script.length) monad.unit(script(index))

--- a/agent-testkit/src/main/scala/sttp/ai/core/agent/testing/ScriptedModel.scala
+++ b/agent-testkit/src/main/scala/sttp/ai/core/agent/testing/ScriptedModel.scala
@@ -1,0 +1,13 @@
+package sttp.ai.core.agent.testing
+
+import sttp.ai.core.model.{AIModel, Capability}
+
+/** Model stand-in for scripted agents. Claims every capability so builder evidence never blocks a test. */
+case object ScriptedModel
+    extends AIModel
+    with Capability.Vision
+    with Capability.ToolCalling
+    with Capability.StructuredOutput
+    with Capability.Reasoning {
+  val value: String = "scripted-model"
+}

--- a/agent-testkit/src/main/scala/sttp/ai/core/agent/testing/ScriptedModel.scala
+++ b/agent-testkit/src/main/scala/sttp/ai/core/agent/testing/ScriptedModel.scala
@@ -3,11 +3,6 @@ package sttp.ai.core.agent.testing
 import sttp.ai.core.model.{AIModel, Capability}
 
 /** Model stand-in for scripted agents. Claims every capability so builder evidence never blocks a test. */
-case object ScriptedModel
-    extends AIModel
-    with Capability.Vision
-    with Capability.ToolCalling
-    with Capability.StructuredOutput
-    with Capability.Reasoning {
+case object ScriptedModel extends AIModel with Capability.All {
   val value: String = "scripted-model"
 }

--- a/agent-testkit/src/test/scala/sttp/ai/core/agent/testing/ScriptedAgentBackendSpec.scala
+++ b/agent-testkit/src/test/scala/sttp/ai/core/agent/testing/ScriptedAgentBackendSpec.scala
@@ -4,7 +4,7 @@ import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import sttp.ai.core.agent.{AgentResponse, AgentTool, ConversationHistory}
+import sttp.ai.core.agent.{AgentResponse, AgentTool, ConversationHistory, IterationInfo}
 import sttp.client4.testing.SyncBackendStub
 import sttp.monad.IdentityMonad
 import sttp.shared.Identity
@@ -26,15 +26,15 @@ class ScriptedAgentBackendSpec extends AnyFlatSpec with Matchers {
   "ScriptedAgentBackend" should "return the scripted responses in order" in {
     val backend = newBackend(ScriptedResponse.text("first"), ScriptedResponse.text("second"))
 
-    backend.sendRequest(history, SyncBackendStub, includeTools = true) shouldBe ScriptedResponse.text("first")
-    backend.sendRequest(history, SyncBackendStub, includeTools = true) shouldBe ScriptedResponse.text("second")
+    backend.sendRequest(history, SyncBackendStub, includeTools = true, IterationInfo(1, 10)) shouldBe ScriptedResponse.text("first")
+    backend.sendRequest(history, SyncBackendStub, includeTools = true, IterationInfo(2, 10)) shouldBe ScriptedResponse.text("second")
   }
 
   it should "record each request with its history, includeTools flag and system prompt" in {
     val backend = newBackend(ScriptedResponse.text("a"), ScriptedResponse.text("b"))
 
-    backend.sendRequest(history, SyncBackendStub, includeTools = true)
-    backend.sendRequest(history, SyncBackendStub, includeTools = false)
+    backend.sendRequest(history, SyncBackendStub, includeTools = true, IterationInfo(1, 10))
+    backend.sendRequest(history, SyncBackendStub, includeTools = false, IterationInfo(2, 10))
 
     backend.requests should have size 2
     backend.requests.map(_.includeTools) shouldBe Seq(true, false)
@@ -45,7 +45,7 @@ class ScriptedAgentBackendSpec extends AnyFlatSpec with Matchers {
   it should "record offered tools with their JSON schemas when includeTools is true" in {
     val backend = newBackend(ScriptedResponse.text("a"))
 
-    backend.sendRequest(history, SyncBackendStub, includeTools = true)
+    backend.sendRequest(history, SyncBackendStub, includeTools = true, IterationInfo(1, 10))
 
     val offered = backend.requests.head.toolsOffered
     offered.map(_.name) shouldBe Seq("echo")
@@ -56,7 +56,7 @@ class ScriptedAgentBackendSpec extends AnyFlatSpec with Matchers {
   it should "record no offered tools when includeTools is false" in {
     val backend = newBackend(ScriptedResponse.text("a"))
 
-    backend.sendRequest(history, SyncBackendStub, includeTools = false)
+    backend.sendRequest(history, SyncBackendStub, includeTools = false, IterationInfo(1, 10))
 
     backend.requests.head.toolsOffered shouldBe empty
   }
@@ -64,9 +64,9 @@ class ScriptedAgentBackendSpec extends AnyFlatSpec with Matchers {
   it should "fail with ScriptExhaustedException when the script runs out" in {
     val backend = newBackend(ScriptedResponse.text("only one"))
 
-    backend.sendRequest(history, SyncBackendStub, includeTools = true)
+    backend.sendRequest(history, SyncBackendStub, includeTools = true, IterationInfo(1, 10))
     val exception = intercept[ScriptExhaustedException] {
-      backend.sendRequest(history, SyncBackendStub, includeTools = true)
+      backend.sendRequest(history, SyncBackendStub, includeTools = true, IterationInfo(2, 10))
     }
     exception.getMessage should include("request 2")
     exception.getMessage should include("1 response(s)")
@@ -75,7 +75,7 @@ class ScriptedAgentBackendSpec extends AnyFlatSpec with Matchers {
   it should "still record the request that exhausted the script" in {
     val backend = newBackend()
 
-    intercept[ScriptExhaustedException](backend.sendRequest(history, SyncBackendStub, includeTools = true))
+    intercept[ScriptExhaustedException](backend.sendRequest(history, SyncBackendStub, includeTools = true, IterationInfo(1, 10)))
 
     backend.requests should have size 1
   }

--- a/agent-testkit/src/test/scala/sttp/ai/core/agent/testing/ScriptedAgentBackendSpec.scala
+++ b/agent-testkit/src/test/scala/sttp/ai/core/agent/testing/ScriptedAgentBackendSpec.scala
@@ -42,6 +42,16 @@ class ScriptedAgentBackendSpec extends AnyFlatSpec with Matchers {
     backend.requests.head.systemPrompt shouldBe Some("be helpful")
   }
 
+  it should "record the IterationInfo of each request" in {
+    val backend = newBackend(ScriptedResponse.text("a"), ScriptedResponse.text("b"))
+
+    backend.sendRequest(history, SyncBackendStub, includeTools = true, IterationInfo(1, 2))
+    backend.sendRequest(history, SyncBackendStub, includeTools = false, IterationInfo(2, 2))
+
+    backend.requests.map(_.iterationInfo) shouldBe Seq(IterationInfo(1, 2), IterationInfo(2, 2))
+    backend.requests.map(_.iterationInfo.isLastIteration) shouldBe Seq(false, true)
+  }
+
   it should "record offered tools with their JSON schemas when includeTools is true" in {
     val backend = newBackend(ScriptedResponse.text("a"))
 

--- a/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
+++ b/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
@@ -13,7 +13,7 @@ import sttp.monad.IdentityMonad
 
 private[claude] class ClaudeAgentBackend[F[_]](
     client: ClaudeClient,
-    modelName: String,
+    modelForIteration: IterationInfo => ClaudeModel,
     val tools: Seq[AgentTool[F, _]],
     val systemPrompt: Option[String],
     responseSchema: Option[ResponseSchema[_]]
@@ -75,7 +75,7 @@ private[claude] class ClaudeAgentBackend[F[_]](
   ): F[AgentResponse] = {
     val messages = buildMessages(history)
     val request = MessageRequest(
-      model = modelName,
+      model = modelForIteration(iterationInfo).value,
       messages = messages.toList,
       maxTokens = 4096,
       system = systemPrompt,
@@ -117,27 +117,58 @@ private[claude] class ClaudeAgentBackend[F[_]](
 
 object ClaudeAgent {
 
-  def builder[F[_]](
-      claudeConfig: ClaudeConfig,
-      modelName: String
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, ClaudeModel.CustomClaudeModel] =
-    builder(ClaudeClient(claudeConfig), modelName)
+  /** Entry point: `ClaudeAgent.builder[F](client, model)`. The indirection lets `M` be inferred while `F` is given explicitly. */
+  def builder[F[_]]: BuilderPartiallyApplied[F] = new BuilderPartiallyApplied[F]
 
-  def builder[F[_]](
-      client: ClaudeClient,
-      modelName: String
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, ClaudeModel.CustomClaudeModel] =
-    AgentBuilder[F, ClaudeModel.CustomClaudeModel](config =>
-      new ClaudeAgentBackend[F](client, modelName, config.userTools, config.systemPrompt, config.responseSchema)
-    )
+  final class BuilderPartiallyApplied[F[_]] private[ClaudeAgent] () {
 
-  def synchronous(
-      claudeConfig: ClaudeConfig,
-      modelName: String
-  ): AgentBuilder[Identity, ClaudeModel.CustomClaudeModel] = builder[Identity](claudeConfig, modelName)(IdentityMonad)
+    def apply[M <: ClaudeModel](client: ClaudeClient, model: M)(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, M] =
+      apply(client, (_: IterationInfo) => model)
 
-  def synchronous(
-      client: ClaudeClient,
-      modelName: String
-  ): AgentBuilder[Identity, ClaudeModel.CustomClaudeModel] = builder[Identity](client, modelName)(IdentityMonad)
+    /** Selects the model per loop iteration (e.g. a cheap model for tool iterations, a stronger one for the forced-final synthesis). `M`
+      * infers to the least upper bound of every model the function can return, so capability checks require the shared capabilities.
+      */
+    def apply[M <: ClaudeModel](client: ClaudeClient, modelForIteration: IterationInfo => M)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M] =
+      AgentBuilder[F, M](config =>
+        new ClaudeAgentBackend[F](client, modelForIteration, config.userTools, config.systemPrompt, config.responseSchema)
+      )
+
+    def apply(client: ClaudeClient, modelName: String)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, ClaudeModel.CustomClaudeModel] =
+      apply(client, ClaudeModel.CustomClaudeModel(modelName))
+
+    def apply[M <: ClaudeModel](claudeConfig: ClaudeConfig, model: M)(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, M] =
+      apply(ClaudeClient(claudeConfig), model)
+
+    def apply[M <: ClaudeModel](claudeConfig: ClaudeConfig, modelForIteration: IterationInfo => M)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M] =
+      apply(ClaudeClient(claudeConfig), modelForIteration)
+
+    def apply(claudeConfig: ClaudeConfig, modelName: String)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, ClaudeModel.CustomClaudeModel] =
+      apply(ClaudeClient(claudeConfig), modelName)
+  }
+
+  def synchronous[M <: ClaudeModel](client: ClaudeClient, model: M): AgentBuilder[Identity, M] =
+    builder[Identity](client, model)(IdentityMonad)
+
+  def synchronous[M <: ClaudeModel](client: ClaudeClient, modelForIteration: IterationInfo => M): AgentBuilder[Identity, M] =
+    builder[Identity](client, modelForIteration)(IdentityMonad)
+
+  def synchronous(client: ClaudeClient, modelName: String): AgentBuilder[Identity, ClaudeModel.CustomClaudeModel] =
+    builder[Identity](client, modelName)(IdentityMonad)
+
+  def synchronous[M <: ClaudeModel](claudeConfig: ClaudeConfig, model: M): AgentBuilder[Identity, M] =
+    builder[Identity](claudeConfig, model)(IdentityMonad)
+
+  def synchronous[M <: ClaudeModel](claudeConfig: ClaudeConfig, modelForIteration: IterationInfo => M): AgentBuilder[Identity, M] =
+    builder[Identity](claudeConfig, modelForIteration)(IdentityMonad)
+
+  def synchronous(claudeConfig: ClaudeConfig, modelName: String): AgentBuilder[Identity, ClaudeModel.CustomClaudeModel] =
+    builder[Identity](claudeConfig, modelName)(IdentityMonad)
 }

--- a/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
+++ b/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
@@ -70,7 +70,8 @@ private[claude] class ClaudeAgentBackend[F[_]](
   override def sendRequest(
       history: ConversationHistory,
       backend: Backend[F],
-      includeTools: Boolean
+      includeTools: Boolean,
+      iterationInfo: IterationInfo
   ): F[AgentResponse] = {
     val messages = buildMessages(history)
     val request = MessageRequest(

--- a/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
+++ b/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
@@ -2,7 +2,7 @@ package sttp.ai.claude.agent
 
 import sttp.ai.claude.ClaudeClient
 import sttp.ai.claude.config.ClaudeConfig
-import sttp.ai.claude.models.{ContentBlock, Message, OutputConfig, OutputFormat, Tool}
+import sttp.ai.claude.models.{ClaudeModel, ContentBlock, Message, OutputConfig, OutputFormat, Tool}
 import sttp.ai.claude.requests.MessageRequest
 import sttp.ai.core.agent._
 import sttp.client4.Backend
@@ -120,22 +120,24 @@ object ClaudeAgent {
   def builder[F[_]](
       claudeConfig: ClaudeConfig,
       modelName: String
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
+  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, ClaudeModel.CustomClaudeModel] =
     builder(ClaudeClient(claudeConfig), modelName)
 
   def builder[F[_]](
       client: ClaudeClient,
       modelName: String
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
-    AgentBuilder[F](config => new ClaudeAgentBackend[F](client, modelName, config.userTools, config.systemPrompt, config.responseSchema))
+  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, ClaudeModel.CustomClaudeModel] =
+    AgentBuilder[F, ClaudeModel.CustomClaudeModel](config =>
+      new ClaudeAgentBackend[F](client, modelName, config.userTools, config.systemPrompt, config.responseSchema)
+    )
 
   def synchronous(
       claudeConfig: ClaudeConfig,
       modelName: String
-  ): AgentBuilder[Identity] = builder[Identity](claudeConfig, modelName)(IdentityMonad)
+  ): AgentBuilder[Identity, ClaudeModel.CustomClaudeModel] = builder[Identity](claudeConfig, modelName)(IdentityMonad)
 
   def synchronous(
       client: ClaudeClient,
       modelName: String
-  ): AgentBuilder[Identity] = builder[Identity](client, modelName)(IdentityMonad)
+  ): AgentBuilder[Identity, ClaudeModel.CustomClaudeModel] = builder[Identity](client, modelName)(IdentityMonad)
 }

--- a/claude/src/main/scala/sttp/ai/claude/models/ClaudeModel.scala
+++ b/claude/src/main/scala/sttp/ai/claude/models/ClaudeModel.scala
@@ -1,36 +1,69 @@
 package sttp.ai.claude.models
 
-sealed trait ClaudeModel {
-  val value: String
+import sttp.ai.core.model.{AIModel, Capability}
+import sttp.ai.core.model.Capability._
+
+sealed abstract class ClaudeModel(val value: String) extends AIModel {
   override def toString: String = value
 }
 
 object ClaudeModel {
-  sealed abstract class Default(val value: String) extends ClaudeModel
-  sealed abstract class WithStructuredOutput(val value: String) extends ClaudeModel
 
-  case object Claude3_5Sonnet extends Default("claude-3-5-sonnet-20241022")
-  case object Claude3_5SonnetLatest extends Default("claude-3-5-sonnet-latest")
-  case object Claude3_5Haiku extends Default("claude-3-5-haiku-20241022")
-  case object Claude3_5HaikuLatest extends Default("claude-3-5-haiku-latest")
-  case object Claude3Opus extends Default("claude-3-opus-20240229")
-  case object Claude3Sonnet extends Default("claude-3-sonnet-20240229")
-  case object Claude3Haiku extends Default("claude-3-haiku-20240307")
+  case object Claude3_5Sonnet extends ClaudeModel("claude-3-5-sonnet-20241022") with Vision with ToolCalling
+  case object Claude3_5SonnetLatest extends ClaudeModel("claude-3-5-sonnet-latest") with Vision with ToolCalling
+  case object Claude3_5Haiku extends ClaudeModel("claude-3-5-haiku-20241022") with ToolCalling
+  case object Claude3_5HaikuLatest extends ClaudeModel("claude-3-5-haiku-latest") with ToolCalling
+  case object Claude3Opus extends ClaudeModel("claude-3-opus-20240229") with Vision with ToolCalling
+  case object Claude3Sonnet extends ClaudeModel("claude-3-sonnet-20240229") with Vision with ToolCalling
+  case object Claude3Haiku extends ClaudeModel("claude-3-haiku-20240307") with Vision with ToolCalling
 
-  case object ClaudeSonnet4_0 extends Default("claude-sonnet-4-20250514")
-  case object ClaudeOpus4_0 extends Default("claude-opus-4-20250514")
+  case object ClaudeSonnet4_0 extends ClaudeModel("claude-sonnet-4-20250514") with Vision with ToolCalling with Reasoning
+  case object ClaudeOpus4_0 extends ClaudeModel("claude-opus-4-20250514") with Vision with ToolCalling with Reasoning
 
-  case object ClaudeOpus4_1 extends WithStructuredOutput("claude-opus-4-1-20250805")
+  case object ClaudeOpus4_1
+      extends ClaudeModel("claude-opus-4-1-20250805")
+      with Vision
+      with ToolCalling
+      with StructuredOutput
+      with Reasoning
 
-  case object ClaudeSonnet4_5 extends WithStructuredOutput("claude-sonnet-4-5-20250929")
-  case object ClaudeSonnet4_5Latest extends WithStructuredOutput("claude-sonnet-4-5")
-  case object ClaudeHaiku4_5 extends WithStructuredOutput("claude-haiku-4-5-20251001")
-  case object ClaudeHaiku4_5Latest extends WithStructuredOutput("claude-haiku-4-5")
-  case object ClaudeOpus4_5 extends WithStructuredOutput("claude-opus-4-5-20251101")
-  case object ClaudeOpus4_5Latest extends WithStructuredOutput("claude-opus-4-5")
+  case object ClaudeSonnet4_5
+      extends ClaudeModel("claude-sonnet-4-5-20250929")
+      with Vision
+      with ToolCalling
+      with StructuredOutput
+      with Reasoning
+  case object ClaudeSonnet4_5Latest
+      extends ClaudeModel("claude-sonnet-4-5")
+      with Vision
+      with ToolCalling
+      with StructuredOutput
+      with Reasoning
+  case object ClaudeHaiku4_5
+      extends ClaudeModel("claude-haiku-4-5-20251001")
+      with Vision
+      with ToolCalling
+      with StructuredOutput
+      with Reasoning
+  case object ClaudeHaiku4_5Latest extends ClaudeModel("claude-haiku-4-5") with Vision with ToolCalling with StructuredOutput with Reasoning
+  case object ClaudeOpus4_5
+      extends ClaudeModel("claude-opus-4-5-20251101")
+      with Vision
+      with ToolCalling
+      with StructuredOutput
+      with Reasoning
+  case object ClaudeOpus4_5Latest extends ClaudeModel("claude-opus-4-5") with Vision with ToolCalling with StructuredOutput with Reasoning
 
-  case object ClaudeSonnet5 extends WithStructuredOutput("claude-sonnet-5")
-  case object ClaudeOpus5 extends WithStructuredOutput("claude-opus-5")
+  case object ClaudeSonnet5 extends ClaudeModel("claude-sonnet-5") with Vision with ToolCalling with StructuredOutput with Reasoning
+  case object ClaudeOpus5 extends ClaudeModel("claude-opus-5") with Vision with ToolCalling with StructuredOutput with Reasoning
+
+  /** A model id not in the predefined list. Claims all capabilities — using it asserts your model supports what you use it for. */
+  case class CustomClaudeModel(override val value: String)
+      extends ClaudeModel(value)
+      with Vision
+      with ToolCalling
+      with StructuredOutput
+      with Reasoning
 
   val values: Set[ClaudeModel] = Set(
     Claude3_5Sonnet,
@@ -55,11 +88,7 @@ object ClaudeModel {
 
   def fromString(value: String): Option[ClaudeModel] = values.find(_.value == value)
 
+  /** Whether the model behind `modelId` supports structured output. Unknown/future models default to supported. */
   def modelSupportsStructuredOutput(modelId: String): Boolean =
-    fromString(modelId) match {
-      case Some(_: WithStructuredOutput) => true
-      case Some(_: Default)              => false
-      case None                          => true // Defaults to supported for unknown/future models
-    }
-
+    fromString(modelId).forall(_.isInstanceOf[Capability.StructuredOutput])
 }

--- a/claude/src/main/scala/sttp/ai/claude/models/ClaudeModel.scala
+++ b/claude/src/main/scala/sttp/ai/claude/models/ClaudeModel.scala
@@ -20,50 +20,20 @@ object ClaudeModel {
   case object ClaudeSonnet4_0 extends ClaudeModel("claude-sonnet-4-20250514") with Vision with ToolCalling with Reasoning
   case object ClaudeOpus4_0 extends ClaudeModel("claude-opus-4-20250514") with Vision with ToolCalling with Reasoning
 
-  case object ClaudeOpus4_1
-      extends ClaudeModel("claude-opus-4-1-20250805")
-      with Vision
-      with ToolCalling
-      with StructuredOutput
-      with Reasoning
+  case object ClaudeOpus4_1 extends ClaudeModel("claude-opus-4-1-20250805") with All
 
-  case object ClaudeSonnet4_5
-      extends ClaudeModel("claude-sonnet-4-5-20250929")
-      with Vision
-      with ToolCalling
-      with StructuredOutput
-      with Reasoning
-  case object ClaudeSonnet4_5Latest
-      extends ClaudeModel("claude-sonnet-4-5")
-      with Vision
-      with ToolCalling
-      with StructuredOutput
-      with Reasoning
-  case object ClaudeHaiku4_5
-      extends ClaudeModel("claude-haiku-4-5-20251001")
-      with Vision
-      with ToolCalling
-      with StructuredOutput
-      with Reasoning
-  case object ClaudeHaiku4_5Latest extends ClaudeModel("claude-haiku-4-5") with Vision with ToolCalling with StructuredOutput with Reasoning
-  case object ClaudeOpus4_5
-      extends ClaudeModel("claude-opus-4-5-20251101")
-      with Vision
-      with ToolCalling
-      with StructuredOutput
-      with Reasoning
-  case object ClaudeOpus4_5Latest extends ClaudeModel("claude-opus-4-5") with Vision with ToolCalling with StructuredOutput with Reasoning
+  case object ClaudeSonnet4_5 extends ClaudeModel("claude-sonnet-4-5-20250929") with All
+  case object ClaudeSonnet4_5Latest extends ClaudeModel("claude-sonnet-4-5") with All
+  case object ClaudeHaiku4_5 extends ClaudeModel("claude-haiku-4-5-20251001") with All
+  case object ClaudeHaiku4_5Latest extends ClaudeModel("claude-haiku-4-5") with All
+  case object ClaudeOpus4_5 extends ClaudeModel("claude-opus-4-5-20251101") with All
+  case object ClaudeOpus4_5Latest extends ClaudeModel("claude-opus-4-5") with All
 
-  case object ClaudeSonnet5 extends ClaudeModel("claude-sonnet-5") with Vision with ToolCalling with StructuredOutput with Reasoning
-  case object ClaudeOpus5 extends ClaudeModel("claude-opus-5") with Vision with ToolCalling with StructuredOutput with Reasoning
+  case object ClaudeSonnet5 extends ClaudeModel("claude-sonnet-5") with All
+  case object ClaudeOpus5 extends ClaudeModel("claude-opus-5") with All
 
   /** A model id not in the predefined list. Claims all capabilities — using it asserts your model supports what you use it for. */
-  case class CustomClaudeModel(override val value: String)
-      extends ClaudeModel(value)
-      with Vision
-      with ToolCalling
-      with StructuredOutput
-      with Reasoning
+  case class CustomClaudeModel(override val value: String) extends ClaudeModel(value) with All
 
   val values: Set[ClaudeModel] = Set(
     Claude3_5Sonnet,

--- a/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.ai.claude.ClaudeClient
 import sttp.ai.claude.config.ClaudeConfig
+import sttp.ai.claude.models.ClaudeModel
 import sttp.ai.claude.models.Tool
 import sttp.ai.core.agent.AgentTool
 import sttp.ai.core.agent.ConversationHistory
@@ -35,7 +36,7 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     val tool = AgentTool.dynamic("create-event", "Creates an event", schema)(_ => "ok")
 
     val client = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
-    val backend = new ClaudeAgentBackend[Identity](client, "claude-haiku-4-5-20251001", Seq(tool), None, None)(IdentityMonad)
+    val backend = new ClaudeAgentBackend[Identity](client, _ => ClaudeModel.ClaudeHaiku4_5, Seq(tool), None, None)(IdentityMonad)
 
     backend.convertedTools.head match {
       case raw: Tool.CustomRaw =>
@@ -54,7 +55,7 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     val tool = AgentTool.dynamic("no-arg-tool", "Takes no arguments", schema)(_ => "ok")
 
     val client = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
-    val backend = new ClaudeAgentBackend[Identity](client, "claude-haiku-4-5-20251001", Seq(tool), None, None)(IdentityMonad)
+    val backend = new ClaudeAgentBackend[Identity](client, _ => ClaudeModel.ClaudeHaiku4_5, Seq(tool), None, None)(IdentityMonad)
 
     backend.convertedTools.head match {
       case raw: Tool.CustomRaw =>
@@ -78,7 +79,7 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     }
 
     val client = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
-    val backend = new ClaudeAgentBackend[Identity](client, "claude-haiku-4-5-20251001", Seq(tool), None, None)(IdentityMonad)
+    val backend = new ClaudeAgentBackend[Identity](client, _ => ClaudeModel.ClaudeHaiku4_5, Seq(tool), None, None)(IdentityMonad)
 
     backend.convertedTools.head match {
       case raw: Tool.CustomRaw => raw.inputSchema shouldBe originalSchema
@@ -97,7 +98,7 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     }
 
     val client = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
-    val backend = new ClaudeAgentBackend[Identity](client, "claude-haiku-4-5-20251001", Seq(tool), None, None)(IdentityMonad)
+    val backend = new ClaudeAgentBackend[Identity](client, _ => ClaudeModel.ClaudeHaiku4_5, Seq(tool), None, None)(IdentityMonad)
 
     backend.convertedTools.head match {
       case raw: Tool.CustomRaw => raw.inputSchema shouldBe parse("""{"type":"object"}""").value
@@ -120,7 +121,7 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     val schema = parse(rawSchema).value.as[Schema](sttp.apispec.circe.schemaDecoder).value
     val tool = AgentTool.dynamic("create-event", "Creates an event", schema)(_ => "ok")
     val client = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
-    val backend = new ClaudeAgentBackend[Identity](client, "claude-haiku-4-5-20251001", Seq(tool), None, None)(IdentityMonad)
+    val backend = new ClaudeAgentBackend[Identity](client, _ => ClaudeModel.ClaudeHaiku4_5, Seq(tool), None, None)(IdentityMonad)
 
     val captured = new AtomicReference[GenericRequest[_, _]](null)
     val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF { request =>
@@ -140,5 +141,32 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
 
   it should "omit tools from the request body when includeTools is false" in {
     captureRequestBody(includeTools = false) should not include "\"tools\""
+  }
+
+  it should "resolve the model per iteration via modelForIteration" in {
+    val capturedModels = new AtomicReference[Vector[String]](Vector.empty)
+    val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF { request =>
+      val body = request.body match {
+        case StringBody(s, _, _) => s
+        case other               => fail(s"expected StringBody, got $other")
+      }
+      val model = parse(body).toOption.flatMap(_.hcursor.get[String]("model").toOption).getOrElse("?")
+      capturedModels.updateAndGet(_ :+ model)
+      ResponseStub.adjust(minimalMessageResponse, StatusCode.Ok)
+    }
+
+    val client = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
+    val backend = new ClaudeAgentBackend[Identity](
+      client,
+      info => if (info.isLastIteration) ClaudeModel.ClaudeOpus5 else ClaudeModel.ClaudeHaiku4_5,
+      Seq.empty,
+      None,
+      None
+    )(IdentityMonad)
+
+    backend.sendRequest(ConversationHistory.withInitialPrompt("hello"), httpStub, includeTools = false, IterationInfo(1, 3)): Unit
+    backend.sendRequest(ConversationHistory.withInitialPrompt("hello"), httpStub, includeTools = false, IterationInfo(3, 3)): Unit
+
+    capturedModels.get() shouldBe Vector("claude-haiku-4-5-20251001", "claude-opus-5")
   }
 }

--- a/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
@@ -10,6 +10,7 @@ import sttp.ai.claude.config.ClaudeConfig
 import sttp.ai.claude.models.Tool
 import sttp.ai.core.agent.AgentTool
 import sttp.ai.core.agent.ConversationHistory
+import sttp.ai.core.agent.IterationInfo
 import sttp.apispec.Schema
 import sttp.client4._
 import sttp.client4.testing.ResponseStub
@@ -126,7 +127,7 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
       captured.set(request)
       ResponseStub.adjust(minimalMessageResponse, StatusCode.Ok)
     }
-    backend.sendRequest(ConversationHistory.withInitialPrompt("hello"), httpStub, includeTools = includeTools): Unit
+    backend.sendRequest(ConversationHistory.withInitialPrompt("hello"), httpStub, includeTools = includeTools, IterationInfo(1, 10)): Unit
     captured.get().body match {
       case StringBody(s, _, _) => s
       case other               => fail(s"expected StringBody, got $other")

--- a/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentCapabilitySpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentCapabilitySpec.scala
@@ -1,0 +1,67 @@
+package sttp.ai.claude.agent
+
+import io.circe.parser.parse
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.claude.ClaudeClient
+import sttp.ai.claude.config.ClaudeConfig
+import sttp.ai.core.agent.{AgentTool, IterationInfo}
+import sttp.ai.claude.models.ClaudeModel
+import sttp.apispec.Schema
+import sttp.shared.Identity
+
+object ClaudeAgentCapabilitySpecFixtures {
+  val client: ClaudeClient = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
+  val echoTool: AgentTool[Identity, _] = {
+    val schema = parse("""{"type":"object"}""").toOption.get.as[Schema](sttp.apispec.circe.schemaDecoder).toOption.get
+    AgentTool.dynamic("echo", "Echoes input", schema)(_ => "ok")
+  }
+}
+
+class ClaudeAgentCapabilitySpec extends AnyFlatSpec with Matchers {
+  import ClaudeAgentCapabilitySpecFixtures._
+
+  "ClaudeAgent" should "reject deriveResponseSchema for Claude 3 Haiku (no StructuredOutput) at compile time" in {
+    assertDoesNotCompile(
+      """import io.circe.Codec
+        import io.circe.generic.semiauto.deriveCodec
+        import sttp.tapir.Schema
+        case class Out(answer: String)
+        object Out {
+          implicit val codec: Codec[Out] = deriveCodec
+          implicit val schema: Schema[Out] = Schema.derived
+        }
+        sttp.ai.claude.agent.ClaudeAgent
+          .synchronous(sttp.ai.claude.agent.ClaudeAgentCapabilitySpecFixtures.client, sttp.ai.claude.models.ClaudeModel.Claude3Haiku)
+          .deriveResponseSchema[Out]"""
+    )
+    assertCompiles(
+      """import io.circe.Codec
+        import io.circe.generic.semiauto.deriveCodec
+        import sttp.tapir.Schema
+        case class Out(answer: String)
+        object Out {
+          implicit val codec: Codec[Out] = deriveCodec
+          implicit val schema: Schema[Out] = Schema.derived
+        }
+        sttp.ai.claude.agent.ClaudeAgent
+          .synchronous(sttp.ai.claude.agent.ClaudeAgentCapabilitySpecFixtures.client, sttp.ai.claude.models.ClaudeModel.ClaudeSonnet5)
+          .deriveResponseSchema[Out]"""
+    )
+  }
+
+  it should "keep String model names working and allow tools on them" in {
+    ClaudeAgent.synchronous(client, "claude-haiku-4-5-20251001").tools(echoTool): Unit
+    succeed
+  }
+
+  it should "infer shared capabilities across a mixed-model hook" in {
+    ClaudeAgent
+      .synchronous(
+        client,
+        (info: IterationInfo) => if (info.isLastIteration) ClaudeModel.ClaudeOpus5 else ClaudeModel.ClaudeHaiku4_5
+      )
+      .tools(echoTool): Unit
+    succeed
+  }
+}

--- a/claude/src/test/scala/sttp/ai/claude/integration/ClaudeAgentIntegrationSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/integration/ClaudeAgentIntegrationSpec.scala
@@ -19,7 +19,7 @@ class ClaudeAgentIntegrationSpec extends AgentIntegrationSpecBase {
     val agentConfig = AgentConfig[Identity](maxIterations = maxIterations, userTools = tools)
     val agentBackend = new ClaudeAgentBackend[Identity](
       client,
-      "claude-haiku-4-5-20251001",
+      _ => sttp.ai.claude.models.ClaudeModel.ClaudeHaiku4_5,
       agentConfig.userTools,
       agentConfig.systemPrompt,
       agentConfig.responseSchema

--- a/claude/src/test/scala/sttp/ai/claude/unit/models/ClaudeModelSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/unit/models/ClaudeModelSpec.scala
@@ -3,6 +3,7 @@ package sttp.ai.claude.unit.models
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.ai.claude.models.ClaudeModel
+import sttp.ai.core.model.Capability
 
 class ClaudeModelSpec extends AnyFlatSpec with Matchers {
 
@@ -64,37 +65,46 @@ class ClaudeModelSpec extends AnyFlatSpec with Matchers {
     ClaudeModel.values should have size 18
   }
 
-  "Structured output support" should "be false for legacy Claude 3.x models (Default type)" in {
-    ClaudeModel.Claude3_5Sonnet shouldBe a[ClaudeModel.Default]
-    ClaudeModel.Claude3_5SonnetLatest shouldBe a[ClaudeModel.Default]
-    ClaudeModel.Claude3_5Haiku shouldBe a[ClaudeModel.Default]
-    ClaudeModel.Claude3_5HaikuLatest shouldBe a[ClaudeModel.Default]
-    ClaudeModel.Claude3Opus shouldBe a[ClaudeModel.Default]
-    ClaudeModel.Claude3Sonnet shouldBe a[ClaudeModel.Default]
-    ClaudeModel.Claude3Haiku shouldBe a[ClaudeModel.Default]
+  "Capability tags" should "not include StructuredOutput on legacy 3.x and 4.0 models" in {
+    ClaudeModel.Claude3_5Sonnet should not be a[Capability.StructuredOutput]
+    ClaudeModel.Claude3_5SonnetLatest should not be a[Capability.StructuredOutput]
+    ClaudeModel.Claude3_5Haiku should not be a[Capability.StructuredOutput]
+    ClaudeModel.Claude3_5HaikuLatest should not be a[Capability.StructuredOutput]
+    ClaudeModel.Claude3Opus should not be a[Capability.StructuredOutput]
+    ClaudeModel.Claude3Sonnet should not be a[Capability.StructuredOutput]
+    ClaudeModel.Claude3Haiku should not be a[Capability.StructuredOutput]
+    ClaudeModel.ClaudeSonnet4_0 should not be a[Capability.StructuredOutput]
+    ClaudeModel.ClaudeOpus4_0 should not be a[Capability.StructuredOutput]
   }
 
-  it should "be false for Claude 4.0 models (Default type)" in {
-    ClaudeModel.ClaudeSonnet4_0 shouldBe a[ClaudeModel.Default]
-    ClaudeModel.ClaudeOpus4_0 shouldBe a[ClaudeModel.Default]
+  it should "include StructuredOutput on 4.1+, 4.5 and 5 models" in {
+    ClaudeModel.ClaudeOpus4_1 shouldBe a[Capability.StructuredOutput]
+    ClaudeModel.ClaudeSonnet4_5 shouldBe a[Capability.StructuredOutput]
+    ClaudeModel.ClaudeSonnet4_5Latest shouldBe a[Capability.StructuredOutput]
+    ClaudeModel.ClaudeHaiku4_5 shouldBe a[Capability.StructuredOutput]
+    ClaudeModel.ClaudeHaiku4_5Latest shouldBe a[Capability.StructuredOutput]
+    ClaudeModel.ClaudeOpus4_5 shouldBe a[Capability.StructuredOutput]
+    ClaudeModel.ClaudeOpus4_5Latest shouldBe a[Capability.StructuredOutput]
+    ClaudeModel.ClaudeSonnet5 shouldBe a[Capability.StructuredOutput]
+    ClaudeModel.ClaudeOpus5 shouldBe a[Capability.StructuredOutput]
   }
 
-  it should "be true for Claude 4.1 models (WithStructuredOutput type)" in {
-    ClaudeModel.ClaudeOpus4_1 shouldBe a[ClaudeModel.WithStructuredOutput]
+  it should "mark every predefined model as ToolCalling, and 3.5 Haiku as text-only" in {
+    ClaudeModel.values.foreach(m => m shouldBe a[Capability.ToolCalling])
+    ClaudeModel.Claude3_5Haiku should not be a[Capability.Vision]
+    ClaudeModel.Claude3_5HaikuLatest should not be a[Capability.Vision]
+    ClaudeModel.Claude3Haiku shouldBe a[Capability.Vision]
+    ClaudeModel.ClaudeSonnet5 shouldBe a[Capability.Vision]
   }
 
-  it should "be true for Claude 4.5 models (WithStructuredOutput type)" in {
-    ClaudeModel.ClaudeSonnet4_5 shouldBe a[ClaudeModel.WithStructuredOutput]
-    ClaudeModel.ClaudeSonnet4_5Latest shouldBe a[ClaudeModel.WithStructuredOutput]
-    ClaudeModel.ClaudeHaiku4_5 shouldBe a[ClaudeModel.WithStructuredOutput]
-    ClaudeModel.ClaudeHaiku4_5Latest shouldBe a[ClaudeModel.WithStructuredOutput]
-    ClaudeModel.ClaudeOpus4_5 shouldBe a[ClaudeModel.WithStructuredOutput]
-    ClaudeModel.ClaudeOpus4_5Latest shouldBe a[ClaudeModel.WithStructuredOutput]
-  }
-
-  it should "be true for Claude 5 models (WithStructuredOutput type)" in {
-    ClaudeModel.ClaudeSonnet5 shouldBe a[ClaudeModel.WithStructuredOutput]
-    ClaudeModel.ClaudeOpus5 shouldBe a[ClaudeModel.WithStructuredOutput]
+  it should "make CustomClaudeModel claim all capabilities" in {
+    val custom = ClaudeModel.CustomClaudeModel("my-model")
+    custom shouldBe a[Capability.Vision]
+    custom shouldBe a[Capability.ToolCalling]
+    custom shouldBe a[Capability.StructuredOutput]
+    custom shouldBe a[Capability.Reasoning]
+    custom.value shouldBe "my-model"
+    ClaudeModel.values should not contain custom
   }
 
   "modelSupportsStructuredOutput" should "return false for known legacy model IDs" in {

--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -42,7 +42,13 @@ class Agent[F[_]](
           history
         }
 
-        val response = agentBackend.sendRequest(historyWithMarker, backend, includeTools = !isLastIteration)
+        val response =
+          agentBackend.sendRequest(
+            historyWithMarker,
+            backend,
+            includeTools = !isLastIteration,
+            IterationInfo(iteration + 1, config.maxIterations)
+          )
 
         response.flatMap { response =>
           if (response.stopReason == StopReason.MaxTokens) {

--- a/core/src/main/scala/sttp/ai/core/agent/AgentBackend.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentBackend.scala
@@ -31,13 +31,16 @@ trait AgentBackend[F[_]] {
     * @param includeTools
     *   Whether the agent's tools should be offered on this call. The agent loop sets this to `false` on the last allowed iteration so the
     *   model is forced to produce a final answer instead of making tool calls whose results would be discarded.
+    * @param iterationInfo
+    *   The position of this request within the agent loop (1-based iteration, and the configured maximum).
     * @return
     *   The LLM's response wrapped in the effect type F, containing text content, tool calls, and stop reason
     */
   def sendRequest(
       history: ConversationHistory,
       backend: Backend[F],
-      includeTools: Boolean
+      includeTools: Boolean,
+      iterationInfo: IterationInfo
   ): F[AgentResponse]
 }
 

--- a/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
@@ -2,50 +2,66 @@ package sttp.ai.core.agent
 
 import io.circe.Codec
 import sttp.ai.core.agent.AgentConfig.SystemPromptParameters
+import sttp.ai.core.model.{AIModel, Capability, Supports}
 import sttp.monad.MonadError
 import sttp.tapir.Schema
 
-final class AgentBuilder[F[_]] private (
+/** Fluent agent configuration. `M` is the model (or family of models) the agent was created with; builder methods that need a model
+  * capability require `Supports[M, C]` evidence, so e.g. adding tools to an agent whose model cannot call tools fails at compile time.
+  */
+final class AgentBuilder[F[_], M <: AIModel] private (
     makeBackend: AgentConfig[F] => AgentBackend[F],
     val config: AgentConfig[F]
 )(implicit monad: MonadError[F]) {
 
-  private def withConfig(next: AgentConfig[F]): AgentBuilder[F] =
-    new AgentBuilder[F](makeBackend, next)
+  private def withConfig(next: AgentConfig[F]): AgentBuilder[F, M] =
+    new AgentBuilder[F, M](makeBackend, next)
 
-  def maxIterations(value: Int): AgentBuilder[F] = withConfig(config.copy(maxIterations = value))
+  def maxIterations(value: Int): AgentBuilder[F, M] = withConfig(config.copy(maxIterations = value))
 
-  def systemPrompt(buildSystemPrompt: SystemPromptParameters => String): AgentBuilder[F] =
+  def systemPrompt(buildSystemPrompt: SystemPromptParameters => String): AgentBuilder[F, M] =
     withConfig(config.copy(systemPromptBuilder = Some(buildSystemPrompt)))
 
-  def systemPrompt(prompt: String): AgentBuilder[F] = systemPrompt(_ => prompt)
+  def systemPrompt(prompt: String): AgentBuilder[F, M] = systemPrompt(_ => prompt)
 
-  def tools(values: Seq[AgentTool[F, _]]): AgentBuilder[F] = withConfig(config.copy(userTools = values))
+  def tools(values: Seq[AgentTool[F, _]])(implicit ev: Supports[M, Capability.ToolCalling]): AgentBuilder[F, M] =
+    withConfig(config.copy(userTools = values))
 
-  def tools(first: AgentTool[F, _], rest: AgentTool[F, _]*): AgentBuilder[F] = tools(first +: rest)
+  def tools(first: AgentTool[F, _], rest: AgentTool[F, _]*)(implicit ev: Supports[M, Capability.ToolCalling]): AgentBuilder[F, M] =
+    tools(first +: rest)
 
-  def addTool(tool: AgentTool[F, _]): AgentBuilder[F] = withConfig(config.copy(userTools = config.userTools :+ tool))
+  def addTool(tool: AgentTool[F, _])(implicit ev: Supports[M, Capability.ToolCalling]): AgentBuilder[F, M] =
+    withConfig(config.copy(userTools = config.userTools :+ tool))
 
-  def exceptionHandler(handler: ExceptionHandler): AgentBuilder[F] = withConfig(config.copy(exceptionHandler = handler))
+  def exceptionHandler(handler: ExceptionHandler): AgentBuilder[F, M] = withConfig(config.copy(exceptionHandler = handler))
 
-  def responseSchema(schema: ResponseSchema[_]): AgentBuilder[F] = withConfig(config.copy(responseSchema = Some(schema)))
+  def responseSchema(schema: ResponseSchema[_])(implicit ev: Supports[M, Capability.StructuredOutput]): AgentBuilder[F, M] =
+    withConfig(config.copy(responseSchema = Some(schema)))
 
-  def deriveResponseSchema[T](implicit schema: Schema[T], codec: Codec[T]): AgentBuilder[F] =
+  def deriveResponseSchema[T](implicit
+      schema: Schema[T],
+      codec: Codec[T],
+      ev: Supports[M, Capability.StructuredOutput]
+  ): AgentBuilder[F, M] =
     withConfig(config.copy(responseSchema = Some(ResponseSchema.derived[T](None))))
 
   // NOTE: the description field is only forwarded to OpenAI. Claude's structured-output `output_config` has no description field.
-  def deriveResponseSchema[T](description: String)(implicit schema: Schema[T], codec: Codec[T]): AgentBuilder[F] =
+  def deriveResponseSchema[T](description: String)(implicit
+      schema: Schema[T],
+      codec: Codec[T],
+      ev: Supports[M, Capability.StructuredOutput]
+  ): AgentBuilder[F, M] =
     withConfig(config.copy(responseSchema = Some(ResponseSchema.derived[T](Some(description)))))
 
-  def hookBeforeToolCall(hook: ToolCall => F[Unit]): AgentBuilder[F] = withConfig(config.copy(beforeToolCall = Some(hook)))
+  def hookBeforeToolCall(hook: ToolCall => F[Unit]): AgentBuilder[F, M] = withConfig(config.copy(beforeToolCall = Some(hook)))
 
-  def hookAfterToolCall(hook: ToolCallRecord => F[Unit]): AgentBuilder[F] = withConfig(config.copy(afterToolCall = Some(hook)))
+  def hookAfterToolCall(hook: ToolCallRecord => F[Unit]): AgentBuilder[F, M] = withConfig(config.copy(afterToolCall = Some(hook)))
 
   def build: Agent[F] = Agent(makeBackend(config), config)
 }
 
 object AgentBuilder {
 
-  def apply[F[_]](makeBackend: AgentConfig[F] => AgentBackend[F])(implicit monad: MonadError[F]): AgentBuilder[F] =
-    new AgentBuilder[F](makeBackend, AgentConfig[F]())
+  def apply[F[_], M <: AIModel](makeBackend: AgentConfig[F] => AgentBackend[F])(implicit monad: MonadError[F]): AgentBuilder[F, M] =
+    new AgentBuilder[F, M](makeBackend, AgentConfig[F]())
 }

--- a/core/src/main/scala/sttp/ai/core/agent/IterationInfo.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/IterationInfo.scala
@@ -7,7 +7,7 @@ package sttp.ai.core.agent
   * @param maxIterations
   *   the configured maximum number of iterations
   */
-case class IterationInfo(iteration: Int, maxIterations: Int) {
+final case class IterationInfo(iteration: Int, maxIterations: Int) {
 
   /** True on the forced-final iteration, where tools are withheld and the model must produce a final answer. Note that the loop cannot know
     * in advance which iteration produces the final answer when the model stops naturally — this flags only the forced last iteration.

--- a/core/src/main/scala/sttp/ai/core/agent/IterationInfo.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/IterationInfo.scala
@@ -1,0 +1,16 @@
+package sttp.ai.core.agent
+
+/** Position of the current request within the agent loop.
+  *
+  * @param iteration
+  *   1-based index of the loop iteration this request belongs to
+  * @param maxIterations
+  *   the configured maximum number of iterations
+  */
+case class IterationInfo(iteration: Int, maxIterations: Int) {
+
+  /** True on the forced-final iteration, where tools are withheld and the model must produce a final answer. Note that the loop cannot know
+    * in advance which iteration produces the final answer when the model stops naturally — this flags only the forced last iteration.
+    */
+  def isLastIteration: Boolean = iteration >= maxIterations
+}

--- a/core/src/main/scala/sttp/ai/core/model/AIModel.scala
+++ b/core/src/main/scala/sttp/ai/core/model/AIModel.scala
@@ -1,7 +1,5 @@
 package sttp.ai.core.model
 
-import scala.annotation.implicitNotFound
-
 /** Base trait for provider model identifiers (OpenAI's `ChatCompletionModel`, `ClaudeModel`, `GeminiModel`).
   *
   * Model constants mix in [[Capability]] marker traits describing what the model supports; agent APIs require the relevant capability via
@@ -11,44 +9,4 @@ trait AIModel {
 
   /** The model identifier sent to the API, e.g. "gpt-4o". */
   def value: String
-}
-
-/** Capability marker traits mixed into model constants. Pure markers — they carry no members, only type-level facts.
-  *
-  * Custom/unknown model classes (e.g. `CustomChatCompletionModel`) mix in all capabilities: using one asserts your model supports whatever
-  * you use it for.
-  */
-object Capability {
-
-  /** The model accepts image input. */
-  trait Vision
-
-  /** The model supports tool/function calling. */
-  trait ToolCalling
-
-  /** The model supports schema-constrained (structured) output. */
-  trait StructuredOutput
-
-  /** The model is a reasoning ("thinking") model. */
-  trait Reasoning
-
-  /** Shorthand for a model that supports every capability. Mixing this in is equivalent to mixing in all four marker traits. */
-  trait All extends Vision with ToolCalling with StructuredOutput with Reasoning
-}
-
-/** Evidence that model type `M` declares capability `C`. Resolved automatically for any model constant that mixes in `C`.
-  *
-  * Sealed by design: capabilities are declared by mixing the marker trait into the model type, not by providing ad-hoc instances. For
-  * models outside the predefined constants, use the provider's custom model class, which claims all capabilities.
-  */
-@implicitNotFound(
-  "Model ${M} is not declared to support ${C}. Pick a model constant that mixes in ${C}, or use the provider's custom model class (which claims all capabilities)."
-)
-sealed trait Supports[M, C]
-
-object Supports {
-  private val instance: Supports[Any, Any] = new Supports[Any, Any] {}
-
-  implicit def fromSubtype[M, C](implicit ev: M <:< C): Supports[M, C] =
-    instance.asInstanceOf[Supports[M, C]]
 }

--- a/core/src/main/scala/sttp/ai/core/model/AIModel.scala
+++ b/core/src/main/scala/sttp/ai/core/model/AIModel.scala
@@ -33,7 +33,11 @@ object Capability {
   trait Reasoning
 }
 
-/** Evidence that model type `M` declares capability `C`. Resolved automatically for any model constant that mixes in `C`. */
+/** Evidence that model type `M` declares capability `C`. Resolved automatically for any model constant that mixes in `C`.
+  *
+  * Sealed by design: capabilities are declared by mixing the marker trait into the model type, not by providing ad-hoc instances. For
+  * models outside the predefined constants, use the provider's custom model class, which claims all capabilities.
+  */
 @implicitNotFound(
   "Model ${M} is not declared to support ${C}. Pick a model constant that mixes in ${C}, or use the provider's custom model class (which claims all capabilities)."
 )

--- a/core/src/main/scala/sttp/ai/core/model/AIModel.scala
+++ b/core/src/main/scala/sttp/ai/core/model/AIModel.scala
@@ -1,0 +1,47 @@
+package sttp.ai.core.model
+
+import scala.annotation.implicitNotFound
+
+/** Base trait for provider model identifiers (OpenAI's `ChatCompletionModel`, `ClaudeModel`, `GeminiModel`).
+  *
+  * Model constants mix in [[Capability]] marker traits describing what the model supports; agent APIs require the relevant capability via
+  * [[Supports]] evidence, so invalid model/task pairings are rejected at compile time.
+  */
+trait AIModel {
+
+  /** The model identifier sent to the API, e.g. "gpt-4o". */
+  def value: String
+}
+
+/** Capability marker traits mixed into model constants. Pure markers — they carry no members, only type-level facts.
+  *
+  * Custom/unknown model classes (e.g. `CustomChatCompletionModel`) mix in all capabilities: using one asserts your model supports whatever
+  * you use it for.
+  */
+object Capability {
+
+  /** The model accepts image input. */
+  trait Vision
+
+  /** The model supports tool/function calling. */
+  trait ToolCalling
+
+  /** The model supports schema-constrained (structured) output. */
+  trait StructuredOutput
+
+  /** The model is a reasoning ("thinking") model. */
+  trait Reasoning
+}
+
+/** Evidence that model type `M` declares capability `C`. Resolved automatically for any model constant that mixes in `C`. */
+@implicitNotFound(
+  "Model ${M} is not declared to support ${C}. Pick a model constant that mixes in ${C}, or use the provider's custom model class (which claims all capabilities)."
+)
+sealed trait Supports[M, C]
+
+object Supports {
+  private val instance: Supports[Any, Any] = new Supports[Any, Any] {}
+
+  implicit def fromSubtype[M, C](implicit ev: M <:< C): Supports[M, C] =
+    instance.asInstanceOf[Supports[M, C]]
+}

--- a/core/src/main/scala/sttp/ai/core/model/AIModel.scala
+++ b/core/src/main/scala/sttp/ai/core/model/AIModel.scala
@@ -31,6 +31,9 @@ object Capability {
 
   /** The model is a reasoning ("thinking") model. */
   trait Reasoning
+
+  /** Shorthand for a model that supports every capability. Mixing this in is equivalent to mixing in all four marker traits. */
+  trait All extends Vision with ToolCalling with StructuredOutput with Reasoning
 }
 
 /** Evidence that model type `M` declares capability `C`. Resolved automatically for any model constant that mixes in `C`.

--- a/core/src/main/scala/sttp/ai/core/model/Capability.scala
+++ b/core/src/main/scala/sttp/ai/core/model/Capability.scala
@@ -1,0 +1,56 @@
+package sttp.ai.core.model
+
+import scala.annotation.implicitNotFound
+
+/** Capability marker traits mixed into model constants. Pure markers — they carry no members, only type-level facts.
+  *
+  * Custom/unknown model classes (e.g. `CustomChatCompletionModel`) mix in all capabilities: using one asserts your model supports whatever
+  * you use it for.
+  */
+object Capability {
+
+  /** The model accepts image input. */
+  trait Vision
+
+  /** The model supports tool/function calling. */
+  trait ToolCalling
+
+  /** The model supports schema-constrained (structured) output. */
+  trait StructuredOutput
+
+  /** The model is a reasoning ("thinking") model. */
+  trait Reasoning
+
+  /** Shorthand for a model that supports every capability. Mixing this in is equivalent to mixing in all four marker traits. */
+  trait All extends Vision with ToolCalling with StructuredOutput with Reasoning
+}
+
+/** Evidence that model type `M` declares capability `C`. Resolved automatically for any model constant that mixes in `C`.
+  *
+  * Sealed by design: capabilities are declared by mixing the marker trait into the model type, not by providing ad-hoc instances. For
+  * models outside the predefined constants, use the provider's custom model class, which claims all capabilities. If a predefined
+  * constant's tag is missing or wrong (capability data is curated and can lag the providers), [[Supports.assume]] is the explicit,
+  * per-capability opt-out.
+  */
+@implicitNotFound(
+  "Model ${M} is not declared to support ${C}. Pick a model constant that mixes in ${C}, or use the provider's custom model class (which claims all capabilities)."
+)
+sealed trait Supports[M, C]
+
+object Supports {
+  private val instance: Supports[Any, Any] = new Supports[Any, Any] {}
+
+  implicit def fromSubtype[M, C](implicit ev: M <:< C): Supports[M, C] =
+    instance.asInstanceOf[Supports[M, C]]
+
+  /** Explicitly asserts that model `M` supports capability `C`, bypassing the tag on the constant.
+    *
+    * Use this when a constant's curated capability tags are missing or wrong — it opts out of checking for exactly this model/capability
+    * pair while keeping every other check intact (unlike falling back to a raw model-name string, which disables all checking):
+    *
+    * {{{
+    * implicit val ev: Supports[ChatCompletionModel.SomeModel.type, Capability.StructuredOutput] = Supports.assume
+    * }}}
+    */
+  def assume[M, C]: Supports[M, C] = instance.asInstanceOf[Supports[M, C]]
+}

--- a/core/src/test/scala/sttp/ai/core/agent/AgentBuilderCapabilitySpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentBuilderCapabilitySpec.scala
@@ -1,0 +1,94 @@
+package sttp.ai.core.agent
+
+import io.circe.parser.parse
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.core.model.{AIModel, Capability}
+import sttp.apispec.Schema
+import sttp.client4.Backend
+import sttp.monad.IdentityMonad
+import sttp.shared.Identity
+
+// Top-level so compile-check snippets can reference everything by stable, fully-qualified path.
+object AgentBuilderCapabilitySpecFixtures {
+  sealed abstract class TestModel(val value: String) extends AIModel
+  case object FullModel extends TestModel("full") with Capability.ToolCalling with Capability.StructuredOutput
+  case object BareModel extends TestModel("bare")
+
+  val echoTool: AgentTool[Identity, _] = {
+    val schema = parse("""{"type":"object"}""").toOption.get.as[Schema](sttp.apispec.circe.schemaDecoder).toOption.get
+    AgentTool.dynamic("echo", "Echoes input", schema)(_ => "ok")
+  }
+
+  private val noopBackend: AgentBackend[Identity] = new AgentBackend[Identity] {
+    val tools: Seq[AgentTool[Identity, _]] = Seq.empty
+    val systemPrompt: Option[String] = None
+    def sendRequest(
+        history: ConversationHistory,
+        backend: Backend[Identity],
+        includeTools: Boolean,
+        iterationInfo: IterationInfo
+    ): Identity[AgentResponse] = AgentResponse("done", Seq.empty, StopReason.EndTurn)
+  }
+
+  def newBuilder[M <: AIModel]: AgentBuilder[Identity, M] =
+    AgentBuilder[Identity, M](_ => noopBackend)(IdentityMonad)
+}
+
+class AgentBuilderCapabilitySpec extends AnyFlatSpec with Matchers with EitherValues {
+  import AgentBuilderCapabilitySpecFixtures._
+
+  "AgentBuilder.tools" should "compile for a model with ToolCalling" in {
+    newBuilder[FullModel.type].tools(echoTool): Unit
+    succeed
+  }
+
+  it should "not compile for a model without ToolCalling" in {
+    assertDoesNotCompile(
+      """sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures
+        .newBuilder[sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures.BareModel.type]
+        .tools(sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures.echoTool)"""
+    )
+    // positive twin proving the snippet shape is valid apart from the model:
+    assertCompiles(
+      """sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures
+        .newBuilder[sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures.FullModel.type]
+        .tools(sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures.echoTool)"""
+    )
+  }
+
+  "AgentBuilder.deriveResponseSchema" should "not compile for a model without StructuredOutput" in {
+    assertDoesNotCompile(
+      """import io.circe.Codec
+        import io.circe.generic.semiauto.deriveCodec
+        import sttp.tapir.Schema
+        case class Out(answer: String)
+        object Out {
+          implicit val codec: Codec[Out] = deriveCodec
+          implicit val schema: Schema[Out] = Schema.derived
+        }
+        sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures
+          .newBuilder[sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures.BareModel.type]
+          .deriveResponseSchema[Out]"""
+    )
+    assertCompiles(
+      """import io.circe.Codec
+        import io.circe.generic.semiauto.deriveCodec
+        import sttp.tapir.Schema
+        case class Out(answer: String)
+        object Out {
+          implicit val codec: Codec[Out] = deriveCodec
+          implicit val schema: Schema[Out] = Schema.derived
+        }
+        sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures
+          .newBuilder[sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures.FullModel.type]
+          .deriveResponseSchema[Out]"""
+    )
+  }
+
+  "AgentBuilder" should "allow builder methods without capability requirements on any model" in {
+    newBuilder[BareModel.type].maxIterations(3).systemPrompt("hi").build: Unit
+    succeed
+  }
+}

--- a/core/src/test/scala/sttp/ai/core/agent/AgentBuilderCapabilitySpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentBuilderCapabilitySpec.scala
@@ -34,6 +34,11 @@ object AgentBuilderCapabilitySpecFixtures {
 
   def newBuilder[M <: AIModel]: AgentBuilder[Identity, M] =
     AgentBuilder[Identity, M](_ => noopBackend)(IdentityMonad)
+
+  case class Out(answer: String)
+  implicit val outCodec: io.circe.Codec[Out] = io.circe.generic.semiauto.deriveCodec
+  implicit val outSchema: sttp.tapir.Schema[Out] = sttp.tapir.Schema.derived
+  val outResponseSchema: ResponseSchema[Out] = ResponseSchema.derived[Out](None)
 }
 
 class AgentBuilderCapabilitySpec extends AnyFlatSpec with Matchers with EitherValues {
@@ -84,6 +89,19 @@ class AgentBuilderCapabilitySpec extends AnyFlatSpec with Matchers with EitherVa
         sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures
           .newBuilder[sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures.FullModel.type]
           .deriveResponseSchema[Out]"""
+    )
+  }
+
+  "AgentBuilder.responseSchema" should "not compile for a model without StructuredOutput" in {
+    assertDoesNotCompile(
+      """sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures
+        .newBuilder[sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures.BareModel.type]
+        .responseSchema(sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures.outResponseSchema)"""
+    )
+    assertCompiles(
+      """sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures
+        .newBuilder[sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures.FullModel.type]
+        .responseSchema(sttp.ai.core.agent.AgentBuilderCapabilitySpecFixtures.outResponseSchema)"""
     )
   }
 

--- a/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
@@ -17,6 +17,7 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     private var callCount = 0
     var receivedHistories: Seq[ConversationHistory] = Seq.empty
     var receivedIncludeTools: Seq[Boolean] = Seq.empty
+    var iterationInfos: Vector[IterationInfo] = Vector.empty
 
     override def tools: Seq[AgentTool[Identity, _]] = Seq.empty
     override def systemPrompt: Option[String] = None
@@ -24,10 +25,12 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     override def sendRequest(
         history: ConversationHistory,
         backend: sttp.client4.Backend[Identity],
-        includeTools: Boolean
+        includeTools: Boolean,
+        iterationInfo: IterationInfo
     ): Identity[AgentResponse] = {
       receivedHistories = receivedHistories :+ history
       receivedIncludeTools = receivedIncludeTools :+ includeTools
+      iterationInfos = iterationInfos :+ iterationInfo
       val response = if (callCount < responses.length) {
         responses(callCount)
       } else {
@@ -236,6 +239,27 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     firstHistory.entries.exists(_.isInstanceOf[ConversationEntry.IterationMarker]) shouldBe false
     val secondHistory = stubBackend.receivedHistories(1)
     secondHistory.entries.exists(_.isInstanceOf[ConversationEntry.IterationMarker]) shouldBe true
+  }
+
+  it should "pass 1-based IterationInfo to the backend and flag the forced-final iteration" in {
+    val dummyTool = AgentTool.fromFunction(
+      "dummy",
+      "Dummy tool"
+    )((_: DummyInput) => "dummy result")
+
+    val stubBackend = new StubAgentBackend(
+      Seq(
+        AgentResponse("", Seq(ToolCall(id = "call_1", toolName = "dummy", input = "{}")), StopReason.ToolUse),
+        AgentResponse("", Seq(ToolCall(id = "call_2", toolName = "dummy", input = "{}")), StopReason.ToolUse),
+        AgentResponse("done", Seq.empty, StopReason.EndTurn)
+      )
+    )
+
+    runLoop(AgentBuilder[Identity](_ => stubBackend)(IdentityMonad).maxIterations(3).tools(dummyTool))
+
+    stubBackend.iterationInfos.map(_.iteration) shouldBe Vector(1, 2, 3)
+    stubBackend.iterationInfos.map(_.maxIterations).distinct shouldBe Vector(3)
+    stubBackend.iterationInfos.map(_.isLastIteration) shouldBe Vector(false, false, true)
   }
 
   it should "accept valid user tools" in {

--- a/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
@@ -14,7 +14,8 @@ import sttp.tapir.Schema
 
 class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
 
-  // Test-only model claiming every capability, so builder methods requiring capability evidence are usable in these tests.
+  // Test-only model claiming ToolCalling and StructuredOutput, so builder methods requiring those capability
+  // evidences are usable in these tests.
   case object TestModel extends AIModel with Capability.ToolCalling with Capability.StructuredOutput {
     val value: String = "test-model"
   }

--- a/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
@@ -6,12 +6,18 @@ import org.scalatest.matchers.should.Matchers
 import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
 import io.circe.parser.decode
+import sttp.ai.core.model.{AIModel, Capability}
 import sttp.client4.testing.SyncBackendStub
 import sttp.monad.IdentityMonad
 import sttp.shared.Identity
 import sttp.tapir.Schema
 
 class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
+
+  // Test-only model claiming every capability, so builder methods requiring capability evidence are usable in these tests.
+  case object TestModel extends AIModel with Capability.ToolCalling with Capability.StructuredOutput {
+    val value: String = "test-model"
+  }
 
   class StubAgentBackend(responses: Seq[AgentResponse]) extends AgentBackend[Identity] {
     private var callCount = 0
@@ -54,10 +60,10 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     s"Result: ${input.a + input.b}"
   }
 
-  private def agentBuilder(responses: AgentResponse*): AgentBuilder[Identity] =
-    AgentBuilder[Identity](_ => new StubAgentBackend(responses))(IdentityMonad)
+  private def agentBuilder(responses: AgentResponse*): AgentBuilder[Identity, TestModel.type] =
+    AgentBuilder[Identity, TestModel.type](_ => new StubAgentBackend(responses))(IdentityMonad)
 
-  private def runLoop(builder: AgentBuilder[Identity]): AgentResult[String] =
+  private def runLoop(builder: AgentBuilder[Identity, TestModel.type]): AgentResult[String] =
     builder.build.run("Test")(backend)
 
   case class DummyInput()
@@ -103,7 +109,7 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
       )
     )
 
-    val result = runLoop(AgentBuilder[Identity](_ => stubBackend)(IdentityMonad).maxIterations(3).tools(dummyTool))
+    val result = runLoop(AgentBuilder[Identity, TestModel.type](_ => stubBackend)(IdentityMonad).maxIterations(3).tools(dummyTool))
 
     stubBackend.receivedIncludeTools shouldBe Seq(true, true, false)
     result.toolCalls should have size 2
@@ -232,7 +238,7 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
         AgentResponse("Done", Seq.empty, StopReason.EndTurn)
       )
     )
-    runLoop(AgentBuilder[Identity](_ => stubBackend)(IdentityMonad).tools(dummyTool))
+    runLoop(AgentBuilder[Identity, TestModel.type](_ => stubBackend)(IdentityMonad).tools(dummyTool))
 
     stubBackend.receivedHistories should have size 2
     val firstHistory = stubBackend.receivedHistories.head
@@ -255,7 +261,7 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
       )
     )
 
-    runLoop(AgentBuilder[Identity](_ => stubBackend)(IdentityMonad).maxIterations(3).tools(dummyTool))
+    runLoop(AgentBuilder[Identity, TestModel.type](_ => stubBackend)(IdentityMonad).maxIterations(3).tools(dummyTool))
 
     stubBackend.iterationInfos.map(_.iteration) shouldBe Vector(1, 2, 3)
     stubBackend.iterationInfos.map(_.maxIterations).distinct shouldBe Vector(3)

--- a/core/src/test/scala/sttp/ai/core/model/CapabilitySpec.scala
+++ b/core/src/test/scala/sttp/ai/core/model/CapabilitySpec.scala
@@ -1,0 +1,42 @@
+package sttp.ai.core.model
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+// Top-level so `assertDoesNotCompile` snippets can reference the models by stable, fully-qualified path.
+object CapabilitySpecModels {
+  sealed abstract class TestModel(val value: String) extends AIModel
+  case object ToolModel extends TestModel("tool-model") with Capability.ToolCalling
+  case object PlainModel extends TestModel("plain-model")
+}
+
+class CapabilitySpec extends AnyFlatSpec with Matchers {
+  import CapabilitySpecModels._
+
+  "Supports" should "resolve for a model that mixes in the capability" in {
+    implicitly[Supports[ToolModel.type, Capability.ToolCalling]]
+    succeed
+  }
+
+  it should "not resolve for a model without the capability" in
+    // The positive twin above proves the snippet shape is otherwise valid, so this failure is the missing evidence.
+    assertDoesNotCompile(
+      "implicitly[sttp.ai.core.model.Supports[sttp.ai.core.model.CapabilitySpecModels.PlainModel.type, sttp.ai.core.model.Capability.ToolCalling]]"
+    )
+
+  it should "resolve for every capability a model mixes in, independently" in {
+    object AllModel
+        extends AIModel
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning {
+      val value: String = "all"
+    }
+    implicitly[Supports[AllModel.type, Capability.Vision]]
+    implicitly[Supports[AllModel.type, Capability.ToolCalling]]
+    implicitly[Supports[AllModel.type, Capability.StructuredOutput]]
+    implicitly[Supports[AllModel.type, Capability.Reasoning]]
+    succeed
+  }
+}

--- a/core/src/test/scala/sttp/ai/core/model/CapabilitySpec.scala
+++ b/core/src/test/scala/sttp/ai/core/model/CapabilitySpec.scala
@@ -24,6 +24,15 @@ class CapabilitySpec extends AnyFlatSpec with Matchers {
       "implicitly[sttp.ai.core.model.Supports[sttp.ai.core.model.CapabilitySpecModels.PlainModel.type, sttp.ai.core.model.Capability.ToolCalling]]"
     )
 
+  it should "allow an explicit Supports.assume opt-out for a missing or wrong tag" in {
+    implicit val assumed: Supports[PlainModel.type, Capability.ToolCalling] = Supports.assume
+    implicitly[Supports[PlainModel.type, Capability.ToolCalling]] shouldBe assumed
+    // other capabilities of the same model stay unchecked-in:
+    assertDoesNotCompile(
+      "implicitly[sttp.ai.core.model.Supports[sttp.ai.core.model.CapabilitySpecModels.PlainModel.type, sttp.ai.core.model.Capability.Vision]]"
+    )
+  }
+
   it should "resolve every capability for a model mixing in Capability.All" in {
     object AllShorthandModel extends AIModel with Capability.All {
       val value: String = "all-shorthand"

--- a/core/src/test/scala/sttp/ai/core/model/CapabilitySpec.scala
+++ b/core/src/test/scala/sttp/ai/core/model/CapabilitySpec.scala
@@ -24,6 +24,17 @@ class CapabilitySpec extends AnyFlatSpec with Matchers {
       "implicitly[sttp.ai.core.model.Supports[sttp.ai.core.model.CapabilitySpecModels.PlainModel.type, sttp.ai.core.model.Capability.ToolCalling]]"
     )
 
+  it should "resolve every capability for a model mixing in Capability.All" in {
+    object AllShorthandModel extends AIModel with Capability.All {
+      val value: String = "all-shorthand"
+    }
+    implicitly[Supports[AllShorthandModel.type, Capability.Vision]]
+    implicitly[Supports[AllShorthandModel.type, Capability.ToolCalling]]
+    implicitly[Supports[AllShorthandModel.type, Capability.StructuredOutput]]
+    implicitly[Supports[AllShorthandModel.type, Capability.Reasoning]]
+    succeed
+  }
+
   it should "resolve for every capability a model mixes in, independently" in {
     object AllModel
         extends AIModel

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -27,7 +27,8 @@ properties nullable); when `false`, tools are registered as non-strict with thei
 ## Model capabilities
 
 Model constants are tagged with capability marker traits: `Vision`, `ToolCalling`, `StructuredOutput`, `Reasoning`
-(in `sttp.ai.core.model.Capability`). Agent builder methods that need a capability require it at compile time:
+(in `sttp.ai.core.model.Capability`; models supporting everything mix in the `Capability.All` shorthand, which
+extends all four). Agent builder methods that need a capability require it at compile time:
 `.tools`/`.addTool` need `ToolCalling`, `.responseSchema`/`.deriveResponseSchema` need `StructuredOutput`.
 
 ```scala mdoc:compile-only

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -30,8 +30,14 @@ Model constants are tagged with capability marker traits: `Vision`, `ToolCalling
 (in `sttp.ai.core.model.Capability`). Agent builder methods that need a capability require it at compile time:
 `.tools`/`.addTool` need `ToolCalling`, `.responseSchema`/`.deriveResponseSchema` need `StructuredOutput`.
 
-```scala
+```scala mdoc:compile-only
+import sttp.ai.core.agent.AgentTool
+import sttp.ai.openai.OpenAI
+import sttp.ai.openai.agent.OpenAIAgent
 import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
+import sttp.shared.Identity
+
+def myTool: AgentTool[Identity, ?] = ???
 
 val agent = OpenAIAgent
   .synchronous(OpenAI.fromEnv, ChatCompletionModel.GPT4o) // GPT4o mixes in ToolCalling
@@ -44,7 +50,14 @@ val agent = OpenAIAgent
 String model names keep working and skip capability checking — they wrap into the provider's custom model class,
 which claims all capabilities (you assert your model supports what you use it for):
 
-```scala
+```scala mdoc:compile-only
+import sttp.ai.core.agent.AgentTool
+import sttp.ai.openai.OpenAI
+import sttp.ai.openai.agent.OpenAIAgent
+import sttp.shared.Identity
+
+def myTool: AgentTool[Identity, ?] = ???
+
 val ollamaAgent = OpenAIAgent.synchronous(OpenAI.fromEnv, "llama3-70b").tools(myTool).build
 ```
 
@@ -53,8 +66,14 @@ val ollamaAgent = OpenAIAgent.synchronous(OpenAI.fromEnv, "llama3-70b").tools(my
 Agents can use a different model per loop iteration — e.g. a cheap model while the agent calls tools, and a stronger
 model for the forced-final iteration (where tools are withheld and the model must answer):
 
-```scala
-import sttp.ai.core.agent.IterationInfo
+```scala mdoc:compile-only
+import sttp.ai.core.agent.{AgentTool, IterationInfo}
+import sttp.ai.openai.OpenAI
+import sttp.ai.openai.agent.OpenAIAgent
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
+import sttp.shared.Identity
+
+def myTool: AgentTool[Identity, ?] = ???
 
 val mixedAgent = OpenAIAgent
   .synchronous(OpenAI.fromEnv, (info: IterationInfo) => if info.isLastIteration then ChatCompletionModel.GPT5 else ChatCompletionModel.GPT4oMini)
@@ -65,7 +84,10 @@ val mixedAgent = OpenAIAgent
 The inferred model type is the least upper bound of every model the function can return, so capability checks require
 the capabilities **all** of them share. If inference produces an unwieldy type, ascribe the function explicitly:
 
-```scala
+```scala mdoc:compile-only
+import sttp.ai.core.agent.IterationInfo
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
+
 val pick: IterationInfo => ChatCompletionModel & sttp.ai.core.model.Capability.ToolCalling =
   info => if info.isLastIteration then ChatCompletionModel.GPT5 else ChatCompletionModel.GPT4oMini
 ```

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -24,6 +24,55 @@ The OpenAI factories additionally accept a `strictTools` flag (default `true`): 
 normalized for OpenAI's strict function calling (`additionalProperties: false`, all properties required, optional
 properties nullable); when `false`, tools are registered as non-strict with their original schemas.
 
+## Model capabilities
+
+Model constants are tagged with capability marker traits: `Vision`, `ToolCalling`, `StructuredOutput`, `Reasoning`
+(in `sttp.ai.core.model.Capability`). Agent builder methods that need a capability require it at compile time:
+`.tools`/`.addTool` need `ToolCalling`, `.responseSchema`/`.deriveResponseSchema` need `StructuredOutput`.
+
+```scala
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
+
+val agent = OpenAIAgent
+  .synchronous(OpenAI.fromEnv, ChatCompletionModel.GPT4o) // GPT4o mixes in ToolCalling
+  .tools(myTool)
+  .build
+
+// OpenAIAgent.synchronous(OpenAI.fromEnv, ChatCompletionModel.O1Mini).tools(myTool) // does not compile: o1-mini has no ToolCalling
+```
+
+String model names keep working and skip capability checking — they wrap into the provider's custom model class,
+which claims all capabilities (you assert your model supports what you use it for):
+
+```scala
+val ollamaAgent = OpenAIAgent.synchronous(OpenAI.fromEnv, "llama3-70b").tools(myTool).build
+```
+
+## Per-iteration model selection
+
+Agents can use a different model per loop iteration — e.g. a cheap model while the agent calls tools, and a stronger
+model for the forced-final iteration (where tools are withheld and the model must answer):
+
+```scala
+import sttp.ai.core.agent.IterationInfo
+
+val mixedAgent = OpenAIAgent
+  .synchronous(OpenAI.fromEnv, (info: IterationInfo) => if info.isLastIteration then ChatCompletionModel.GPT5 else ChatCompletionModel.GPT4oMini)
+  .tools(myTool)
+  .build
+```
+
+The inferred model type is the least upper bound of every model the function can return, so capability checks require
+the capabilities **all** of them share. If inference produces an unwieldy type, ascribe the function explicitly:
+
+```scala
+val pick: IterationInfo => ChatCompletionModel & sttp.ai.core.model.Capability.ToolCalling =
+  info => if info.isLastIteration then ChatCompletionModel.GPT5 else ChatCompletionModel.GPT4oMini
+```
+
+Note: `isLastIteration` flags only the *forced* last iteration (`maxIterations` reached). The loop cannot know in
+advance on which iteration the model will answer naturally.
+
 ## Hooks
 
 The loop can invoke optional effectful hooks around each tool call. Both run inside the agent loop, so an error in either hook interrupts the run.

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -62,6 +62,26 @@ def myTool: AgentTool[Identity, ?] = ???
 val ollamaAgent = OpenAIAgent.synchronous(OpenAI.fromEnv, "llama3-70b").tools(myTool).build
 ```
 
+### Custom models and wrong tags
+
+The provider model hierarchies are sealed, so you cannot define your own constant with hand-picked capability tags —
+a model outside the predefined constants always goes through the provider's custom model class and claims all
+capabilities. If a *predefined* constant's tags are missing or wrong (capability data is curated and can lag the
+providers), `Supports.assume` opts out of checking for exactly that model/capability pair while keeping every other
+check intact — unlike falling back to a raw model-name string, which disables all checking:
+
+```scala mdoc:compile-only
+import sttp.ai.core.model.{Capability, Supports}
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
+
+// you have verified the model really supports this, even though its constant isn't tagged with it
+given Supports[ChatCompletionModel.GPT4o20240513.type, Capability.StructuredOutput] = Supports.assume
+```
+
+Note that capability checks work on the model's singleton type: ascribing a constant to the base type
+(`val m: ChatCompletionModel = ChatCompletionModel.GPT4o`) widens away the tags, and `.tools(...)` on it will not
+compile. Pass constants directly, or keep the precise type (`ChatCompletionModel.GPT4o.type`).
+
 ## Per-iteration model selection
 
 Agents can use a different model per loop iteration — e.g. a cheap model while the agent calls tools, and a stronger
@@ -87,9 +107,10 @@ the capabilities **all** of them share. If inference produces an unwieldy type, 
 
 ```scala mdoc:compile-only
 import sttp.ai.core.agent.IterationInfo
+import sttp.ai.core.model.Capability
 import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
 
-val pick: IterationInfo => ChatCompletionModel & sttp.ai.core.model.Capability.ToolCalling =
+val pick: IterationInfo => ChatCompletionModel & Capability.ToolCalling =
   info => if info.isLastIteration then ChatCompletionModel.GPT5 else ChatCompletionModel.GPT4oMini
 ```
 

--- a/docs/agents/custom-backends.md
+++ b/docs/agents/custom-backends.md
@@ -8,16 +8,20 @@ The [agent loop](quickstart.md) talks to a model through the `AgentBackend` inte
 trait AgentBackend[F[_]] {
   def sendRequest(
       history: ConversationHistory,
-      backend: Backend[F]
+      backend: Backend[F],
+      includeTools: Boolean,
+      iterationInfo: IterationInfo
   ): F[AgentResponse]
 }
 
 case class AgentResponse(
     textContent: String,
     toolCalls: Seq[ToolCall],
-    stopReason: Option[String]
+    stopReason: StopReason
 )
 ```
+
+`iterationInfo` tells the backend which loop iteration this request belongs to (1-based) — use it to vary the model per iteration.
 
 Your implementation needs to:
 1. Convert `ConversationHistory` to your API's message format

--- a/docs/agents/quickstart.md
+++ b/docs/agents/quickstart.md
@@ -19,6 +19,7 @@ Framework for building autonomous AI agents that iteratively solve tasks using t
 import sttp.ai.core.agent.*
 import sttp.ai.openai.OpenAI
 import sttp.ai.openai.agent.OpenAIAgent
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
 import sttp.client4.DefaultSyncBackend
 import sttp.tapir.Schema
 
@@ -35,7 +36,7 @@ object BasicExample extends App {
   val backend = DefaultSyncBackend()
   try {
     val agent = OpenAIAgent
-      .synchronous(OpenAI.fromEnv, "gpt-4o-mini")
+      .synchronous(OpenAI.fromEnv, ChatCompletionModel.GPT4oMini)
       .maxIterations(5)
       .tools(weatherTool)
       .build

--- a/docs/claude/structured-outputs.md
+++ b/docs/claude/structured-outputs.md
@@ -139,7 +139,7 @@ val outputFormat = OutputFormat.JsonSchema(schema)
 See [JSON Schemas: structured outputs & tools](../other/json-schemas.md) for deriving schemas with Tapir instead of writing them by hand.
 
 **Important Notes:**
-- Structured outputs require Claude 4.1+ models (`claude-opus-4-1-*`, the 4.5 family (`claude-sonnet-4-5-*`, `claude-haiku-4-5-*`, `claude-opus-4-5-*`), and the 5 family (`claude-sonnet-5`, `claude-opus-5`) — the `ClaudeModel.WithStructuredOutput` entries)
+- Structured outputs require Claude 4.1+ models (`claude-opus-4-1-*`, the 4.5 family (`claude-sonnet-4-5-*`, `claude-haiku-4-5-*`, `claude-opus-4-5-*`), and the 5 family (`claude-sonnet-5`, `claude-opus-5`) — the constants tagged with `Capability.StructuredOutput`)
 - Legacy models will throw `UnsupportedModelForStructuredOutputException`
 - The beta feature uses `anthropic-beta: structured-outputs-2025-11-13` header automatically
 - Unknown/future models default to supporting structured outputs for forward compatibility

--- a/gemini/src/main/scala/sttp/ai/gemini/agent/GeminiAgent.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/agent/GeminiAgent.scala
@@ -16,7 +16,7 @@ import sttp.monad.IdentityMonad
 
 private[gemini] class GeminiAgentBackend[F[_]](
     client: GeminiClient,
-    modelName: String,
+    modelForIteration: IterationInfo => GeminiModel,
     val tools: Seq[AgentTool[F, _]],
     val systemPrompt: Option[String],
     responseSchema: Option[ResponseSchema[_]]
@@ -85,7 +85,7 @@ private[gemini] class GeminiAgentBackend[F[_]](
       case Left(e)      => monad.error(e)
       case Right(steps) =>
         val request = InteractionRequest(
-          model = modelName,
+          model = modelForIteration(iterationInfo).value,
           input = InteractionInput.StepsInput(steps),
           systemInstruction = systemPrompt,
           tools = if (includeTools && convertedTools.nonEmpty) Some(convertedTools.toList) else None,
@@ -132,27 +132,58 @@ private[gemini] class GeminiAgentBackend[F[_]](
 
 object GeminiAgent {
 
-  def builder[F[_]](
-      geminiConfig: GeminiConfig,
-      modelName: String
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, GeminiModel.CustomModel] =
-    builder(GeminiClient(geminiConfig), modelName)
+  /** Entry point: `GeminiAgent.builder[F](client, model)`. The indirection lets `M` be inferred while `F` is given explicitly. */
+  def builder[F[_]]: BuilderPartiallyApplied[F] = new BuilderPartiallyApplied[F]
 
-  def builder[F[_]](
-      client: GeminiClient,
-      modelName: String
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, GeminiModel.CustomModel] =
-    AgentBuilder[F, GeminiModel.CustomModel](config =>
-      new GeminiAgentBackend[F](client, modelName, config.userTools, config.systemPrompt, config.responseSchema)
-    )
+  final class BuilderPartiallyApplied[F[_]] private[GeminiAgent] () {
 
-  def synchronous(
-      geminiConfig: GeminiConfig,
-      modelName: String
-  ): AgentBuilder[Identity, GeminiModel.CustomModel] = builder[Identity](geminiConfig, modelName)(IdentityMonad)
+    def apply[M <: GeminiModel](client: GeminiClient, model: M)(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, M] =
+      apply(client, (_: IterationInfo) => model)
 
-  def synchronous(
-      client: GeminiClient,
-      modelName: String
-  ): AgentBuilder[Identity, GeminiModel.CustomModel] = builder[Identity](client, modelName)(IdentityMonad)
+    /** Selects the model per loop iteration (e.g. a cheap model for tool iterations, a stronger one for the forced-final synthesis). `M`
+      * infers to the least upper bound of every model the function can return, so capability checks require the shared capabilities.
+      */
+    def apply[M <: GeminiModel](client: GeminiClient, modelForIteration: IterationInfo => M)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M] =
+      AgentBuilder[F, M](config =>
+        new GeminiAgentBackend[F](client, modelForIteration, config.userTools, config.systemPrompt, config.responseSchema)
+      )
+
+    def apply(client: GeminiClient, modelName: String)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, GeminiModel.CustomModel] =
+      apply(client, GeminiModel.CustomModel(modelName))
+
+    def apply[M <: GeminiModel](geminiConfig: GeminiConfig, model: M)(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, M] =
+      apply(GeminiClient(geminiConfig), model)
+
+    def apply[M <: GeminiModel](geminiConfig: GeminiConfig, modelForIteration: IterationInfo => M)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M] =
+      apply(GeminiClient(geminiConfig), modelForIteration)
+
+    def apply(geminiConfig: GeminiConfig, modelName: String)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, GeminiModel.CustomModel] =
+      apply(GeminiClient(geminiConfig), modelName)
+  }
+
+  def synchronous[M <: GeminiModel](client: GeminiClient, model: M): AgentBuilder[Identity, M] =
+    builder[Identity](client, model)(IdentityMonad)
+
+  def synchronous[M <: GeminiModel](client: GeminiClient, modelForIteration: IterationInfo => M): AgentBuilder[Identity, M] =
+    builder[Identity](client, modelForIteration)(IdentityMonad)
+
+  def synchronous(client: GeminiClient, modelName: String): AgentBuilder[Identity, GeminiModel.CustomModel] =
+    builder[Identity](client, modelName)(IdentityMonad)
+
+  def synchronous[M <: GeminiModel](geminiConfig: GeminiConfig, model: M): AgentBuilder[Identity, M] =
+    builder[Identity](geminiConfig, model)(IdentityMonad)
+
+  def synchronous[M <: GeminiModel](geminiConfig: GeminiConfig, modelForIteration: IterationInfo => M): AgentBuilder[Identity, M] =
+    builder[Identity](geminiConfig, modelForIteration)(IdentityMonad)
+
+  def synchronous(geminiConfig: GeminiConfig, modelName: String): AgentBuilder[Identity, GeminiModel.CustomModel] =
+    builder[Identity](geminiConfig, modelName)(IdentityMonad)
 }

--- a/gemini/src/main/scala/sttp/ai/gemini/agent/GeminiAgent.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/agent/GeminiAgent.scala
@@ -2,7 +2,7 @@ package sttp.ai.gemini.agent
 
 import sttp.ai.gemini.GeminiClient
 import sttp.ai.gemini.config.GeminiConfig
-import sttp.ai.gemini.models.{Content, GenerationConfig, InteractionInput, InteractionStatus, ResponseFormat, Step, Tool}
+import sttp.ai.gemini.models.{Content, GeminiModel, GenerationConfig, InteractionInput, InteractionStatus, ResponseFormat, Step, Tool}
 import sttp.ai.gemini.requests.InteractionRequest
 import sttp.ai.gemini.responses.InteractionResponse
 import sttp.ai.core.agent._
@@ -135,22 +135,24 @@ object GeminiAgent {
   def builder[F[_]](
       geminiConfig: GeminiConfig,
       modelName: String
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
+  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, GeminiModel.CustomModel] =
     builder(GeminiClient(geminiConfig), modelName)
 
   def builder[F[_]](
       client: GeminiClient,
       modelName: String
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
-    AgentBuilder[F](config => new GeminiAgentBackend[F](client, modelName, config.userTools, config.systemPrompt, config.responseSchema))
+  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, GeminiModel.CustomModel] =
+    AgentBuilder[F, GeminiModel.CustomModel](config =>
+      new GeminiAgentBackend[F](client, modelName, config.userTools, config.systemPrompt, config.responseSchema)
+    )
 
   def synchronous(
       geminiConfig: GeminiConfig,
       modelName: String
-  ): AgentBuilder[Identity] = builder[Identity](geminiConfig, modelName)(IdentityMonad)
+  ): AgentBuilder[Identity, GeminiModel.CustomModel] = builder[Identity](geminiConfig, modelName)(IdentityMonad)
 
   def synchronous(
       client: GeminiClient,
       modelName: String
-  ): AgentBuilder[Identity] = builder[Identity](client, modelName)(IdentityMonad)
+  ): AgentBuilder[Identity, GeminiModel.CustomModel] = builder[Identity](client, modelName)(IdentityMonad)
 }

--- a/gemini/src/main/scala/sttp/ai/gemini/agent/GeminiAgent.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/agent/GeminiAgent.scala
@@ -78,7 +78,8 @@ private[gemini] class GeminiAgentBackend[F[_]](
   override def sendRequest(
       history: ConversationHistory,
       backend: Backend[F],
-      includeTools: Boolean
+      includeTools: Boolean,
+      iterationInfo: IterationInfo
   ): F[AgentResponse] =
     buildSteps(history) match {
       case Left(e)      => monad.error(e)

--- a/gemini/src/main/scala/sttp/ai/gemini/models/GeminiModel.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/GeminiModel.scala
@@ -1,17 +1,42 @@
 package sttp.ai.gemini.models
 
+import sttp.ai.core.model.{AIModel, Capability}
+import sttp.ai.core.model.Capability._
+
 /** Well-known Gemini model identifiers. Use [[GeminiModel.CustomModel]] for models not listed here. */
-sealed abstract class GeminiModel(val value: String)
+sealed abstract class GeminiModel(val value: String) extends AIModel
 
 object GeminiModel {
-  case object Gemini36Flash extends GeminiModel("gemini-3.6-flash")
-  case object Gemini35Flash extends GeminiModel("gemini-3.5-flash")
-  case object Gemini35FlashLite extends GeminiModel("gemini-3.5-flash-lite")
-  case object Gemini31FlashLite extends GeminiModel("gemini-3.1-flash-lite")
-  case object Gemini25Pro extends GeminiModel("gemini-2.5-pro")
-  case object Gemini25Flash extends GeminiModel("gemini-2.5-flash")
-  case object Gemini25FlashLite extends GeminiModel("gemini-2.5-flash-lite")
-  case class CustomModel(override val value: String) extends GeminiModel(value)
+  case object Gemini36Flash extends GeminiModel("gemini-3.6-flash") with Vision with ToolCalling with StructuredOutput with Reasoning
+  case object Gemini35Flash extends GeminiModel("gemini-3.5-flash") with Vision with ToolCalling with StructuredOutput with Reasoning
+  case object Gemini35FlashLite
+      extends GeminiModel("gemini-3.5-flash-lite")
+      with Vision
+      with ToolCalling
+      with StructuredOutput
+      with Reasoning
+  case object Gemini31FlashLite
+      extends GeminiModel("gemini-3.1-flash-lite")
+      with Vision
+      with ToolCalling
+      with StructuredOutput
+      with Reasoning
+  case object Gemini25Pro extends GeminiModel("gemini-2.5-pro") with Vision with ToolCalling with StructuredOutput with Reasoning
+  case object Gemini25Flash extends GeminiModel("gemini-2.5-flash") with Vision with ToolCalling with StructuredOutput with Reasoning
+  case object Gemini25FlashLite
+      extends GeminiModel("gemini-2.5-flash-lite")
+      with Vision
+      with ToolCalling
+      with StructuredOutput
+      with Reasoning
+
+  /** A model id not in the predefined list. Claims all capabilities — using it asserts your model supports what you use it for. */
+  case class CustomModel(override val value: String)
+      extends GeminiModel(value)
+      with Vision
+      with ToolCalling
+      with StructuredOutput
+      with Reasoning
 
   val values: List[GeminiModel] =
     List(Gemini36Flash, Gemini35Flash, Gemini35FlashLite, Gemini31FlashLite, Gemini25Pro, Gemini25Flash, Gemini25FlashLite)

--- a/gemini/src/main/scala/sttp/ai/gemini/models/GeminiModel.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/models/GeminiModel.scala
@@ -7,36 +7,16 @@ import sttp.ai.core.model.Capability._
 sealed abstract class GeminiModel(val value: String) extends AIModel
 
 object GeminiModel {
-  case object Gemini36Flash extends GeminiModel("gemini-3.6-flash") with Vision with ToolCalling with StructuredOutput with Reasoning
-  case object Gemini35Flash extends GeminiModel("gemini-3.5-flash") with Vision with ToolCalling with StructuredOutput with Reasoning
-  case object Gemini35FlashLite
-      extends GeminiModel("gemini-3.5-flash-lite")
-      with Vision
-      with ToolCalling
-      with StructuredOutput
-      with Reasoning
-  case object Gemini31FlashLite
-      extends GeminiModel("gemini-3.1-flash-lite")
-      with Vision
-      with ToolCalling
-      with StructuredOutput
-      with Reasoning
-  case object Gemini25Pro extends GeminiModel("gemini-2.5-pro") with Vision with ToolCalling with StructuredOutput with Reasoning
-  case object Gemini25Flash extends GeminiModel("gemini-2.5-flash") with Vision with ToolCalling with StructuredOutput with Reasoning
-  case object Gemini25FlashLite
-      extends GeminiModel("gemini-2.5-flash-lite")
-      with Vision
-      with ToolCalling
-      with StructuredOutput
-      with Reasoning
+  case object Gemini36Flash extends GeminiModel("gemini-3.6-flash") with All
+  case object Gemini35Flash extends GeminiModel("gemini-3.5-flash") with All
+  case object Gemini35FlashLite extends GeminiModel("gemini-3.5-flash-lite") with All
+  case object Gemini31FlashLite extends GeminiModel("gemini-3.1-flash-lite") with All
+  case object Gemini25Pro extends GeminiModel("gemini-2.5-pro") with All
+  case object Gemini25Flash extends GeminiModel("gemini-2.5-flash") with All
+  case object Gemini25FlashLite extends GeminiModel("gemini-2.5-flash-lite") with All
 
   /** A model id not in the predefined list. Claims all capabilities — using it asserts your model supports what you use it for. */
-  case class CustomModel(override val value: String)
-      extends GeminiModel(value)
-      with Vision
-      with ToolCalling
-      with StructuredOutput
-      with Reasoning
+  case class CustomModel(override val value: String) extends GeminiModel(value) with All
 
   val values: List[GeminiModel] =
     List(Gemini36Flash, Gemini35Flash, Gemini35FlashLite, Gemini31FlashLite, Gemini25Pro, Gemini25Flash, Gemini25FlashLite)

--- a/gemini/src/test/scala/sttp/ai/gemini/agent/GeminiAgentBackendSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/agent/GeminiAgentBackendSpec.scala
@@ -46,7 +46,9 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
       responseSchema: Option[ResponseSchema[_]] = None
   ): GeminiAgentBackend[Identity] = {
     val client = GeminiClient(GeminiConfig(apiKey = "test-key"))
-    new GeminiAgentBackend[Identity](client, testModel, tools, systemPrompt, responseSchema)(IdentityMonad)
+    new GeminiAgentBackend[Identity](client, _ => GeminiModel.CustomModel(testModel), tools, systemPrompt, responseSchema)(
+      IdentityMonad
+    )
   }
 
   "GeminiAgentBackend" should "pass the full tool schema through, preserving nested structure" in {
@@ -294,5 +296,42 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
 
     input.downN(1).downField("type").as[String] shouldBe Right("user_input")
     input.downN(1).downField("content").downN(0).downField("text").as[String] shouldBe Right("[Iteration 2 of 5]")
+  }
+
+  it should "resolve the model per iteration via modelForIteration" in {
+    val capturedModels = new AtomicReference[Vector[String]](Vector.empty)
+    val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF { request =>
+      val body = request.body match {
+        case StringBody(s, _, _) => s
+        case other               => fail(s"expected StringBody, got $other")
+      }
+      val model = parse(body).toOption.flatMap(_.hcursor.get[String]("model").toOption).getOrElse("?")
+      capturedModels.updateAndGet(_ :+ model)
+      ResponseStub.adjust(completedResponse, StatusCode.Ok)
+    }
+
+    val client = GeminiClient(GeminiConfig(apiKey = "test-key"))
+    val backend = new GeminiAgentBackend[Identity](
+      client,
+      info => if (info.isLastIteration) GeminiModel.Gemini25Pro else GeminiModel.Gemini25FlashLite,
+      Seq.empty,
+      None,
+      None
+    )(IdentityMonad)
+
+    backend.sendRequest(ConversationHistory.withInitialPrompt("hello"), httpStub, includeTools = false, IterationInfo(1, 3)): Unit
+    backend.sendRequest(ConversationHistory.withInitialPrompt("hello"), httpStub, includeTools = false, IterationInfo(3, 3)): Unit
+
+    capturedModels.get() shouldBe Vector("gemini-2.5-flash-lite", "gemini-2.5-pro")
+  }
+
+  it should "build typed and mixed-model agents through GeminiAgent" in {
+    GeminiAgent.synchronous(GeminiConfig(apiKey = "test-key"), GeminiModel.Gemini25Flash): Unit
+    GeminiAgent.synchronous(
+      GeminiConfig(apiKey = "test-key"),
+      (info: IterationInfo) => if (info.isLastIteration) GeminiModel.Gemini25Pro else GeminiModel.Gemini25FlashLite
+    ): Unit
+    GeminiAgent.synchronous(GeminiConfig(apiKey = "test-key"), "gemini-experimental"): Unit
+    succeed
   }
 }

--- a/gemini/src/test/scala/sttp/ai/gemini/agent/GeminiAgentBackendSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/agent/GeminiAgentBackendSpec.scala
@@ -101,7 +101,7 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
       captured.set(request)
       ResponseStub.adjust(completedResponse, StatusCode.Ok)
     }
-    backend.sendRequest(history, httpStub, includeTools = includeTools): Unit
+    backend.sendRequest(history, httpStub, includeTools = includeTools, IterationInfo(1, 10)): Unit
     captured.get().body match {
       case StringBody(s, _, _) => s
       case other               => fail(s"expected StringBody, got $other")
@@ -147,7 +147,7 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     val backend = newBackend(Seq.empty)
     val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF(_ => ResponseStub.adjust(completedResponse, StatusCode.Ok))
 
-    val response = backend.sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false)
+    val response = backend.sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false, IterationInfo(1, 10))
     response.textContent shouldBe "done"
     response.toolCalls shouldBe empty
     response.stopReason shouldBe StopReason.EndTurn
@@ -163,7 +163,7 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     val backend = newBackend(Seq.empty)
     val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF(_ => ResponseStub.adjust(toolCallResponse, StatusCode.Ok))
 
-    val response = backend.sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false)
+    val response = backend.sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false, IterationInfo(1, 10))
     response.stopReason shouldBe StopReason.ToolUse
     response.toolCalls shouldBe Seq(ToolCall("call_9", "get_weather", """{"city":"Warsaw"}"""))
   }
@@ -174,7 +174,7 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF(_ => ResponseStub.adjust(failedResponse, StatusCode.Ok))
 
     a[RuntimeException] should be thrownBy
-      backend.sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false)
+      backend.sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false, IterationInfo(1, 10))
   }
 
   it should "map completed responses that still contain function calls to ToolUse" in {
@@ -185,7 +185,7 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     val backend = newBackend(Seq.empty)
     val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF(_ => ResponseStub.adjust(completedWithCalls, StatusCode.Ok))
 
-    val response = backend.sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false)
+    val response = backend.sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false, IterationInfo(1, 10))
     response.stopReason shouldBe StopReason.ToolUse
     response.toolCalls.map(_.toolName) shouldBe Seq("get_weather")
   }
@@ -196,7 +196,7 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF(_ => ResponseStub.adjust(cancelledResponse, StatusCode.Ok))
 
     val ex = the[RuntimeException] thrownBy
-      backend.sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false)
+      backend.sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false, IterationInfo(1, 10))
     ex.getMessage should include("cancelled")
   }
 
@@ -207,7 +207,7 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     val backend = newBackend(Seq.empty)
     val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF(_ => ResponseStub.adjust(nullArgsResponse, StatusCode.Ok))
 
-    val response = backend.sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false)
+    val response = backend.sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false, IterationInfo(1, 10))
     response.toolCalls shouldBe Seq(ToolCall("call_9", "now", "{}"))
   }
 
@@ -216,7 +216,7 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     val backend = newBackend(Seq.empty)
     val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF(_ => ResponseStub.adjust(completedResponse, StatusCode.Ok))
 
-    a[io.circe.ParsingFailure] should be thrownBy backend.sendRequest(history, httpStub, includeTools = false)
+    a[io.circe.ParsingFailure] should be thrownBy backend.sendRequest(history, httpStub, includeTools = false, IterationInfo(1, 10))
   }
 
   it should "surface the typed GeminiException instead of wrapping it in a generic RuntimeException" in {
@@ -225,7 +225,7 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF(_ => ResponseStub.adjust(errorBody, StatusCode.TooManyRequests))
 
     an[GeminiException.RateLimitException] should be thrownBy
-      backend.sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false)
+      backend.sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false, IterationInfo(1, 10))
   }
 
   it should "send the system prompt as system_instruction" in {
@@ -268,13 +268,13 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     val incompleteStub =
       DefaultSyncBackend.stub.whenAnyRequest.thenRespondF(_ => ResponseStub.adjust("""{"status":"incomplete"}""", StatusCode.Ok))
     backend
-      .sendRequest(ConversationHistory.withInitialPrompt("hi"), incompleteStub, includeTools = false)
+      .sendRequest(ConversationHistory.withInitialPrompt("hi"), incompleteStub, includeTools = false, IterationInfo(1, 10))
       .stopReason shouldBe StopReason.MaxTokens
 
     val budgetStub =
       DefaultSyncBackend.stub.whenAnyRequest.thenRespondF(_ => ResponseStub.adjust("""{"status":"budget_exceeded"}""", StatusCode.Ok))
     backend
-      .sendRequest(ConversationHistory.withInitialPrompt("hi"), budgetStub, includeTools = false)
+      .sendRequest(ConversationHistory.withInitialPrompt("hi"), budgetStub, includeTools = false, IterationInfo(1, 10))
       .stopReason shouldBe StopReason.MaxTokens
   }
 
@@ -283,7 +283,7 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF(_ => ResponseStub.adjust("""{"status":"queued"}""", StatusCode.Ok))
 
     backend
-      .sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false)
+      .sendRequest(ConversationHistory.withInitialPrompt("hi"), httpStub, includeTools = false, IterationInfo(1, 10))
       .stopReason shouldBe StopReason.Other("queued")
   }
 

--- a/gemini/src/test/scala/sttp/ai/gemini/integration/GeminiAgentIntegrationSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/integration/GeminiAgentIntegrationSpec.scala
@@ -34,7 +34,7 @@ class GeminiAgentIntegrationSpec extends AgentIntegrationSpecBase {
       responseSchema: ResponseSchema[T]
   ): Agent[Identity] =
     GeminiAgent
-      .synchronous(GeminiConfig.fromEnv, GeminiModel.Gemini35FlashLite.value)
+      .synchronous(GeminiConfig.fromEnv, GeminiModel.Gemini35FlashLite)
       .maxIterations(maxIterations)
       .tools(tools)
       .responseSchema(responseSchema)

--- a/gemini/src/test/scala/sttp/ai/gemini/integration/GeminiAgentIntegrationSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/integration/GeminiAgentIntegrationSpec.scala
@@ -11,8 +11,6 @@ import sttp.shared.Identity
 
 class GeminiAgentIntegrationSpec extends AgentIntegrationSpecBase {
 
-  private val testModel = GeminiModel.Gemini35FlashLite.value
-
   override def providerName: String = "Gemini"
   override def apiKeyEnvVar: String = "GEMINI_API_KEY"
 
@@ -22,7 +20,7 @@ class GeminiAgentIntegrationSpec extends AgentIntegrationSpecBase {
     val agentConfig = AgentConfig[Identity](maxIterations = maxIterations, userTools = tools)
     val agentBackend = new GeminiAgentBackend[Identity](
       client,
-      testModel,
+      _ => GeminiModel.Gemini35FlashLite,
       agentConfig.userTools,
       agentConfig.systemPrompt,
       agentConfig.responseSchema
@@ -36,7 +34,7 @@ class GeminiAgentIntegrationSpec extends AgentIntegrationSpecBase {
       responseSchema: ResponseSchema[T]
   ): Agent[Identity] =
     GeminiAgent
-      .synchronous(GeminiConfig.fromEnv, testModel)
+      .synchronous(GeminiConfig.fromEnv, GeminiModel.Gemini35FlashLite.value)
       .maxIterations(maxIterations)
       .tools(tools)
       .responseSchema(responseSchema)

--- a/gemini/src/test/scala/sttp/ai/gemini/unit/models/GeminiModelSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/unit/models/GeminiModelSpec.scala
@@ -2,6 +2,7 @@ package sttp.ai.gemini.unit.models
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.ai.core.model.Capability
 import sttp.ai.gemini.models.GeminiModel
 
 class GeminiModelSpec extends AnyFlatSpec with Matchers {
@@ -21,4 +22,20 @@ class GeminiModelSpec extends AnyFlatSpec with Matchers {
 
   it should "have a non-empty value for every model" in
     GeminiModel.values.foreach(_.value should not be empty)
+
+  "GeminiModel" should "tag every predefined model with all four capabilities" in
+    GeminiModel.values.foreach { m =>
+      m shouldBe a[Capability.Vision]
+      m shouldBe a[Capability.ToolCalling]
+      m shouldBe a[Capability.StructuredOutput]
+      m shouldBe a[Capability.Reasoning]
+    }
+
+  it should "make CustomModel claim all capabilities" in {
+    val custom = GeminiModel.CustomModel("my-gemini")
+    custom shouldBe a[Capability.Vision]
+    custom shouldBe a[Capability.ToolCalling]
+    custom shouldBe a[Capability.StructuredOutput]
+    custom shouldBe a[Capability.Reasoning]
+  }
 }

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/integration/McpAgentIntegrationSpec.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/integration/McpAgentIntegrationSpec.scala
@@ -13,6 +13,7 @@ import sttp.ai.claude.agent.ClaudeAgent
 import sttp.ai.claude.config.ClaudeConfig
 import sttp.ai.core.agent.mcp.McpTools
 import sttp.ai.core.agent.{AgentBuilder, AgentResult, AgentTool}
+import sttp.ai.core.model.AIModel
 import sttp.ai.openai.OpenAI
 import sttp.ai.openai.agent.OpenAIAgent
 import sttp.client4.DefaultSyncBackend
@@ -33,7 +34,7 @@ class McpAgentIntegrationSpec extends AnyFlatSpec with Matchers {
   case class Location(lat: Double, lng: Double) derives Codec, Schema
   case class CreateEventInput(title: String, location: Option[Location], priority: Option[String]) derives Codec, Schema
 
-  private def withMcpAgentRun(builderFor: Seq[AgentTool[Identity, ?]] => AgentBuilder[Identity])(
+  private def withMcpAgentRun[M <: AIModel](builderFor: Seq[AgentTool[Identity, ?]] => AgentBuilder[Identity, M])(
       check: AgentResult[String] => Assertion
   ): Assertion =
     supervised {

--- a/model_update_scripts/README.md
+++ b/model_update_scripts/README.md
@@ -75,6 +75,10 @@ with `with Capability.X` mixins resolved fresh from this config, in canonical or
 `StructuredOutput`, `Reasoning`). Any hand-written mixins already in the file are discarded; the yaml config is
 the source of truth. Endpoints with no `capabilities` entry render with no mixin clause, unchanged from before.
 
+Note: the script only manages the mixin clauses. Before adding a `capabilities` entry for a new endpoint, the
+target file must already import `sttp.ai.core.model.Capability` and its model class must extend
+`sttp.ai.core.model.AIModel` — otherwise the generated `with Capability.X` clauses won't compile.
+
 ## Default Behavior
 
 - **JSON file**: `models.json` is used by default

--- a/model_update_scripts/README.md
+++ b/model_update_scripts/README.md
@@ -60,6 +60,20 @@ The `model_update_config.yaml` file defines:
 - **Name conversion rules**: How to convert model names to Scala identifiers
 - **Insert markers**: Where to place new case objects in each file
 - **Values sets**: Optional companion value sets to maintain
+- **Capability tags**: Optional `Capability` mixins to render on each endpoint's model constants (see below)
+
+### Capability tags
+
+The `capabilities` section maps an endpoint (e.g. `"v1/chat/completions"`) to a list of glob `rules` plus a
+`defaults` fallback. Each rule has a `pattern` (glob over the model id, `*` matches any characters) and a
+`capabilities` list; **the first matching rule (top to bottom) wins** and gives the model's complete capability
+set. A model id matching no rule falls back to `defaults`. This section is hand-curated - it is never scraped
+or inferred from the model listing.
+
+On `--apply`, every constant in an endpoint's managed block - both existing and newly added - is re-rendered
+with `with Capability.X` mixins resolved fresh from this config, in canonical order (`Vision`, `ToolCalling`,
+`StructuredOutput`, `Reasoning`). Any hand-written mixins already in the file are discarded; the yaml config is
+the source of truth. Endpoints with no `capabilities` entry render with no mixin clause, unchanged from before.
 
 ## Default Behavior
 

--- a/model_update_scripts/README.md
+++ b/model_update_scripts/README.md
@@ -80,6 +80,12 @@ Note: the script only manages the mixin clauses. Before adding a `capabilities` 
 target file must already import `sttp.ai.core.model.Capability` and its model class must extend
 `sttp.ai.core.model.AIModel` — otherwise the generated `with Capability.X` clauses won't compile.
 
+The block parser has unit tests; run them with:
+
+```bash
+scala-cli test update_code_with_new_models.scala update_code_with_new_models.test.scala
+```
+
 ## Default Behavior
 
 - **JSON file**: `models.json` is used by default

--- a/model_update_scripts/README.md
+++ b/model_update_scripts/README.md
@@ -72,7 +72,8 @@ or inferred from the model listing.
 
 On `--apply`, every constant in an endpoint's managed block - both existing and newly added - is re-rendered
 with `with Capability.X` mixins resolved fresh from this config, in canonical order (`Vision`, `ToolCalling`,
-`StructuredOutput`, `Reasoning`). Any hand-written mixins already in the file are discarded; the yaml config is
+`StructuredOutput`, `Reasoning`); a model with all four capabilities is rendered with the `with Capability.All`
+shorthand instead. Any hand-written mixins already in the file are discarded; the yaml config is
 the source of truth. Endpoints with no `capabilities` entry render with no mixin clause, unchanged from before.
 
 Note: the script only manages the mixin clauses. Before adding a `capabilities` entry for a new endpoint, the

--- a/model_update_scripts/model_update_config.yaml
+++ b/model_update_scripts/model_update_config.yaml
@@ -74,6 +74,7 @@ endpoints:
 # Capability tags applied to generated model constants. First matching rule (top to bottom)
 # gives the model's COMPLETE capability set; models matching no rule get `defaults`.
 # Patterns are globs over the model id ('*' matches any characters). Maintained by hand — never scraped.
+# Curated from OpenAI's per-model documentation (platform.openai.com/docs/models), last reviewed 2026-08-06.
 capabilities:
   "v1/chat/completions":
     defaults: [ToolCalling]
@@ -83,6 +84,9 @@ capabilities:
       - pattern: "gpt-3.5-turbo-instruct"
         capabilities: []
       - pattern: "gpt-3.5-turbo-0301"
+        capabilities: []
+      # the -0314 snapshots predate function calling (introduced with -0613)
+      - pattern: "gpt-4*-0314"
         capabilities: []
       - pattern: "gpt-4-1106-vision-preview"
         capabilities: [Vision]
@@ -96,6 +100,9 @@ capabilities:
         capabilities: [ToolCalling]
       - pattern: "gpt-4o*search-preview*"
         capabilities: [StructuredOutput]
+      # json_schema structured outputs need gpt-4o-2024-08-06 or later
+      - pattern: "gpt-4o-2024-05-13"
+        capabilities: [Vision, ToolCalling]
       - pattern: "gpt-4o*"
         capabilities: [Vision, ToolCalling, StructuredOutput]
       - pattern: "gpt-5-chat-latest"

--- a/model_update_scripts/model_update_config.yaml
+++ b/model_update_scripts/model_update_config.yaml
@@ -1,75 +1,119 @@
 endpoints:
   "v1/assistants":
-    file: "openai/src/main/scala/sttp/openai/requests/assistants/AssistantsModel.scala"
+    file: "openai/src/main/scala/sttp/ai/openai/requests/assistants/AssistantsModel.scala"
     className: "AssistantsModel"
     insertBeforeMarker: "case class CustomAssistantsModel"
     valuesSetName: "values"
 
   "v1/chat/completions":
-    file: "openai/src/main/scala/sttp/openai/requests/completions/chat/ChatRequestBody.scala"
+    file: "openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestBody.scala"
     className: "ChatCompletionModel"
     insertBeforeMarker: "case class CustomChatCompletionModel"
     valuesSetName: "values"
-    
+
   "v1/completions":
-    file: "openai/src/main/scala/sttp/openai/requests/completions/CompletionsRequestBody.scala"
+    file: "openai/src/main/scala/sttp/ai/openai/requests/completions/CompletionsRequestBody.scala"
     className: "CompletionModel"
     insertBeforeMarker: "case class CustomCompletionModel"
     valuesSetName: "values"
-    
+
   "v1/embeddings":
-    file: "openai/src/main/scala/sttp/openai/requests/embeddings/EmbeddingsRequestBody.scala"
+    file: "openai/src/main/scala/sttp/ai/openai/requests/embeddings/EmbeddingsRequestBody.scala"
     className: "EmbeddingsModel"
     insertBeforeMarker: "case class CustomEmbeddingsModel"
     valuesSetName: "values"
-  
+
   "v1/images/generations":
-    file: "openai/src/main/scala/sttp/openai/requests/images/creation/ImageCreationRequestBody.scala"
+    file: "openai/src/main/scala/sttp/ai/openai/requests/images/creation/ImageCreationRequestBody.scala"
     className: "ImageCreationModel"
     insertBeforeMarker: "case class CustomImageCreationModel"
     valuesSetName: null
-  
+
   "v1/images/edits":
-    file: "openai/src/main/scala/sttp/openai/requests/images/edit/ImageEditsConfig.scala"
+    file: "openai/src/main/scala/sttp/ai/openai/requests/images/edit/ImageEditsConfig.scala"
     className: "ImageEditsModel"
     insertBeforeMarker: "case class CustomImageEditsModel"
     valuesSetName: null
 
   "v1/fine-tuning":
-    file: "openai/src/main/scala/sttp/openai/requests/finetuning/FineTuningModel.scala"
+    file: "openai/src/main/scala/sttp/ai/openai/requests/finetuning/FineTuningModel.scala"
     className: "FineTuningModel"
     insertBeforeMarker: "case class CustomFineTuningModel"
     valuesSetName: "values"
-    
+
   "v1/moderations":
-    file: "openai/src/main/scala/sttp/openai/requests/moderations/ModerationsRequestBody.scala"
+    file: "openai/src/main/scala/sttp/ai/openai/requests/moderations/ModerationsRequestBody.scala"
     className: "ModerationModel"
     insertBeforeMarker: "case class CustomModerationModel"
     valuesSetName: "values"
 
   "v1/responses":
-    file: "openai/src/main/scala/sttp/openai/requests/responses/ResponsesModel.scala"
+    file: "openai/src/main/scala/sttp/ai/openai/requests/responses/ResponsesModel.scala"
     className: "ResponsesModel"
     insertBeforeMarker: "case class CustomResponsesModel"
     valuesSetName: "values"
 
   "v1/audio/speech":
-    file: "openai/src/main/scala/sttp/openai/requests/audio/speech/SpeechRequestBody.scala"
+    file: "openai/src/main/scala/sttp/ai/openai/requests/audio/speech/SpeechRequestBody.scala"
     className: "SpeechModel"
     insertBeforeMarker: "case class CustomSpeechModel"
     valuesSetName: null
-    
+
   "v1/audio/transcriptions":
-    file: "openai/src/main/scala/sttp/openai/requests/audio/transcriptions/TranscriptionModel.scala"
+    file: "openai/src/main/scala/sttp/ai/openai/requests/audio/transcriptions/TranscriptionModel.scala"
     className: "TranscriptionModel"
     insertBeforeMarker: "case class Custom"
     valuesSetName: null
-    
+
   "v1/audio/translations":
-    file: "openai/src/main/scala/sttp/openai/requests/audio/translations/TranslationModel.scala"
+    file: "openai/src/main/scala/sttp/ai/openai/requests/audio/translations/TranslationModel.scala"
     className: "TranslationModel"
     insertBeforeMarker: "case class Custom"
     valuesSetName: null
+
+# Capability tags applied to generated model constants. First matching rule (top to bottom)
+# gives the model's COMPLETE capability set; models matching no rule get `defaults`.
+# Patterns are globs over the model id ('*' matches any characters). Maintained by hand — never scraped.
+capabilities:
+  "v1/chat/completions":
+    defaults: [ToolCalling]
+    rules:
+      - pattern: "chatgpt-4o-latest"
+        capabilities: [Vision]
+      - pattern: "gpt-3.5-turbo-instruct"
+        capabilities: []
+      - pattern: "gpt-3.5-turbo-0301"
+        capabilities: []
+      - pattern: "gpt-4-1106-vision-preview"
+        capabilities: [Vision]
+      - pattern: "gpt-4-turbo-2024-04-09"
+        capabilities: [Vision, ToolCalling]
+      - pattern: "gpt-4.5-preview*"
+        capabilities: [Vision, ToolCalling, StructuredOutput]
+      - pattern: "gpt-4.1*"
+        capabilities: [Vision, ToolCalling, StructuredOutput]
+      - pattern: "gpt-4o*audio-preview*"
+        capabilities: [ToolCalling]
+      - pattern: "gpt-4o*search-preview*"
+        capabilities: [StructuredOutput]
+      - pattern: "gpt-4o*"
+        capabilities: [Vision, ToolCalling, StructuredOutput]
+      - pattern: "gpt-5-chat-latest"
+        capabilities: [Vision, StructuredOutput]
+      - pattern: "gpt-5*"
+        capabilities: [Vision, ToolCalling, StructuredOutput, Reasoning]
+      - pattern: "o1-mini*"
+        capabilities: [Reasoning]
+      - pattern: "o1-preview*"
+        capabilities: [Reasoning]
+      - pattern: "o1*"
+        capabilities: [Vision, ToolCalling, StructuredOutput, Reasoning]
+      - pattern: "o3-mini*"
+        capabilities: [ToolCalling, StructuredOutput, Reasoning]
+      - pattern: "o3*"
+        capabilities: [Vision, ToolCalling, StructuredOutput, Reasoning]
+      - pattern: "o4-mini*"
+        capabilities: [Vision, ToolCalling, StructuredOutput, Reasoning]
 
 # Name conversion rules for model names to Scala identifiers
 nameConversion:

--- a/model_update_scripts/update_code_with_new_models.scala
+++ b/model_update_scripts/update_code_with_new_models.scala
@@ -36,18 +36,26 @@ def capabilitiesFor(modelId: String, config: Option[CapabilityConfig]): List[Str
       CanonicalOrder.filter(set.contains)
   }
 
-// Validates every rule and defaults list up front (at config load), so a typo in a shadowed or
-// currently-unmatched rule fails loudly instead of lying dormant until a model id first hits it.
-def validateCapabilityNames(capabilities: Map[String, CapabilityConfig]): Unit =
-  capabilities.foreach { case (endpoint, cfg) =>
-    def check(names: List[String], where: String): Unit =
-      names.filterNot(CanonicalOrder.contains).foreach { unknown =>
-        throw new IllegalArgumentException(
-          s"Unknown capability '$unknown' in $where of endpoint '$endpoint' (known capabilities: ${CanonicalOrder.mkString(", ")})"
-        )
-      }
-    check(cfg.defaults, "defaults")
-    cfg.rules.foreach(r => check(r.capabilities, s"rule '${r.pattern}'"))
+// Validates the whole capabilities section up front (at config load): every capability name in every
+// rule and defaults list (so a typo in a shadowed or currently-unmatched rule fails loudly instead of
+// lying dormant), and every endpoint key (so a typo'd endpoint doesn't silently tag nothing).
+def validateCapabilities(config: ModelUpdateConfig): Unit =
+  config.capabilities.foreach { capabilities =>
+    capabilities.keys.filterNot(config.endpoints.contains).foreach { endpoint =>
+      throw new IllegalArgumentException(
+        s"capabilities section references unknown endpoint '$endpoint' (configured endpoints: ${config.endpoints.keys.mkString(", ")})"
+      )
+    }
+    capabilities.foreach { case (endpoint, cfg) =>
+      def check(names: List[String], where: String): Unit =
+        names.filterNot(CanonicalOrder.contains).foreach { unknown =>
+          throw new IllegalArgumentException(
+            s"Unknown capability '$unknown' in $where of endpoint '$endpoint' (known capabilities: ${CanonicalOrder.mkString(", ")})"
+          )
+        }
+      check(cfg.defaults, "defaults")
+      cfg.rules.foreach(r => check(r.capabilities, s"rule '${r.pattern}'"))
+    }
   }
 
 def mixinClause(capabilities: List[String]): String =
@@ -198,7 +206,7 @@ object ModelUpdater extends IOApp {
           case e: Exception => throw e
         }
       }
-      _ <- IO(config.capabilities.foreach(validateCapabilityNames))
+      _ <- IO(validateCapabilities(config))
       _ <- logger.debug(s"✅ Loaded config with ${config.endpoints.size} endpoints")
     } yield config
 
@@ -386,10 +394,20 @@ object ModelUpdater extends IOApp {
       // A bare `case object Name` only starts a block for our className if the following
       // non-empty line is its `extends ClassName(` continuation - otherwise it may be a
       // case object of a different class entirely.
-      lines.drop(index + 1).find(_.trim.nonEmpty).exists(_.trim.startsWith(s"extends $className("))
+      val next = nextNonEmptyIndex(lines, index + 1)
+      next < lines.length && lines(next).trim.startsWith(s"extends $className(")
     } else {
       false
     }
+  }
+
+  /** Index of the first line at or after `from` whose trimmed content is non-empty; `lines.length` if none. Shared by
+    * [[isCaseObjectStart]] and [[parseCaseObjects]] so both treat blank lines inside a wrapped definition identically.
+    */
+  private def nextNonEmptyIndex(lines: collection.Seq[String], from: Int): Int = {
+    var j = from
+    while (j < lines.length && lines(j).trim.isEmpty) j += 1
+    j
   }
 
   private def isContinuationLine(line: String): Boolean = {
@@ -397,7 +415,8 @@ object ModelUpdater extends IOApp {
     trimmed.startsWith("with ") || trimmed.startsWith("extends ")
   }
 
-  private def parseCaseObjects(blockLines: List[String], className: String): List[CaseObjectInfo] = {
+  // Not private: exercised directly by update_code_with_new_models.test.scala.
+  def parseCaseObjects(blockLines: List[String], className: String): List[CaseObjectInfo] = {
     val fullPattern = s"""^\\s*case object\\s+(\\w+)\\s+extends\\s+$className\\("([^"]+)"\\).*""".r
     val shortStartPattern = """^case object\s+(\w+)$""".r
     val extendsPattern = s"""^extends\\s+$className\\("([^"]+)"\\).*""".r
@@ -414,7 +433,7 @@ object ModelUpdater extends IOApp {
         case line =>
           line.trim match {
             case shortStartPattern(name) =>
-              val extendsLineIndex = i + 1
+              val extendsLineIndex = nextNonEmptyIndex(linesArray, i + 1)
               if (extendsLineIndex < linesArray.length) {
                 linesArray(extendsLineIndex).trim match {
                   case extendsPattern(modelName) =>

--- a/model_update_scripts/update_code_with_new_models.scala
+++ b/model_update_scripts/update_code_with_new_models.scala
@@ -23,6 +23,22 @@ import scala.io.Source
 import scala.util.boundary.break
 import scala.util.{boundary, Using}
 
+val CanonicalOrder = List("Vision", "ToolCalling", "StructuredOutput", "Reasoning")
+
+def globToRegex(glob: String): scala.util.matching.Regex =
+  ("^" + glob.split("\\*", -1).map(java.util.regex.Pattern.quote).mkString(".*") + "$").r
+
+def capabilitiesFor(modelId: String, config: Option[CapabilityConfig]): List[String] =
+  config match {
+    case None      => Nil
+    case Some(cfg) =>
+      val set = cfg.rules.find(r => globToRegex(r.pattern).matches(modelId)).map(_.capabilities).getOrElse(cfg.defaults)
+      CanonicalOrder.filter(set.contains)
+  }
+
+def mixinClause(capabilities: List[String]): String =
+  capabilities.map(c => s" with Capability.$c").mkString
+
 opaque type Endpoint = String
 
 object Endpoint {
@@ -59,9 +75,14 @@ case class NameConversionConfig(
 
 case class ModelWithSnapshots(name: String, snapshots: List[String])
 
+case class CapabilityRule(pattern: String, capabilities: List[String]) derives YamlCodec
+
+case class CapabilityConfig(defaults: List[String], rules: List[CapabilityRule]) derives YamlCodec
+
 case class ModelUpdateConfig(
     endpoints: Map[String, EndpointConfig],
-    nameConversion: NameConversionConfig
+    nameConversion: NameConversionConfig,
+    capabilities: Option[Map[String, CapabilityConfig]] = None
 ) derives YamlCodec
 
 object ModelUpdater extends IOApp {
@@ -203,7 +224,8 @@ object ModelUpdater extends IOApp {
               _ <- modelsWithSnapshots.traverse_ { model =>
                 logger.debug(s"  ${model.name} (${model.snapshots.size} snapshots: ${model.snapshots.mkString(", ")})")
               }
-              result <- updateSingleModelClass(endpointConfig, allModelNames, config.nameConversion, dryRun)
+              capabilityConfig = config.capabilities.flatMap(_.get(endpoint))
+              result <- updateSingleModelClass(endpointConfig, allModelNames, config.nameConversion, capabilityConfig, dryRun)
             } yield Some(result)
           case None =>
             logger.warn(s"⚠️ No config found for endpoint: $endpoint") *>
@@ -234,6 +256,7 @@ object ModelUpdater extends IOApp {
       endpointConfig: EndpointConfig,
       models: List[String],
       nameConversion: NameConversionConfig,
+      capabilityConfig: Option[CapabilityConfig],
       dryRun: Boolean
   ): IO[String] =
     for {
@@ -258,14 +281,20 @@ object ModelUpdater extends IOApp {
         existingModelNames.contains(scalaId)
       }
 
-      newCaseObjects = modelsToAdd.map { case (modelName, scalaId) =>
-        CaseObjectInfo(scalaId, s"  case object $scalaId extends ${endpointConfig.className}(\"$modelName\")", modelName)
+      existingCaseObjectsRendered = caseObjectBlock.caseObjects.map { caseObj =>
+        renderCaseObject(caseObj.name, caseObj.originalModelName, endpointConfig.className, capabilityConfig)
       }
 
-      allCaseObjects = (caseObjectBlock.caseObjects ++ newCaseObjects).sortBy(_.name)
+      newCaseObjects = modelsToAdd.map { case (modelName, scalaId) =>
+        renderCaseObject(scalaId, modelName, endpointConfig.className, capabilityConfig)
+      }
 
+      allCaseObjects = (existingCaseObjectsRendered ++ newCaseObjects).sortBy(_.name)
+
+      // Capability mixins are re-derived from config on every run (config is the source of truth), so any
+      // endpoint with a capability config must always be re-rendered, even when no models were added.
       _ <-
-        if (modelsToAdd.nonEmpty || caseObjectBlock.caseObjects.size != allCaseObjects.size) {
+        if (modelsToAdd.nonEmpty || caseObjectBlock.caseObjects.size != allCaseObjects.size || capabilityConfig.isDefined) {
           for {
             _ <- logger.info(
               s"🔄 Reordering ${allCaseObjects.size} case objects (${modelsToAdd.size} new, ${caseObjectBlock.caseObjects.size} existing)"
@@ -310,15 +339,84 @@ object ModelUpdater extends IOApp {
 
   case class CaseObjectBlock(startIndex: Int, endIndex: Int, caseObjects: List[CaseObjectInfo])
 
+  // Mixins are always re-derived from the capability config (config is the source of truth); any hand-written
+  // mixins found in the file are discarded and replaced by whatever the config resolves for this model id.
+  private def renderCaseObject(
+      scalaId: String,
+      modelName: String,
+      className: String,
+      capabilityConfig: Option[CapabilityConfig]
+  ): CaseObjectInfo = {
+    val caps = capabilitiesFor(modelName, capabilityConfig)
+    CaseObjectInfo(scalaId, s"  case object $scalaId extends $className(\"$modelName\")${mixinClause(caps)}", modelName)
+  }
+
+  // scalafmt wraps long tagged definitions across multiple lines, e.g.:
+  //   case object GPT41
+  //       extends ChatCompletionModel("gpt-4.1")
+  //       with Capability.Vision
+  //       with Capability.ToolCalling
+  // so a case object definition either matches fully on one line, or starts with a bare
+  // `case object Name`, is followed by an `extends ClassName("id")` line, and is then
+  // followed by zero or more `with ...` continuation lines - all of which are discarded here
+  // (mixins are always re-derived from the capability config, never read back from the file).
+  private def isCaseObjectStart(className: String)(line: String): Boolean = {
+    val fullPattern = s"""^\\s*case object\\s+(\\w+)\\s+extends\\s+$className\\("([^"]+)"\\).*""".r
+    val shortStartPattern = """^case object\s+(\w+)$""".r
+    fullPattern.matches(line) || shortStartPattern.matches(line.trim)
+  }
+
+  private def isContinuationLine(line: String): Boolean = {
+    val trimmed = line.trim
+    trimmed.startsWith("with ") || trimmed.startsWith("extends ")
+  }
+
+  private def parseCaseObjects(blockLines: List[String], className: String): List[CaseObjectInfo] = {
+    val fullPattern = s"""^\\s*case object\\s+(\\w+)\\s+extends\\s+$className\\("([^"]+)"\\).*""".r
+    val shortStartPattern = """^case object\s+(\w+)$""".r
+    val extendsPattern = s"""^extends\\s+$className\\("([^"]+)"\\).*""".r
+
+    val linesArray = blockLines.toArray
+    val result = scala.collection.mutable.ListBuffer.empty[CaseObjectInfo]
+    var i = 0
+    while (i < linesArray.length) {
+      linesArray(i) match {
+        case fullPattern(name, modelName) =>
+          result += CaseObjectInfo(name, linesArray(i).trim, modelName)
+          i += 1
+          while (i < linesArray.length && isContinuationLine(linesArray(i))) i += 1
+        case line =>
+          line.trim match {
+            case shortStartPattern(name) =>
+              val extendsLineIndex = i + 1
+              if (extendsLineIndex < linesArray.length) {
+                linesArray(extendsLineIndex).trim match {
+                  case extendsPattern(modelName) =>
+                    result += CaseObjectInfo(name, s"case object $name extends $className(\"$modelName\")", modelName)
+                    i = extendsLineIndex + 1
+                    while (i < linesArray.length && isContinuationLine(linesArray(i))) i += 1
+                  case _ =>
+                    i += 1
+                }
+              } else {
+                i += 1
+              }
+            case _ =>
+              i += 1
+          }
+      }
+    }
+    result.toList
+  }
+
   private def findCaseObjectBlock(content: String, className: String, insertBeforeMarker: String): Option[CaseObjectBlock] =
     val lines = content.split("\n").toList
-    val caseObjectPattern = s"""^\\s*case object\\s+(\\w+)\\s+extends\\s+$className\\("([^"]+)"\\).*""".r
     val markerIndex = lines.indexWhere(_.contains(insertBeforeMarker))
 
     if (markerIndex == -1) {
       None
     } else {
-      val startIndex = lines.indexWhere(caseObjectPattern.matches)
+      val startIndex = lines.indexWhere(isCaseObjectStart(className))
       val endIndex = boundary {
         lines.take(markerIndex).zipWithIndex.reverse.foldLeft(-1) { case (passedIndex, (line, index)) =>
           if (!isCommentLine(line)) {
@@ -332,17 +430,9 @@ object ModelUpdater extends IOApp {
         // No case objects found before marker
         Some(CaseObjectBlock(markerIndex, markerIndex, List.empty))
       } else {
-        // Extract all case objects in the block that extend our className
-        val caseObjects = lines
-          .slice(startIndex, endIndex)
-          .zipWithIndex
-          .flatMap { case (line, index) =>
-            line match {
-              case caseObjectPattern(name, modelName) =>
-                Some(CaseObjectInfo(name, line.trim, modelName))
-              case _ => None
-            }
-          }
+        // Extract all case objects in the block that extend our className, tolerating definitions
+        // wrapped across multiple lines by scalafmt.
+        val caseObjects = parseCaseObjects(lines.slice(startIndex, endIndex), className)
 
         Some(CaseObjectBlock(startIndex, endIndex, caseObjects))
       }

--- a/model_update_scripts/update_code_with_new_models.scala
+++ b/model_update_scripts/update_code_with_new_models.scala
@@ -32,7 +32,11 @@ def capabilitiesFor(modelId: String, config: Option[CapabilityConfig]): List[Str
   config match {
     case None      => Nil
     case Some(cfg) =>
-      val set = cfg.rules.find(r => globToRegex(r.pattern).matches(modelId)).map(_.capabilities).getOrElse(cfg.defaults)
+      val (set, patternLabel) =
+        cfg.rules.find(r => globToRegex(r.pattern).matches(modelId)).map(r => (r.capabilities, r.pattern)).getOrElse((cfg.defaults, "defaults"))
+      set.find(name => !CanonicalOrder.contains(name)).foreach { unknown =>
+        throw new IllegalArgumentException(s"Unknown capability '$unknown' in $patternLabel (known capabilities: ${CanonicalOrder.mkString(", ")})")
+      }
       CanonicalOrder.filter(set.contains)
   }
 
@@ -360,10 +364,20 @@ object ModelUpdater extends IOApp {
   // `case object Name`, is followed by an `extends ClassName("id")` line, and is then
   // followed by zero or more `with ...` continuation lines - all of which are discarded here
   // (mixins are always re-derived from the capability config, never read back from the file).
-  private def isCaseObjectStart(className: String)(line: String): Boolean = {
+  private def isCaseObjectStart(className: String)(lines: List[String], index: Int): Boolean = {
+    val line = lines(index)
     val fullPattern = s"""^\\s*case object\\s+(\\w+)\\s+extends\\s+$className\\("([^"]+)"\\).*""".r
     val shortStartPattern = """^case object\s+(\w+)$""".r
-    fullPattern.matches(line) || shortStartPattern.matches(line.trim)
+    if (fullPattern.matches(line)) {
+      true
+    } else if (shortStartPattern.matches(line.trim)) {
+      // A bare `case object Name` only starts a block for our className if the following
+      // non-empty line is its `extends ClassName(` continuation - otherwise it may be a
+      // case object of a different class entirely (see finding #3).
+      lines.drop(index + 1).find(_.trim.nonEmpty).exists(_.trim.startsWith(s"extends $className("))
+    } else {
+      false
+    }
   }
 
   private def isContinuationLine(line: String): Boolean = {
@@ -416,7 +430,7 @@ object ModelUpdater extends IOApp {
     if (markerIndex == -1) {
       None
     } else {
-      val startIndex = lines.indexWhere(isCaseObjectStart(className))
+      val startIndex = lines.indices.find(i => isCaseObjectStart(className)(lines, i)).getOrElse(-1)
       val endIndex = boundary {
         lines.take(markerIndex).zipWithIndex.reverse.foldLeft(-1) { case (passedIndex, (line, index)) =>
           if (!isCommentLine(line)) {

--- a/model_update_scripts/update_code_with_new_models.scala
+++ b/model_update_scripts/update_code_with_new_models.scala
@@ -32,12 +32,22 @@ def capabilitiesFor(modelId: String, config: Option[CapabilityConfig]): List[Str
   config match {
     case None      => Nil
     case Some(cfg) =>
-      val (set, patternLabel) =
-        cfg.rules.find(r => globToRegex(r.pattern).matches(modelId)).map(r => (r.capabilities, r.pattern)).getOrElse((cfg.defaults, "defaults"))
-      set.find(name => !CanonicalOrder.contains(name)).foreach { unknown =>
-        throw new IllegalArgumentException(s"Unknown capability '$unknown' in $patternLabel (known capabilities: ${CanonicalOrder.mkString(", ")})")
-      }
+      val set = cfg.rules.find(r => globToRegex(r.pattern).matches(modelId)).map(_.capabilities).getOrElse(cfg.defaults)
       CanonicalOrder.filter(set.contains)
+  }
+
+// Validates every rule and defaults list up front (at config load), so a typo in a shadowed or
+// currently-unmatched rule fails loudly instead of lying dormant until a model id first hits it.
+def validateCapabilityNames(capabilities: Map[String, CapabilityConfig]): Unit =
+  capabilities.foreach { case (endpoint, cfg) =>
+    def check(names: List[String], where: String): Unit =
+      names.filterNot(CanonicalOrder.contains).foreach { unknown =>
+        throw new IllegalArgumentException(
+          s"Unknown capability '$unknown' in $where of endpoint '$endpoint' (known capabilities: ${CanonicalOrder.mkString(", ")})"
+        )
+      }
+    check(cfg.defaults, "defaults")
+    cfg.rules.foreach(r => check(r.capabilities, s"rule '${r.pattern}'"))
   }
 
 def mixinClause(capabilities: List[String]): String =
@@ -187,6 +197,7 @@ object ModelUpdater extends IOApp {
           case e: Exception => throw e
         }
       }
+      _ <- IO(config.capabilities.foreach(validateCapabilityNames))
       _ <- logger.debug(s"✅ Loaded config with ${config.endpoints.size} endpoints")
     } yield config
 
@@ -373,7 +384,7 @@ object ModelUpdater extends IOApp {
     } else if (shortStartPattern.matches(line.trim)) {
       // A bare `case object Name` only starts a block for our className if the following
       // non-empty line is its `extends ClassName(` continuation - otherwise it may be a
-      // case object of a different class entirely (see finding #3).
+      // case object of a different class entirely.
       lines.drop(index + 1).find(_.trim.nonEmpty).exists(_.trim.startsWith(s"extends $className("))
     } else {
       false

--- a/model_update_scripts/update_code_with_new_models.scala
+++ b/model_update_scripts/update_code_with_new_models.scala
@@ -51,7 +51,8 @@ def validateCapabilityNames(capabilities: Map[String, CapabilityConfig]): Unit =
   }
 
 def mixinClause(capabilities: List[String]): String =
-  capabilities.map(c => s" with Capability.$c").mkString
+  if (capabilities == CanonicalOrder) " with Capability.All"
+  else capabilities.map(c => s" with Capability.$c").mkString
 
 opaque type Endpoint = String
 

--- a/model_update_scripts/update_code_with_new_models.test.scala
+++ b/model_update_scripts/update_code_with_new_models.test.scala
@@ -1,0 +1,53 @@
+//> using test.dep org.scalameta::munit::1.0.4
+
+// Run with: scala-cli test update_code_with_new_models.scala update_code_with_new_models.test.scala
+class ParseCaseObjectsTest extends munit.FunSuite {
+
+  private val className = "ChatCompletionModel"
+
+  test("parses single-line definitions, with and without mixins") {
+    val lines = List(
+      """    case object GPT4 extends ChatCompletionModel("gpt-4") with Capability.ToolCalling""",
+      """    case object GPT35TurboInstruct extends ChatCompletionModel("gpt-3.5-turbo-instruct")"""
+    )
+    val parsed = ModelUpdater.parseCaseObjects(lines, className)
+    assertEquals(parsed.map(p => (p.name, p.originalModelName)), List(("GPT4", "gpt-4"), ("GPT35TurboInstruct", "gpt-3.5-turbo-instruct")))
+  }
+
+  test("parses scalafmt-wrapped definitions: extends on its own line, with-continuations consumed") {
+    val lines = List(
+      """    case object GPT5""",
+      """        extends ChatCompletionModel("gpt-5")""",
+      """        with Capability.All""",
+      """    case object O3Mini""",
+      """        extends ChatCompletionModel("o3-mini")""",
+      """        with Capability.ToolCalling""",
+      """        with Capability.StructuredOutput""",
+      """        with Capability.Reasoning"""
+    )
+    val parsed = ModelUpdater.parseCaseObjects(lines, className)
+    assertEquals(parsed.map(p => (p.name, p.originalModelName)), List(("GPT5", "gpt-5"), ("O3Mini", "o3-mini")))
+  }
+
+  test("tolerates blank lines between a case object line and its extends continuation") {
+    val lines = List(
+      """    case object GPT5""",
+      "",
+      """        extends ChatCompletionModel("gpt-5")""",
+      """        with Capability.All"""
+    )
+    val parsed = ModelUpdater.parseCaseObjects(lines, className)
+    assertEquals(parsed.map(p => (p.name, p.originalModelName)), List(("GPT5", "gpt-5")))
+  }
+
+  test("ignores case objects extending a different class") {
+    val lines = List(
+      """    case object Ash extends Standard""",
+      """    case object Low""",
+      """        extends SomeOtherModel("low")""",
+      """    case object GPT4 extends ChatCompletionModel("gpt-4") with Capability.ToolCalling"""
+    )
+    val parsed = ModelUpdater.parseCaseObjects(lines, className)
+    assertEquals(parsed.map(_.name), List("GPT4"))
+  }
+}

--- a/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
+++ b/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
@@ -144,31 +144,31 @@ object OpenAIAgent {
   def builder[F[_]](
       openAI: OpenAI,
       modelName: String
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
+  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
     builder(openAI, modelName, strictTools = true)
 
   def builder[F[_]](
       apiKey: String,
       modelName: String
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
+  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
     builder(apiKey, modelName, strictTools = true)
 
   def synchronous(
       openAI: OpenAI,
       modelName: String
-  ): AgentBuilder[Identity] = synchronous(openAI, modelName, strictTools = true)
+  ): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel] = synchronous(openAI, modelName, strictTools = true)
 
   def synchronous(
       apiKey: String,
       modelName: String
-  ): AgentBuilder[Identity] = synchronous(apiKey, modelName, strictTools = true)
+  ): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel] = synchronous(apiKey, modelName, strictTools = true)
 
   def builder[F[_]](
       openAI: OpenAI,
       modelName: String,
       strictTools: Boolean
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
-    AgentBuilder[F](config =>
+  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
+    AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel](config =>
       new OpenAIAgentBackend[F](openAI, modelName, config.userTools, config.systemPrompt, config.responseSchema, strictTools)
     )
 
@@ -176,18 +176,20 @@ object OpenAIAgent {
       apiKey: String,
       modelName: String,
       strictTools: Boolean
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F] =
+  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
     builder(new OpenAI(apiKey), modelName, strictTools)
 
   def synchronous(
       openAI: OpenAI,
       modelName: String,
       strictTools: Boolean
-  ): AgentBuilder[Identity] = builder[Identity](openAI, modelName, strictTools)(IdentityMonad)
+  ): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel] =
+    builder[Identity](openAI, modelName, strictTools)(IdentityMonad)
 
   def synchronous(
       apiKey: String,
       modelName: String,
       strictTools: Boolean
-  ): AgentBuilder[Identity] = builder[Identity](apiKey, modelName, strictTools)(IdentityMonad)
+  ): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel] =
+    builder[Identity](apiKey, modelName, strictTools)(IdentityMonad)
 }

--- a/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
+++ b/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
@@ -82,7 +82,8 @@ private[openai] class OpenAIAgentBackend[F[_]](
   override def sendRequest(
       history: ConversationHistory,
       backend: Backend[F],
-      includeTools: Boolean
+      includeTools: Boolean,
+      iterationInfo: IterationInfo
   ): F[AgentResponse] = {
     val messages = buildMessages(history)
     val request = ChatBody(

--- a/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
+++ b/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
@@ -188,6 +188,24 @@ object OpenAIAgent {
         monad: sttp.monad.MonadError[F]
     ): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
       apply(new OpenAI(apiKey), modelName, strictTools)
+
+    def apply[M <: ChatCompletionModel](apiKey: String, model: M)(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, M] =
+      apply(new OpenAI(apiKey), model)
+
+    def apply[M <: ChatCompletionModel](apiKey: String, model: M, strictTools: Boolean)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M] =
+      apply(new OpenAI(apiKey), model, strictTools)
+
+    def apply[M <: ChatCompletionModel](apiKey: String, modelForIteration: IterationInfo => M)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M] =
+      apply(new OpenAI(apiKey), modelForIteration)
+
+    def apply[M <: ChatCompletionModel](apiKey: String, modelForIteration: IterationInfo => M, strictTools: Boolean)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M] =
+      apply(new OpenAI(apiKey), modelForIteration, strictTools)
   }
 
   def synchronous[M <: ChatCompletionModel](openAI: OpenAI, model: M): AgentBuilder[Identity, M] =
@@ -225,4 +243,20 @@ object OpenAIAgent {
       strictTools: Boolean
   ): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel] =
     builder[Identity](apiKey, modelName, strictTools)(IdentityMonad)
+
+  def synchronous[M <: ChatCompletionModel](apiKey: String, model: M): AgentBuilder[Identity, M] =
+    builder[Identity](apiKey, model)(IdentityMonad)
+
+  def synchronous[M <: ChatCompletionModel](apiKey: String, model: M, strictTools: Boolean): AgentBuilder[Identity, M] =
+    builder[Identity](apiKey, model, strictTools)(IdentityMonad)
+
+  def synchronous[M <: ChatCompletionModel](apiKey: String, modelForIteration: IterationInfo => M): AgentBuilder[Identity, M] =
+    builder[Identity](apiKey, modelForIteration)(IdentityMonad)
+
+  def synchronous[M <: ChatCompletionModel](
+      apiKey: String,
+      modelForIteration: IterationInfo => M,
+      strictTools: Boolean
+  ): AgentBuilder[Identity, M] =
+    builder[Identity](apiKey, modelForIteration, strictTools)(IdentityMonad)
 }

--- a/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
+++ b/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
@@ -11,7 +11,7 @@ import sttp.monad.IdentityMonad
 
 private[openai] class OpenAIAgentBackend[F[_]](
     openAI: OpenAI,
-    modelName: String,
+    modelForIteration: IterationInfo => ChatCompletionModel,
     val tools: Seq[AgentTool[F, _]],
     val systemPrompt: Option[String],
     responseSchema: Option[ResponseSchema[_]],
@@ -87,7 +87,7 @@ private[openai] class OpenAIAgentBackend[F[_]](
   ): F[AgentResponse] = {
     val messages = buildMessages(history)
     val request = ChatBody(
-      model = ChatCompletionModel.CustomChatCompletionModel(modelName),
+      model = modelForIteration(iterationInfo),
       messages = messages,
       tools = if (includeTools && convertedTools.nonEmpty) Some(convertedTools) else None,
       responseFormat = responseFormat
@@ -141,43 +141,73 @@ private[openai] class OpenAIAgentBackend[F[_]](
 
 object OpenAIAgent {
 
-  def builder[F[_]](
+  /** Entry point: `OpenAIAgent.builder[F](openAI, model)`. The indirection lets `M` be inferred while `F` is given explicitly. */
+  def builder[F[_]]: BuilderPartiallyApplied[F] = new BuilderPartiallyApplied[F]
+
+  final class BuilderPartiallyApplied[F[_]] private[OpenAIAgent] () {
+
+    def apply[M <: ChatCompletionModel](openAI: OpenAI, model: M)(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, M] =
+      apply(openAI, model, strictTools = true)
+
+    def apply[M <: ChatCompletionModel](openAI: OpenAI, model: M, strictTools: Boolean)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M] =
+      apply(openAI, (_: IterationInfo) => model, strictTools)
+
+    /** Selects the model per loop iteration (e.g. a cheap model for tool iterations, a stronger one for the forced-final synthesis). `M`
+      * infers to the least upper bound of every model the function can return, so capability checks require the shared capabilities.
+      */
+    def apply[M <: ChatCompletionModel](openAI: OpenAI, modelForIteration: IterationInfo => M)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M] =
+      apply(openAI, modelForIteration, strictTools = true)
+
+    def apply[M <: ChatCompletionModel](openAI: OpenAI, modelForIteration: IterationInfo => M, strictTools: Boolean)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M] =
+      AgentBuilder[F, M](config =>
+        new OpenAIAgentBackend[F](openAI, modelForIteration, config.userTools, config.systemPrompt, config.responseSchema, strictTools)
+      )
+
+    def apply(openAI: OpenAI, modelName: String)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
+      apply(openAI, ChatCompletionModel.CustomChatCompletionModel(modelName))
+
+    def apply(openAI: OpenAI, modelName: String, strictTools: Boolean)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
+      apply(openAI, ChatCompletionModel.CustomChatCompletionModel(modelName), strictTools)
+
+    def apply(apiKey: String, modelName: String)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
+      apply(new OpenAI(apiKey), modelName)
+
+    def apply(apiKey: String, modelName: String, strictTools: Boolean)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
+      apply(new OpenAI(apiKey), modelName, strictTools)
+  }
+
+  def synchronous[M <: ChatCompletionModel](openAI: OpenAI, model: M): AgentBuilder[Identity, M] =
+    builder[Identity](openAI, model)(IdentityMonad)
+
+  def synchronous[M <: ChatCompletionModel](openAI: OpenAI, model: M, strictTools: Boolean): AgentBuilder[Identity, M] =
+    builder[Identity](openAI, model, strictTools)(IdentityMonad)
+
+  def synchronous[M <: ChatCompletionModel](openAI: OpenAI, modelForIteration: IterationInfo => M): AgentBuilder[Identity, M] =
+    builder[Identity](openAI, modelForIteration)(IdentityMonad)
+
+  def synchronous[M <: ChatCompletionModel](
       openAI: OpenAI,
-      modelName: String
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
-    builder(openAI, modelName, strictTools = true)
-
-  def builder[F[_]](
-      apiKey: String,
-      modelName: String
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
-    builder(apiKey, modelName, strictTools = true)
-
-  def synchronous(
-      openAI: OpenAI,
-      modelName: String
-  ): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel] = synchronous(openAI, modelName, strictTools = true)
-
-  def synchronous(
-      apiKey: String,
-      modelName: String
-  ): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel] = synchronous(apiKey, modelName, strictTools = true)
-
-  def builder[F[_]](
-      openAI: OpenAI,
-      modelName: String,
+      modelForIteration: IterationInfo => M,
       strictTools: Boolean
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
-    AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel](config =>
-      new OpenAIAgentBackend[F](openAI, modelName, config.userTools, config.systemPrompt, config.responseSchema, strictTools)
-    )
+  ): AgentBuilder[Identity, M] =
+    builder[Identity](openAI, modelForIteration, strictTools)(IdentityMonad)
 
-  def builder[F[_]](
-      apiKey: String,
-      modelName: String,
-      strictTools: Boolean
-  )(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
-    builder(new OpenAI(apiKey), modelName, strictTools)
+  def synchronous(openAI: OpenAI, modelName: String): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel] =
+    builder[Identity](openAI, modelName)(IdentityMonad)
 
   def synchronous(
       openAI: OpenAI,
@@ -185,6 +215,9 @@ object OpenAIAgent {
       strictTools: Boolean
   ): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel] =
     builder[Identity](openAI, modelName, strictTools)(IdentityMonad)
+
+  def synchronous(apiKey: String, modelName: String): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel] =
+    builder[Identity](apiKey, modelName)(IdentityMonad)
 
   def synchronous(
       apiKey: String,

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestBody.scala
@@ -3,6 +3,7 @@ package sttp.ai.openai.requests.completions.chat
 import io.circe.Json
 import io.circe.syntax._
 import sttp.apispec.Schema
+import sttp.ai.core.model.{AIModel, Capability}
 import sttp.ai.openai.json.OpenAIDerivedCodecs.chatBodyEncoder
 import sttp.ai.openai.requests.caching.CacheRetentionPolicy
 import sttp.ai.openai.requests.completions.Stop
@@ -244,69 +245,202 @@ object ChatRequestBody {
     case class CustomReasoningEffort(customReasoningEffort: String) extends ReasoningEffort
   }
 
-  sealed abstract class ChatCompletionModel(val value: String)
+  sealed abstract class ChatCompletionModel(val value: String) extends AIModel
 
   object ChatCompletionModel {
-    case object ChatGPT4oLatest extends ChatCompletionModel("chatgpt-4o-latest")
-    case object GPT35Turbo extends ChatCompletionModel("gpt-3.5-turbo")
-    case object GPT35Turbo0125 extends ChatCompletionModel("gpt-3.5-turbo-0125")
+    case object ChatGPT4oLatest extends ChatCompletionModel("chatgpt-4o-latest") with Capability.Vision
+    case object GPT35Turbo extends ChatCompletionModel("gpt-3.5-turbo") with Capability.ToolCalling
+    case object GPT35Turbo0125 extends ChatCompletionModel("gpt-3.5-turbo-0125") with Capability.ToolCalling
     case object GPT35Turbo0301 extends ChatCompletionModel("gpt-3.5-turbo-0301")
-    case object GPT35Turbo1106 extends ChatCompletionModel("gpt-3.5-turbo-1106")
+    case object GPT35Turbo1106 extends ChatCompletionModel("gpt-3.5-turbo-1106") with Capability.ToolCalling
     case object GPT35TurboInstruct extends ChatCompletionModel("gpt-3.5-turbo-instruct")
-    case object GPT4 extends ChatCompletionModel("gpt-4")
-    case object GPT40125Preview extends ChatCompletionModel("gpt-4-0125-preview")
-    case object GPT40314 extends ChatCompletionModel("gpt-4-0314")
-    case object GPT40613 extends ChatCompletionModel("gpt-4-0613")
-    case object GPT41 extends ChatCompletionModel("gpt-4.1")
-    case object GPT41106VisionPreview extends ChatCompletionModel("gpt-4-1106-vision-preview")
-    case object GPT4120250414 extends ChatCompletionModel("gpt-4.1-2025-04-14")
-    case object GPT41Mini extends ChatCompletionModel("gpt-4.1-mini")
-    case object GPT41Mini20250414 extends ChatCompletionModel("gpt-4.1-mini-2025-04-14")
-    case object GPT41Nano extends ChatCompletionModel("gpt-4.1-nano")
-    case object GPT41Nano20250414 extends ChatCompletionModel("gpt-4.1-nano-2025-04-14")
-    case object GPT432k extends ChatCompletionModel("gpt-4-32k")
-    case object GPT432k0314 extends ChatCompletionModel("gpt-4-32k-0314")
-    case object GPT45Preview extends ChatCompletionModel("gpt-4.5-preview")
-    case object GPT45Preview20250227 extends ChatCompletionModel("gpt-4.5-preview-2025-02-27")
-    case object GPT4Turbo extends ChatCompletionModel("gpt-4-1106-preview")
-    case object GPT4Turbo20240409 extends ChatCompletionModel("gpt-4-turbo-2024-04-09")
-    case object GPT4TurboPreview extends ChatCompletionModel("gpt-4-turbo-preview")
-    case object GPT4o extends ChatCompletionModel("gpt-4o")
-    case object GPT4o20240513 extends ChatCompletionModel("gpt-4o-2024-05-13")
-    case object GPT4o20240806 extends ChatCompletionModel("gpt-4o-2024-08-06")
-    case object GPT4o20241120 extends ChatCompletionModel("gpt-4o-2024-11-20")
-    case object GPT4oAudioPreview extends ChatCompletionModel("gpt-4o-audio-preview")
-    case object GPT4oAudioPreview20241001 extends ChatCompletionModel("gpt-4o-audio-preview-2024-10-01")
-    case object GPT4oAudioPreview20241217 extends ChatCompletionModel("gpt-4o-audio-preview-2024-12-17")
-    case object GPT4oAudioPreview20250603 extends ChatCompletionModel("gpt-4o-audio-preview-2025-06-03")
-    case object GPT4oMini extends ChatCompletionModel("gpt-4o-mini")
-    case object GPT4oMini20240718 extends ChatCompletionModel("gpt-4o-mini-2024-07-18")
-    case object GPT4oMiniAudioPreview extends ChatCompletionModel("gpt-4o-mini-audio-preview")
-    case object GPT4oMiniAudioPreview20241217 extends ChatCompletionModel("gpt-4o-mini-audio-preview-2024-12-17")
-    case object GPT4oMiniSearchPreview extends ChatCompletionModel("gpt-4o-mini-search-preview")
-    case object GPT4oMiniSearchPreview20250311 extends ChatCompletionModel("gpt-4o-mini-search-preview-2025-03-11")
-    case object GPT4oSearchPreview extends ChatCompletionModel("gpt-4o-search-preview")
-    case object GPT4oSearchPreview20250311 extends ChatCompletionModel("gpt-4o-search-preview-2025-03-11")
-    case object GPT5 extends ChatCompletionModel("gpt-5")
-    case object GPT520250807 extends ChatCompletionModel("gpt-5-2025-08-07")
-    case object GPT5ChatLatest extends ChatCompletionModel("gpt-5-chat-latest")
-    case object GPT5Mini extends ChatCompletionModel("gpt-5-mini")
-    case object GPT5Mini20250807 extends ChatCompletionModel("gpt-5-mini-2025-08-07")
-    case object GPT5Nano extends ChatCompletionModel("gpt-5-nano")
-    case object GPT5Nano20250807 extends ChatCompletionModel("gpt-5-nano-2025-08-07")
-    case object O1 extends ChatCompletionModel("o1")
-    case object O120241217 extends ChatCompletionModel("o1-2024-12-17")
-    case object O1Mini extends ChatCompletionModel("o1-mini")
-    case object O1Mini20240912 extends ChatCompletionModel("o1-mini-2024-09-12")
-    case object O1Preview extends ChatCompletionModel("o1-preview")
-    case object O1Preview20240912 extends ChatCompletionModel("o1-preview-2024-09-12")
-    case object O3 extends ChatCompletionModel("o3")
-    case object O320250416 extends ChatCompletionModel("o3-2025-04-16")
-    case object O3Mini extends ChatCompletionModel("o3-mini")
-    case object O3Mini20250131 extends ChatCompletionModel("o3-mini-2025-01-31")
-    case object O4Mini extends ChatCompletionModel("o4-mini")
-    case object O4Mini20250416 extends ChatCompletionModel("o4-mini-2025-04-16")
-    case class CustomChatCompletionModel(customChatCompletionModel: String) extends ChatCompletionModel(customChatCompletionModel)
+    case object GPT4 extends ChatCompletionModel("gpt-4") with Capability.ToolCalling
+    case object GPT40125Preview extends ChatCompletionModel("gpt-4-0125-preview") with Capability.ToolCalling
+    case object GPT40314 extends ChatCompletionModel("gpt-4-0314") with Capability.ToolCalling
+    case object GPT40613 extends ChatCompletionModel("gpt-4-0613") with Capability.ToolCalling
+    case object GPT41
+        extends ChatCompletionModel("gpt-4.1")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+    case object GPT41106VisionPreview extends ChatCompletionModel("gpt-4-1106-vision-preview") with Capability.Vision
+    case object GPT4120250414
+        extends ChatCompletionModel("gpt-4.1-2025-04-14")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+    case object GPT41Mini
+        extends ChatCompletionModel("gpt-4.1-mini")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+    case object GPT41Mini20250414
+        extends ChatCompletionModel("gpt-4.1-mini-2025-04-14")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+    case object GPT41Nano
+        extends ChatCompletionModel("gpt-4.1-nano")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+    case object GPT41Nano20250414
+        extends ChatCompletionModel("gpt-4.1-nano-2025-04-14")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+    case object GPT432k extends ChatCompletionModel("gpt-4-32k") with Capability.ToolCalling
+    case object GPT432k0314 extends ChatCompletionModel("gpt-4-32k-0314") with Capability.ToolCalling
+    case object GPT45Preview
+        extends ChatCompletionModel("gpt-4.5-preview")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+    case object GPT45Preview20250227
+        extends ChatCompletionModel("gpt-4.5-preview-2025-02-27")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+    case object GPT4Turbo extends ChatCompletionModel("gpt-4-1106-preview") with Capability.ToolCalling
+    case object GPT4Turbo20240409 extends ChatCompletionModel("gpt-4-turbo-2024-04-09") with Capability.Vision with Capability.ToolCalling
+    case object GPT4TurboPreview extends ChatCompletionModel("gpt-4-turbo-preview") with Capability.ToolCalling
+    case object GPT4o
+        extends ChatCompletionModel("gpt-4o")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+    case object GPT4o20240513
+        extends ChatCompletionModel("gpt-4o-2024-05-13")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+    case object GPT4o20240806
+        extends ChatCompletionModel("gpt-4o-2024-08-06")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+    case object GPT4o20241120
+        extends ChatCompletionModel("gpt-4o-2024-11-20")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+    case object GPT4oAudioPreview extends ChatCompletionModel("gpt-4o-audio-preview") with Capability.ToolCalling
+    case object GPT4oAudioPreview20241001 extends ChatCompletionModel("gpt-4o-audio-preview-2024-10-01") with Capability.ToolCalling
+    case object GPT4oAudioPreview20241217 extends ChatCompletionModel("gpt-4o-audio-preview-2024-12-17") with Capability.ToolCalling
+    case object GPT4oAudioPreview20250603 extends ChatCompletionModel("gpt-4o-audio-preview-2025-06-03") with Capability.ToolCalling
+    case object GPT4oMini
+        extends ChatCompletionModel("gpt-4o-mini")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+    case object GPT4oMini20240718
+        extends ChatCompletionModel("gpt-4o-mini-2024-07-18")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+    case object GPT4oMiniAudioPreview extends ChatCompletionModel("gpt-4o-mini-audio-preview") with Capability.ToolCalling
+    case object GPT4oMiniAudioPreview20241217
+        extends ChatCompletionModel("gpt-4o-mini-audio-preview-2024-12-17")
+        with Capability.ToolCalling
+    case object GPT4oMiniSearchPreview extends ChatCompletionModel("gpt-4o-mini-search-preview") with Capability.StructuredOutput
+    case object GPT4oMiniSearchPreview20250311
+        extends ChatCompletionModel("gpt-4o-mini-search-preview-2025-03-11")
+        with Capability.StructuredOutput
+    case object GPT4oSearchPreview extends ChatCompletionModel("gpt-4o-search-preview") with Capability.StructuredOutput
+    case object GPT4oSearchPreview20250311 extends ChatCompletionModel("gpt-4o-search-preview-2025-03-11") with Capability.StructuredOutput
+    case object GPT5
+        extends ChatCompletionModel("gpt-5")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning
+    case object GPT520250807
+        extends ChatCompletionModel("gpt-5-2025-08-07")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning
+    case object GPT5ChatLatest extends ChatCompletionModel("gpt-5-chat-latest") with Capability.Vision with Capability.StructuredOutput
+    case object GPT5Mini
+        extends ChatCompletionModel("gpt-5-mini")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning
+    case object GPT5Mini20250807
+        extends ChatCompletionModel("gpt-5-mini-2025-08-07")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning
+    case object GPT5Nano
+        extends ChatCompletionModel("gpt-5-nano")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning
+    case object GPT5Nano20250807
+        extends ChatCompletionModel("gpt-5-nano-2025-08-07")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning
+    case object O1
+        extends ChatCompletionModel("o1")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning
+    case object O120241217
+        extends ChatCompletionModel("o1-2024-12-17")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning
+    case object O1Mini extends ChatCompletionModel("o1-mini") with Capability.Reasoning
+    case object O1Mini20240912 extends ChatCompletionModel("o1-mini-2024-09-12") with Capability.Reasoning
+    case object O1Preview extends ChatCompletionModel("o1-preview") with Capability.Reasoning
+    case object O1Preview20240912 extends ChatCompletionModel("o1-preview-2024-09-12") with Capability.Reasoning
+    case object O3
+        extends ChatCompletionModel("o3")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning
+    case object O320250416
+        extends ChatCompletionModel("o3-2025-04-16")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning
+    case object O3Mini
+        extends ChatCompletionModel("o3-mini")
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning
+    case object O3Mini20250131
+        extends ChatCompletionModel("o3-mini-2025-01-31")
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning
+    case object O4Mini
+        extends ChatCompletionModel("o4-mini")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning
+    case object O4Mini20250416
+        extends ChatCompletionModel("o4-mini-2025-04-16")
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning
+    case class CustomChatCompletionModel(customChatCompletionModel: String)
+        extends ChatCompletionModel(customChatCompletionModel)
+        with Capability.Vision
+        with Capability.ToolCalling
+        with Capability.StructuredOutput
+        with Capability.Reasoning
 
     val values: Set[ChatCompletionModel] =
       Set(

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestBody.scala
@@ -256,7 +256,7 @@ object ChatRequestBody {
     case object GPT35TurboInstruct extends ChatCompletionModel("gpt-3.5-turbo-instruct")
     case object GPT4 extends ChatCompletionModel("gpt-4") with Capability.ToolCalling
     case object GPT40125Preview extends ChatCompletionModel("gpt-4-0125-preview") with Capability.ToolCalling
-    case object GPT40314 extends ChatCompletionModel("gpt-4-0314") with Capability.ToolCalling
+    case object GPT40314 extends ChatCompletionModel("gpt-4-0314")
     case object GPT40613 extends ChatCompletionModel("gpt-4-0613") with Capability.ToolCalling
     case object GPT41
         extends ChatCompletionModel("gpt-4.1")
@@ -290,7 +290,7 @@ object ChatRequestBody {
         with Capability.ToolCalling
         with Capability.StructuredOutput
     case object GPT432k extends ChatCompletionModel("gpt-4-32k") with Capability.ToolCalling
-    case object GPT432k0314 extends ChatCompletionModel("gpt-4-32k-0314") with Capability.ToolCalling
+    case object GPT432k0314 extends ChatCompletionModel("gpt-4-32k-0314")
     case object GPT45Preview
         extends ChatCompletionModel("gpt-4.5-preview")
         with Capability.Vision
@@ -309,11 +309,7 @@ object ChatRequestBody {
         with Capability.Vision
         with Capability.ToolCalling
         with Capability.StructuredOutput
-    case object GPT4o20240513
-        extends ChatCompletionModel("gpt-4o-2024-05-13")
-        with Capability.Vision
-        with Capability.ToolCalling
-        with Capability.StructuredOutput
+    case object GPT4o20240513 extends ChatCompletionModel("gpt-4o-2024-05-13") with Capability.Vision with Capability.ToolCalling
     case object GPT4o20240806
         extends ChatCompletionModel("gpt-4o-2024-08-06")
         with Capability.Vision

--- a/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestBody.scala
+++ b/openai/src/main/scala/sttp/ai/openai/requests/completions/chat/ChatRequestBody.scala
@@ -348,71 +348,21 @@ object ChatRequestBody {
         with Capability.StructuredOutput
     case object GPT4oSearchPreview extends ChatCompletionModel("gpt-4o-search-preview") with Capability.StructuredOutput
     case object GPT4oSearchPreview20250311 extends ChatCompletionModel("gpt-4o-search-preview-2025-03-11") with Capability.StructuredOutput
-    case object GPT5
-        extends ChatCompletionModel("gpt-5")
-        with Capability.Vision
-        with Capability.ToolCalling
-        with Capability.StructuredOutput
-        with Capability.Reasoning
-    case object GPT520250807
-        extends ChatCompletionModel("gpt-5-2025-08-07")
-        with Capability.Vision
-        with Capability.ToolCalling
-        with Capability.StructuredOutput
-        with Capability.Reasoning
+    case object GPT5 extends ChatCompletionModel("gpt-5") with Capability.All
+    case object GPT520250807 extends ChatCompletionModel("gpt-5-2025-08-07") with Capability.All
     case object GPT5ChatLatest extends ChatCompletionModel("gpt-5-chat-latest") with Capability.Vision with Capability.StructuredOutput
-    case object GPT5Mini
-        extends ChatCompletionModel("gpt-5-mini")
-        with Capability.Vision
-        with Capability.ToolCalling
-        with Capability.StructuredOutput
-        with Capability.Reasoning
-    case object GPT5Mini20250807
-        extends ChatCompletionModel("gpt-5-mini-2025-08-07")
-        with Capability.Vision
-        with Capability.ToolCalling
-        with Capability.StructuredOutput
-        with Capability.Reasoning
-    case object GPT5Nano
-        extends ChatCompletionModel("gpt-5-nano")
-        with Capability.Vision
-        with Capability.ToolCalling
-        with Capability.StructuredOutput
-        with Capability.Reasoning
-    case object GPT5Nano20250807
-        extends ChatCompletionModel("gpt-5-nano-2025-08-07")
-        with Capability.Vision
-        with Capability.ToolCalling
-        with Capability.StructuredOutput
-        with Capability.Reasoning
-    case object O1
-        extends ChatCompletionModel("o1")
-        with Capability.Vision
-        with Capability.ToolCalling
-        with Capability.StructuredOutput
-        with Capability.Reasoning
-    case object O120241217
-        extends ChatCompletionModel("o1-2024-12-17")
-        with Capability.Vision
-        with Capability.ToolCalling
-        with Capability.StructuredOutput
-        with Capability.Reasoning
+    case object GPT5Mini extends ChatCompletionModel("gpt-5-mini") with Capability.All
+    case object GPT5Mini20250807 extends ChatCompletionModel("gpt-5-mini-2025-08-07") with Capability.All
+    case object GPT5Nano extends ChatCompletionModel("gpt-5-nano") with Capability.All
+    case object GPT5Nano20250807 extends ChatCompletionModel("gpt-5-nano-2025-08-07") with Capability.All
+    case object O1 extends ChatCompletionModel("o1") with Capability.All
+    case object O120241217 extends ChatCompletionModel("o1-2024-12-17") with Capability.All
     case object O1Mini extends ChatCompletionModel("o1-mini") with Capability.Reasoning
     case object O1Mini20240912 extends ChatCompletionModel("o1-mini-2024-09-12") with Capability.Reasoning
     case object O1Preview extends ChatCompletionModel("o1-preview") with Capability.Reasoning
     case object O1Preview20240912 extends ChatCompletionModel("o1-preview-2024-09-12") with Capability.Reasoning
-    case object O3
-        extends ChatCompletionModel("o3")
-        with Capability.Vision
-        with Capability.ToolCalling
-        with Capability.StructuredOutput
-        with Capability.Reasoning
-    case object O320250416
-        extends ChatCompletionModel("o3-2025-04-16")
-        with Capability.Vision
-        with Capability.ToolCalling
-        with Capability.StructuredOutput
-        with Capability.Reasoning
+    case object O3 extends ChatCompletionModel("o3") with Capability.All
+    case object O320250416 extends ChatCompletionModel("o3-2025-04-16") with Capability.All
     case object O3Mini
         extends ChatCompletionModel("o3-mini")
         with Capability.ToolCalling
@@ -423,24 +373,11 @@ object ChatRequestBody {
         with Capability.ToolCalling
         with Capability.StructuredOutput
         with Capability.Reasoning
-    case object O4Mini
-        extends ChatCompletionModel("o4-mini")
-        with Capability.Vision
-        with Capability.ToolCalling
-        with Capability.StructuredOutput
-        with Capability.Reasoning
-    case object O4Mini20250416
-        extends ChatCompletionModel("o4-mini-2025-04-16")
-        with Capability.Vision
-        with Capability.ToolCalling
-        with Capability.StructuredOutput
-        with Capability.Reasoning
+    case object O4Mini extends ChatCompletionModel("o4-mini") with Capability.All
+    case object O4Mini20250416 extends ChatCompletionModel("o4-mini-2025-04-16") with Capability.All
     case class CustomChatCompletionModel(customChatCompletionModel: String)
         extends ChatCompletionModel(customChatCompletionModel)
-        with Capability.Vision
-        with Capability.ToolCalling
-        with Capability.StructuredOutput
-        with Capability.Reasoning
+        with Capability.All
 
     val values: Set[ChatCompletionModel] =
       Set(

--- a/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.ai.core.agent.AgentTool
 import sttp.ai.core.agent.ConversationHistory
+import sttp.ai.core.agent.IterationInfo
 import sttp.ai.openai.OpenAI
 import sttp.apispec.Schema
 import sttp.client4._
@@ -57,7 +58,8 @@ class OpenAIAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     backend(strictTools = true).sendRequest(
       ConversationHistory.withInitialPrompt("hello"),
       httpStub,
-      includeTools = includeTools
+      includeTools = includeTools,
+      IterationInfo(1, 10)
     ): Unit
     captured.get().body match {
       case StringBody(s, _, _) => s

--- a/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
@@ -9,6 +9,7 @@ import sttp.ai.core.agent.AgentTool
 import sttp.ai.core.agent.ConversationHistory
 import sttp.ai.core.agent.IterationInfo
 import sttp.ai.openai.OpenAI
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
 import sttp.apispec.Schema
 import sttp.client4._
 import sttp.client4.testing.ResponseStub
@@ -29,7 +30,14 @@ class OpenAIAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
   }
 
   private def backend(strictTools: Boolean): OpenAIAgentBackend[Identity] =
-    new OpenAIAgentBackend[Identity](new OpenAI("test-key"), "gpt-4o-mini", Seq(testTool), None, None, strictTools)(IdentityMonad)
+    new OpenAIAgentBackend[Identity](
+      new OpenAI("test-key"),
+      _ => ChatCompletionModel.GPT4oMini,
+      Seq(testTool),
+      None,
+      None,
+      strictTools
+    )(IdentityMonad)
 
   "OpenAIAgentBackend" should "register tools as strict with normalized schemas when strictTools is true" in {
     val fn = backend(strictTools = true).convertedTools.head
@@ -73,5 +81,32 @@ class OpenAIAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
 
   it should "omit tools from the request body when includeTools is false" in {
     captureRequestBody(includeTools = false) should not include "\"tools\""
+  }
+
+  it should "resolve the model per iteration via modelForIteration" in {
+    val capturedModels = new AtomicReference[Vector[String]](Vector.empty)
+    val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF { request =>
+      val body = request.body match {
+        case StringBody(s, _, _) => s
+        case other               => fail(s"expected StringBody, got $other")
+      }
+      val model = io.circe.parser.parse(body).toOption.flatMap(_.hcursor.get[String]("model").toOption).getOrElse("?")
+      capturedModels.updateAndGet(_ :+ model)
+      ResponseStub.adjust(sttp.ai.openai.fixtures.CompletionsFixture.structuredOutputsResponse, StatusCode.Ok)
+    }
+
+    val backend = new OpenAIAgentBackend[Identity](
+      new OpenAI("test-key"),
+      info => if (info.isLastIteration) ChatCompletionModel.GPT41 else ChatCompletionModel.GPT4oMini,
+      Seq.empty,
+      None,
+      None,
+      strictTools = true
+    )(IdentityMonad)
+
+    backend.sendRequest(ConversationHistory.withInitialPrompt("hello"), httpStub, includeTools = false, IterationInfo(1, 3)): Unit
+    backend.sendRequest(ConversationHistory.withInitialPrompt("hello"), httpStub, includeTools = false, IterationInfo(3, 3)): Unit
+
+    capturedModels.get() shouldBe Vector("gpt-4o-mini", "gpt-4.1")
   }
 }

--- a/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentCapabilitySpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentCapabilitySpec.scala
@@ -1,0 +1,59 @@
+package sttp.ai.openai.agent
+
+import io.circe.parser.parse
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.openai.OpenAI
+import sttp.ai.core.agent.{AgentTool, IterationInfo}
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
+import sttp.apispec.Schema
+import sttp.shared.Identity
+
+object OpenAIAgentCapabilitySpecFixtures {
+  val openAI = new OpenAI("test-key")
+  val echoTool: AgentTool[Identity, _] = {
+    val schema = parse("""{"type":"object"}""").toOption.get.as[Schema](sttp.apispec.circe.schemaDecoder).toOption.get
+    AgentTool.dynamic("echo", "Echoes input", schema)(_ => "ok")
+  }
+}
+
+class OpenAIAgentCapabilitySpec extends AnyFlatSpec with Matchers {
+  import OpenAIAgentCapabilitySpecFixtures._
+
+  "OpenAIAgent" should "accept tools for a ToolCalling model" in {
+    OpenAIAgent.synchronous(openAI, ChatCompletionModel.GPT4o).tools(echoTool): Unit
+    succeed
+  }
+
+  it should "reject tools for o1-mini (no ToolCalling) at compile time" in {
+    assertDoesNotCompile(
+      """sttp.ai.openai.agent.OpenAIAgent
+        .synchronous(
+          sttp.ai.openai.agent.OpenAIAgentCapabilitySpecFixtures.openAI,
+          sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel.O1Mini
+        )
+        .tools(sttp.ai.openai.agent.OpenAIAgentCapabilitySpecFixtures.echoTool)"""
+    )
+    assertCompiles(
+      """sttp.ai.openai.agent.OpenAIAgent
+        .synchronous(
+          sttp.ai.openai.agent.OpenAIAgentCapabilitySpecFixtures.openAI,
+          sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel.GPT4o
+        )
+        .tools(sttp.ai.openai.agent.OpenAIAgentCapabilitySpecFixtures.echoTool)"""
+    )
+  }
+
+  it should "keep String model names working (custom model claims all capabilities)" in {
+    OpenAIAgent.synchronous(openAI, "llama3-70b").tools(echoTool): Unit
+    succeed
+  }
+
+  it should "require the shared capabilities of all models a hook can return" in {
+    // GPT4o and GPT41 both have ToolCalling — the inferred M supports tools:
+    OpenAIAgent
+      .synchronous(openAI, (info: IterationInfo) => if (info.isLastIteration) ChatCompletionModel.GPT41 else ChatCompletionModel.GPT4o)
+      .tools(echoTool): Unit
+    succeed
+  }
+}

--- a/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentCapabilitySpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentCapabilitySpec.scala
@@ -10,7 +10,7 @@ import sttp.apispec.Schema
 import sttp.shared.Identity
 
 object OpenAIAgentCapabilitySpecFixtures {
-  val openAI = new OpenAI("test-key")
+  val openAI: OpenAI = new OpenAI("test-key")
   val echoTool: AgentTool[Identity, _] = {
     val schema = parse("""{"type":"object"}""").toOption.get.as[Schema](sttp.apispec.circe.schemaDecoder).toOption.get
     AgentTool.dynamic("echo", "Echoes input", schema)(_ => "ok")

--- a/openai/src/test/scala/sttp/ai/openai/integration/OpenAIAgentIntegrationSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/integration/OpenAIAgentIntegrationSpec.scala
@@ -4,6 +4,7 @@ import sttp.ai.core.agent.integration.AgentIntegrationSpecBase
 import sttp.ai.core.agent._
 import sttp.ai.openai.OpenAI
 import sttp.ai.openai.agent._
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
 import sttp.monad.IdentityMonad
 import sttp.shared.Identity
 
@@ -17,7 +18,7 @@ class OpenAIAgentIntegrationSpec extends AgentIntegrationSpecBase {
     val agentConfig = AgentConfig[Identity](maxIterations = maxIterations, userTools = tools)
     val agentBackend = new OpenAIAgentBackend[Identity](
       openai,
-      "gpt-4o-mini",
+      _ => ChatCompletionModel.GPT4oMini,
       agentConfig.userTools,
       agentConfig.systemPrompt,
       agentConfig.responseSchema,

--- a/openai/src/test/scala/sttp/ai/openai/unit/ChatCompletionModelCapabilitySpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/unit/ChatCompletionModelCapabilitySpec.scala
@@ -1,0 +1,55 @@
+package sttp.ai.openai.unit
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.core.model.Capability
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel._
+
+class ChatCompletionModelCapabilitySpec extends AnyFlatSpec with Matchers {
+
+  "ChatCompletionModel capability tags" should "mark 4o/4.1/4.5 family as Vision + ToolCalling + StructuredOutput" in
+    Seq[ChatCompletionModel](GPT4o, GPT4oMini, GPT41, GPT41Mini, GPT41Nano, GPT45Preview).foreach { m =>
+      m shouldBe a[Capability.Vision]
+      m shouldBe a[Capability.ToolCalling]
+      m shouldBe a[Capability.StructuredOutput]
+      m should not be a[Capability.Reasoning]
+    }
+
+  it should "mark gpt-5 family as reasoning models (except gpt-5-chat-latest)" in {
+    Seq[ChatCompletionModel](GPT5, GPT5Mini, GPT5Nano).foreach { m =>
+      m shouldBe a[Capability.Reasoning]
+      m shouldBe a[Capability.ToolCalling]
+    }
+    GPT5ChatLatest should not be a[Capability.Reasoning]
+    GPT5ChatLatest should not be a[Capability.ToolCalling]
+    GPT5ChatLatest shouldBe a[Capability.Vision]
+  }
+
+  it should "mark o-series correctly" in {
+    O1Mini shouldBe a[Capability.Reasoning]
+    O1Mini should not be a[Capability.ToolCalling]
+    O3Mini shouldBe a[Capability.ToolCalling]
+    O3Mini should not be a[Capability.Vision]
+    O3 shouldBe a[Capability.Vision]
+    O4Mini shouldBe a[Capability.Vision]
+  }
+
+  it should "leave plain-ToolCalling defaults on legacy gpt-4 / gpt-3.5 models" in {
+    Seq[ChatCompletionModel](GPT4, GPT40613, GPT35Turbo).foreach { m =>
+      m shouldBe a[Capability.ToolCalling]
+      m should not be a[Capability.Vision]
+    }
+    GPT35TurboInstruct should not be a[Capability.ToolCalling]
+    GPT41106VisionPreview shouldBe a[Capability.Vision]
+    GPT41106VisionPreview should not be a[Capability.ToolCalling]
+  }
+
+  it should "make CustomChatCompletionModel claim all capabilities" in {
+    val custom = CustomChatCompletionModel("llama3")
+    custom shouldBe a[Capability.Vision]
+    custom shouldBe a[Capability.ToolCalling]
+    custom shouldBe a[Capability.StructuredOutput]
+    custom shouldBe a[Capability.Reasoning]
+  }
+}

--- a/openai/src/test/scala/sttp/ai/openai/unit/ChatCompletionModelCapabilitySpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/unit/ChatCompletionModelCapabilitySpec.scala
@@ -45,6 +45,18 @@ class ChatCompletionModelCapabilitySpec extends AnyFlatSpec with Matchers {
     GPT41106VisionPreview should not be a[Capability.ToolCalling]
   }
 
+  it should "not claim ToolCalling on the pre-function-calling -0314 snapshots" in {
+    GPT40314 should not be a[Capability.ToolCalling]
+    GPT432k0314 should not be a[Capability.ToolCalling]
+  }
+
+  it should "not claim StructuredOutput on gpt-4o-2024-05-13 (json_schema needs 2024-08-06+)" in {
+    GPT4o20240513 shouldBe a[Capability.Vision]
+    GPT4o20240513 shouldBe a[Capability.ToolCalling]
+    GPT4o20240513 should not be a[Capability.StructuredOutput]
+    GPT4o20240806 shouldBe a[Capability.StructuredOutput]
+  }
+
   it should "make CustomChatCompletionModel claim all capabilities" in {
     val custom = CustomChatCompletionModel("llama3")
     custom shouldBe a[Capability.Vision]


### PR DESCRIPTION
Capability-tagged model constants (all three providers)

- New marker traits in core — sttp.ai.core.model.Capability.{Vision, ToolCalling, StructuredOutput, Reasoning} — plus a Capability.All shorthand extending all four, and Supports[M, C] implicit evidence with a readable @implicitNotFound message. Supports is sealed by design: capabilities are declared by mixing traits into the model type, and custom model classes are the intended escape hatch.
- OpenAI ChatCompletionModel, ClaudeModel, and GeminiModel constants mix in the capabilities they support (e.g. GPT4o is Vision with ToolCalling with StructuredOutput; O1Mini is Reasoning only; ClaudeSonnet5 is Capability.All). OpenAI tags are maintained by the model-update script from a curated mapping; Claude/Gemini are hand-maintained.
- Custom/unknown model classes (CustomChatCompletionModel, new CustomClaudeModel, GeminiModel.CustomModel) claim all capabilities — using a raw model-name string asserts your model supports what you use it for, so OpenAI-compatible providers (Ollama, Groq, OpenRouter) keep working unchanged.

Compile-time enforcement in the agent APIs

- AgentBuilder gains a phantom model type: AgentBuilder[F, M <: AIModel]. .tools(...)/.addTool require ToolCalling on M; .responseSchema/.deriveResponseSchema require StructuredOutput. An agent with no tools accepts any model.
- Typed provider entry points: ClaudeAgent.builder[F](client, ClaudeModel.ClaudeSonnet5) infers the model's capabilities, so invalid pairings — .tools on o1-mini, .deriveResponseSchema on claude-3-haiku — fail to compile. All modelName: String call shapes keep compiling and skip capability checking.

Per-iteration model selection ("LLM mixing")

- The loop passes IterationInfo(iteration, maxIterations) (1-based; isLastIteration flags the forced-final iteration where tools are withheld) to AgentBackend.sendRequest.
- Provider builders accept modelForIteration: IterationInfo => M — e.g. a cheap model for tool iterations and a stronger one for the forced-final synthesis. The inferred M covers every model the hook can return, so capability checks require what all of them share. Same provider only; cross-provider mixing is out of scope.

Tooling, testkit & docs

- update_code_with_new_models.scala maintains the mixin clauses from a hand-curated, first-match-wins capabilities section in model_update_config.yaml (never scraped). It re-renders every constant in the managed block on each run (config is the source of truth), renders Capability.All for full-capability models, tolerates scalafmt-wrapped definitions, and validates all capability names eagerly at config load. The config's stale sttp/openai/... paths were fixed to sttp/ai/openai/....
- agent-testkit: ScriptedModel stand-in claims all capabilities so scripted tests never fight evidence; RecordedRequest records the per-request IterationInfo.
- Docs: new "Model capabilities" and "Per-iteration model selection" sections in docs/agents/configuration.md as mdoc:compile-only snippets (pinned against API drift); updated AgentBackend signature in custom-backends.md; quickstart uses a typed constant. examples/ untouched (compiles against released artifacts).

⚠️ Breaking changes (0.x, binary-incompatible)

- AgentBuilder[F] → AgentBuilder[F, M <: AIModel] (type annotations on builders need updating).
- AgentBackend.sendRequest gains a fourth parameter, iterationInfo: IterationInfo (affects custom backe
- ClaudeModel changed from sealed trait to sealed abstract class ClaudeModel(val value: String) extendsult and ClaudeModel.WithStructuredOutput are removed — use the Capability.StructuredOutput tag instead
(modelSupportsStructuredOutput keeps its exact semantics, unknown ⇒ supported).
- RecordedRequest (agent-testkit) gains an iterationInfo field (constructor arity change).
- Provider builder[F] methods became partially-applied applicators (builder[F] returns a class with appd call shapes (builder[IO](client, "name"), synchronous(...)) remain source-compatible, but binary
compatibility is broken and exotic usages (eta-expansion of builder) change.
- ScriptedAgent.builder (agent-testkit) now returns AgentBuilder[F, ScriptedModel.type].

Wire formats are unchanged — the model field sent to each API is still the same string.

Testing

- Compile-time behavior tested with assertDoesNotCompile/assertCompiles pairs (every negative has a posi, and claude, including Capability.All evidence resolution.
- Per-iteration model selection verified at the wire level for all three providers (stubbed HTTP, assersent per request); testkit's IterationInfo recording asserted.
- Claude structured-output regression contract preserved verbatim (incl. unknown-model ⇒ supported).
- Script verified byte-idempotent (--apply + sbt scalafmtAll twice → identical file), and a typo'd caparule fails loudly at config load.
- Full JVM suite green on Scala 2.13 and 3 (1188+ tests, 0 failures); compileDocumentation green.