### PR TITLE
Feature/agent interceptor

### DIFF
--- a/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
+++ b/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
@@ -97,7 +97,7 @@ private[claude] class ClaudeAgentBackend[F[_]](
         val stopReason = mapClaudeStopReason(response.stopReason)
         val u = response.usage
         val usage = TokenUsage(
-          inputTokens = Tokens((u.inputTokens + u.cacheReadInputTokens.getOrElse(0) + u.cacheCreationInputTokens.getOrElse(0)).toLong),
+          inputTokens = Tokens(u.totalInputTokens.toLong),
           outputTokens = Tokens(u.outputTokens.toLong),
           cachedInputTokens = Tokens(u.cacheReadInputTokens.getOrElse(0).toLong),
           reasoningTokens = Tokens.Zero

--- a/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
+++ b/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
@@ -95,7 +95,14 @@ private[claude] class ClaudeAgentBackend[F[_]](
         }
 
         val stopReason = mapClaudeStopReason(response.stopReason)
-        monad.unit(AgentResponse(textContent, toolCalls, stopReason))
+        val u = response.usage
+        val usage = TokenUsage(
+          inputTokens = Tokens((u.inputTokens + u.cacheReadInputTokens.getOrElse(0) + u.cacheCreationInputTokens.getOrElse(0)).toLong),
+          outputTokens = Tokens(u.outputTokens.toLong),
+          cachedInputTokens = Tokens(u.cacheReadInputTokens.getOrElse(0).toLong),
+          reasoningTokens = Tokens.Zero
+        )
+        monad.unit(AgentResponse(textContent, toolCalls, stopReason, usage = Some(usage), model = Some(response.model)))
 
       case Left(error) =>
         monad.error(

--- a/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
+++ b/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
@@ -100,7 +100,8 @@ private[claude] class ClaudeAgentBackend[F[_]](
           inputTokens = Tokens(u.totalInputTokens.toLong),
           outputTokens = Tokens(u.outputTokens.toLong),
           cachedInputTokens = Tokens(u.cacheReadInputTokens.getOrElse(0).toLong),
-          reasoningTokens = Tokens.Zero
+          reasoningTokens = Tokens.Zero,
+          cacheWriteInputTokens = Tokens(u.cacheCreationInputTokens.getOrElse(0).toLong)
         )
         monad.unit(AgentResponse(textContent, toolCalls, stopReason, usage = Some(usage), model = Some(response.model)))
 

--- a/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
@@ -204,7 +204,8 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
         inputTokens = sttp.ai.core.agent.Tokens(147L), // 100 + 40 cache-read + 7 cache-creation
         outputTokens = sttp.ai.core.agent.Tokens(30L),
         cachedInputTokens = sttp.ai.core.agent.Tokens(40L),
-        reasoningTokens = sttp.ai.core.agent.Tokens.Zero
+        reasoningTokens = sttp.ai.core.agent.Tokens.Zero,
+        cacheWriteInputTokens = sttp.ai.core.agent.Tokens(7L)
       )
     )
   }

--- a/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/agent/ClaudeAgentBackendSpec.scala
@@ -169,4 +169,43 @@ class ClaudeAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
 
     capturedModels.get() shouldBe Vector("claude-haiku-4-5-20251001", "claude-opus-5")
   }
+
+  it should "surface provider-reported usage and model on AgentResponse" in {
+    val responseJson =
+      """{
+        |  "id": "msg_1",
+        |  "type": "message",
+        |  "role": "assistant",
+        |  "content": [ { "type": "text", "text": "hi" } ],
+        |  "model": "claude-haiku-4-5",
+        |  "stop_reason": "end_turn",
+        |  "usage": {
+        |    "input_tokens": 100,
+        |    "output_tokens": 30,
+        |    "cache_read_input_tokens": 40,
+        |    "cache_creation_input_tokens": 7
+        |  }
+        |}""".stripMargin
+    val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF(_ => ResponseStub.adjust(responseJson, StatusCode.Ok))
+
+    val client = ClaudeClient(ClaudeConfig(apiKey = "test-key"))
+    val backend = new ClaudeAgentBackend[Identity](client, _ => ClaudeModel.ClaudeHaiku4_5, Seq.empty, None, None)(IdentityMonad)
+
+    val response = backend.sendRequest(
+      ConversationHistory.withInitialPrompt("hello"),
+      httpStub,
+      includeTools = false,
+      IterationInfo(1, 10)
+    )
+
+    response.model shouldBe Some("claude-haiku-4-5")
+    response.usage shouldBe Some(
+      sttp.ai.core.agent.TokenUsage(
+        inputTokens = sttp.ai.core.agent.Tokens(147L), // 100 + 40 cache-read + 7 cache-creation
+        outputTokens = sttp.ai.core.agent.Tokens(30L),
+        cachedInputTokens = sttp.ai.core.agent.Tokens(40L),
+        reasoningTokens = sttp.ai.core.agent.Tokens.Zero
+      )
+    )
+  }
 }

--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -13,88 +13,117 @@ class Agent[F[_]](
 
   private val toolMap = config.userTools.map(t => t.name -> t).toMap
 
-  private val beforeToolCall: ToolCall => F[Unit] = config.beforeToolCall.getOrElse((_: ToolCall) => monad.unit(()))
-  private val afterToolCall: ToolCallRecord => F[Unit] = config.afterToolCall.getOrElse((_: ToolCallRecord) => monad.unit(()))
+  // Adapts the deprecated beforeToolCall/afterToolCall hooks into an interceptor, appended AFTER user
+  // interceptors so hooks run innermost (closest to the tool call), preserving pre-interceptor behavior.
+  private val legacyHookInterceptor: Option[AgentInterceptor[F]] =
+    if (config.beforeToolCall.isEmpty && config.afterToolCall.isEmpty) None
+    else
+      Some(new AgentInterceptor[F] {
+        override def aroundToolCall(ctx: ToolCallContext)(next: => F[ToolCallRecord]): F[ToolCallRecord] = {
+          val before = config.beforeToolCall.map(_(ctx.toolCall)).getOrElse(monad.unit(()))
+          before.flatMap { _ =>
+            next.flatMap { record =>
+              config.afterToolCall.map(_(record)).getOrElse(monad.unit(())).map(_ => record)
+            }
+          }
+        }
+      })
+
+  private val interceptor: AgentInterceptor[F] =
+    AgentInterceptor.compose(config.interceptors ++ legacyHookInterceptor.toSeq)
+
+  private sealed trait IterationOutcome
+  private final case class ContinueLoop(
+      history: ConversationHistory,
+      records: Seq[ToolCallRecord],
+      usage: TokenUsage,
+      llmCalls: Seq[LlmCallUsage]
+  ) extends IterationOutcome
+  private final case class Finished(result: AgentResult[String]) extends IterationOutcome
 
   def run(
       initialPrompt: String
   )(backend: Backend[F]): F[AgentResult[String]] = {
     val initialHistory = ConversationHistory.withInitialPrompt(initialPrompt)
 
-    def loop(history: ConversationHistory, iteration: Int, toolCallRecords: Seq[ToolCallRecord]): F[AgentResult[String]] =
-      // Safety net for maxIterations <= 0. For maxIterations >= 1 this is unreachable: the isLastIteration branch below
-      // always returns at iteration == maxIterations - 1, so the loop never recurses to iteration == maxIterations.
+    def loop(
+        history: ConversationHistory,
+        iteration: Int,
+        records: Seq[ToolCallRecord],
+        usage: TokenUsage,
+        llmCalls: Seq[LlmCallUsage]
+    ): F[AgentResult[String]] =
+      // Safety net for maxIterations <= 0. For maxIterations >= 1 this is unreachable: the final-iteration branch
+      // below always returns at iteration == maxIterations - 1, so the loop never recurses past it.
       if (iteration >= config.maxIterations) {
         monad.unit(
-          AgentResult(
-            finalAnswer = extractFinalAnswer(history),
-            iterations = iteration,
-            toolCalls = toolCallRecords,
-            finishReason = FinishReason.MaxIterations
-          )
+          AgentResult(extractFinalAnswer(history), iteration, records, FinishReason.MaxIterations, usage, llmCalls)
         )
       } else {
-        val isLastIteration = iteration == config.maxIterations - 1
+        val decision = interceptor.decide(AgentRunState(iteration, config.maxIterations, usage, llmCalls))
+        val info = IterationInfo(iteration + 1, config.maxIterations)
+        interceptor
+          .aroundIteration(IterationContext(info))(runIteration(history, iteration, records, usage, llmCalls, decision, backend))
+          .flatMap {
+            case ContinueLoop(h, r, u, lc) => loop(h, iteration + 1, r, u, lc)
+            case Finished(result)          => monad.unit(result)
+          }
+      }
 
-        val historyWithMarker = if (iteration > 0) {
-          history.addIterationMarker(iteration + 1, config.maxIterations)
-        } else {
-          history
-        }
+    loop(initialHistory, 0, Seq.empty, TokenUsage.Zero, Seq.empty)
+  }
 
-        val response =
-          agentBackend.sendRequest(
-            historyWithMarker,
-            backend,
-            includeTools = !isLastIteration,
-            IterationInfo(iteration + 1, config.maxIterations)
+  private def runIteration(
+      history: ConversationHistory,
+      iteration: Int,
+      records: Seq[ToolCallRecord],
+      usage: TokenUsage,
+      llmCalls: Seq[LlmCallUsage],
+      decision: LoopDecision,
+      backend: Backend[F]
+  ): F[IterationOutcome] = {
+    val isLastByCount = iteration == config.maxIterations - 1
+    // steering wired in next commit
+    val isFinalIteration = isLastByCount
+
+    val withMarker = if (iteration > 0) history.addIterationMarker(iteration + 1, config.maxIterations) else history
+    val requestHistory = withMarker
+
+    val info = IterationInfo(iteration + 1, config.maxIterations)
+    val includeTools = !isFinalIteration
+
+    interceptor
+      .aroundLlmCall(LlmCallContext(requestHistory, includeTools, info))(
+        agentBackend.sendRequest(requestHistory, backend, includeTools, info)
+      )
+      .flatMap { response =>
+        val callUsage = response.usage.getOrElse(TokenUsage.Zero)
+        val newUsage = usage + callUsage
+        val newLlmCalls = llmCalls :+ LlmCallUsage(response.model, callUsage)
+
+        if (response.stopReason == StopReason.MaxTokens) {
+          monad.unit(
+            Finished(AgentResult(response.textContent, iteration + 1, records, FinishReason.TokenLimit, newUsage, newLlmCalls))
           )
-
-        response.flatMap { response =>
-          if (response.stopReason == StopReason.MaxTokens) {
-            monad.unit(
-              AgentResult(
-                finalAnswer = response.textContent,
-                iterations = iteration + 1,
-                toolCalls = toolCallRecords,
-                finishReason = FinishReason.TokenLimit
-              )
-            )
-          } else if (isLastIteration) {
-            // Tools were not offered on the last allowed iteration, so any tool calls in the response are
-            // spurious and must not be executed. Force the final answer: prefer the model's text, and fall
-            // back to the last tool result / assistant text if the model returned no text.
-            val finalAnswer = if (response.textContent.nonEmpty) response.textContent else extractFinalAnswer(history)
-            monad.unit(
-              AgentResult(
-                finalAnswer = finalAnswer,
-                iterations = iteration + 1,
-                toolCalls = toolCallRecords,
-                finishReason = FinishReason.MaxIterations
-              )
-            )
-          } else if (response.toolCalls.isEmpty) {
-            // No tool calls - the agent has produced its final answer, so complete the loop.
-            monad.unit(
-              AgentResult(
-                finalAnswer = response.textContent,
-                iterations = iteration + 1,
-                toolCalls = toolCallRecords,
-                finishReason = FinishReason.NaturalStop
-              )
-            )
-          } else {
-            val updatedHistory = history.addAssistantResponse(response.textContent, response.toolCalls)
-
-            runToolCalls(response.toolCalls.toList, iteration + 1, updatedHistory, toolCallRecords).flatMap {
-              case (historyWithResults, results) =>
-                loop(historyWithResults, iteration + 1, results)
-            }
+        } else if (isFinalIteration) {
+          // Tools were not offered on the final iteration, so any tool calls in the response are spurious and must not
+          // be executed. Force the final answer: prefer the model's text, fall back to the last tool result / assistant text.
+          val finalAnswer = if (response.textContent.nonEmpty) response.textContent else extractFinalAnswer(history)
+          monad.unit(
+            Finished(AgentResult(finalAnswer, iteration + 1, records, FinishReason.MaxIterations, newUsage, newLlmCalls))
+          )
+        } else if (response.toolCalls.isEmpty) {
+          // No tool calls - the agent has produced its final answer, so complete the loop.
+          monad.unit(
+            Finished(AgentResult(response.textContent, iteration + 1, records, FinishReason.NaturalStop, newUsage, newLlmCalls))
+          )
+        } else {
+          val updatedHistory = history.addAssistantResponse(response.textContent, response.toolCalls)
+          runToolCalls(response.toolCalls.toList, iteration + 1, updatedHistory, records).map { case (h, r) =>
+            ContinueLoop(h, r, newUsage, newLlmCalls)
           }
         }
       }
-
-    loop(initialHistory, 0, Seq.empty)
   }
 
   def runAs[T](
@@ -123,9 +152,7 @@ class Agent[F[_]](
       case Nil              => monad.unit((history, results))
       case toolCall :: rest =>
         for {
-          _ <- beforeToolCall(toolCall)
-          result <- runToolCall(toolCall, iteration)
-          _ <- afterToolCall(result)
+          result <- interceptor.aroundToolCall(ToolCallContext(toolCall, iteration))(runToolCall(toolCall, iteration))
           updatedHistory = history.addToolResult(result)
           acc <- runToolCalls(rest, iteration, updatedHistory, results :+ result)
         } yield acc

--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -83,11 +83,17 @@ class Agent[F[_]](
       backend: Backend[F]
   ): F[IterationOutcome] = {
     val isLastByCount = iteration == config.maxIterations - 1
-    // steering wired in next commit
-    val isFinalIteration = isLastByCount
+    val forcedCause: Option[FinishReason] = decision match {
+      case LoopDecision.FinishNow(cause, _) => Some(cause)
+      case LoopDecision.Continue            => None
+    }
+    val isFinalIteration = isLastByCount || forcedCause.nonEmpty
 
     val withMarker = if (iteration > 0) history.addIterationMarker(iteration + 1, config.maxIterations) else history
-    val requestHistory = withMarker
+    val requestHistory = decision match {
+      case LoopDecision.FinishNow(_, instruction) => withMarker.addUserPrompt(instruction)
+      case LoopDecision.Continue                  => withMarker
+    }
 
     val info = IterationInfo(iteration + 1, config.maxIterations)
     val includeTools = !isFinalIteration
@@ -109,9 +115,9 @@ class Agent[F[_]](
           // Tools were not offered on the final iteration, so any tool calls in the response are spurious and must not
           // be executed. Force the final answer: prefer the model's text, fall back to the last tool result / assistant text.
           val finalAnswer = if (response.textContent.nonEmpty) response.textContent else extractFinalAnswer(history)
-          monad.unit(
-            Finished(AgentResult(finalAnswer, iteration + 1, records, FinishReason.MaxIterations, newUsage, newLlmCalls))
-          )
+          // MaxIterations takes precedence when the forced last iteration and a FinishNow coincide.
+          val reason = if (isLastByCount) FinishReason.MaxIterations else forcedCause.getOrElse(FinishReason.MaxIterations)
+          monad.unit(Finished(AgentResult(finalAnswer, iteration + 1, records, reason, newUsage, newLlmCalls)))
         } else if (response.toolCalls.isEmpty) {
           // No tool calls - the agent has produced its final answer, so complete the loop.
           monad.unit(

--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -6,6 +6,8 @@ import sttp.client4.Backend
 import sttp.monad.MonadError
 import sttp.monad.syntax.MonadErrorOps
 
+import scala.annotation.nowarn
+
 class Agent[F[_]](
     agentBackend: AgentBackend[F],
     config: AgentConfig[F]
@@ -15,6 +17,7 @@ class Agent[F[_]](
 
   // Adapts the deprecated beforeToolCall/afterToolCall hooks into an interceptor, appended AFTER user
   // interceptors so hooks run innermost (closest to the tool call), preserving pre-interceptor behavior.
+  @nowarn("cat=deprecation")
   private val legacyHookInterceptor: Option[AgentInterceptor[F]] =
     if (config.beforeToolCall.isEmpty && config.afterToolCall.isEmpty) None
     else

--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -6,43 +6,15 @@ import sttp.client4.Backend
 import sttp.monad.MonadError
 import sttp.monad.syntax.MonadErrorOps
 
-import scala.annotation.nowarn
-
 class Agent[F[_]](
     agentBackend: AgentBackend[F],
     config: AgentConfig[F]
 )(implicit monad: MonadError[F]) {
+  import Agent.{ContinueLoop, Finished, IterationOutcome}
 
   private val toolMap = config.userTools.map(t => t.name -> t).toMap
 
-  // Adapts the deprecated beforeToolCall/afterToolCall hooks into an interceptor, appended AFTER user
-  // interceptors so hooks run innermost (closest to the tool call), preserving pre-interceptor behavior.
-  @nowarn("cat=deprecation")
-  private val legacyHookInterceptor: Option[AgentInterceptor[F]] =
-    if (config.beforeToolCall.isEmpty && config.afterToolCall.isEmpty) None
-    else
-      Some(new AgentInterceptor[F] {
-        override def aroundToolCall(ctx: ToolCallContext)(next: => F[ToolCallRecord]): F[ToolCallRecord] = {
-          val before = config.beforeToolCall.map(_(ctx.toolCall)).getOrElse(monad.unit(()))
-          before.flatMap { _ =>
-            next.flatMap { record =>
-              config.afterToolCall.map(_(record)).getOrElse(monad.unit(())).map(_ => record)
-            }
-          }
-        }
-      })
-
-  private val interceptor: AgentInterceptor[F] =
-    AgentInterceptor.compose(config.interceptors ++ legacyHookInterceptor.toSeq)
-
-  private sealed trait IterationOutcome
-  private final case class ContinueLoop(
-      history: ConversationHistory,
-      records: Seq[ToolCallRecord],
-      usage: TokenUsage,
-      llmCalls: Seq[LlmCallUsage]
-  ) extends IterationOutcome
-  private final case class Finished(result: AgentResult[String]) extends IterationOutcome
+  private val interceptor: AgentInterceptor[F] = AgentInterceptor.compose(config.interceptors)
 
   def run(
       initialPrompt: String
@@ -64,7 +36,7 @@ class Agent[F[_]](
         )
       } else {
         val decision = interceptor.decide(AgentRunState(iteration, config.maxIterations, usage, llmCalls))
-        val info = IterationInfo(iteration + 1, config.maxIterations)
+        val info = IterationInfo(iteration + 1, config.maxIterations, forcedFinal = decision != LoopDecision.Continue)
         interceptor
           .aroundIteration(IterationContext(info))(runIteration(history, iteration, records, usage, llmCalls, decision, backend))
           .flatMap {
@@ -86,19 +58,21 @@ class Agent[F[_]](
       backend: Backend[F]
   ): F[IterationOutcome] = {
     val isLastByCount = iteration == config.maxIterations - 1
-    val forcedCause: Option[FinishReason] = decision match {
+    val forcedCause: Option[FinishReason.ForcedStop] = decision match {
       case LoopDecision.FinishNow(cause, _) => Some(cause)
       case LoopDecision.Continue            => None
     }
     val isFinalIteration = isLastByCount || forcedCause.nonEmpty
 
-    val withMarker = if (iteration > 0) history.addIterationMarker(iteration + 1, config.maxIterations) else history
     val requestHistory = decision match {
-      case LoopDecision.FinishNow(_, instruction) => withMarker.addUserPrompt(instruction)
-      case LoopDecision.Continue                  => withMarker
+      case LoopDecision.FinishNow(_, instruction) =>
+        // No iteration marker on a forced-final request: "[Iteration 3 of 10]" would contradict the injected instruction.
+        history.addUserPrompt(instruction)
+      case LoopDecision.Continue =>
+        if (iteration > 0) history.addIterationMarker(iteration + 1, config.maxIterations) else history
     }
 
-    val info = IterationInfo(iteration + 1, config.maxIterations)
+    val info = IterationInfo(iteration + 1, config.maxIterations, forcedFinal = forcedCause.nonEmpty)
     val includeTools = !isFinalIteration
 
     interceptor
@@ -142,7 +116,7 @@ class Agent[F[_]](
       val parsed: Either[AgentFailure, T] = res.finishReason match {
         case FinishReason.NaturalStop =>
           decode[T](res.finalAnswer).left.map(e => AgentParseError(res.finalAnswer, e))
-        case FinishReason.MaxIterations | FinishReason.BudgetExceeded =>
+        case FinishReason.MaxIterations | _: FinishReason.ForcedStop =>
           // A forced final iteration withholds tools and keeps schema guidance, so the answer may still be valid.
           decode[T](res.finalAnswer).left.map(e => AgentIncomplete(res.finalAnswer, res.finishReason, Some(e)))
         case FinishReason.TokenLimit | FinishReason.Error(_) =>
@@ -223,4 +197,15 @@ object Agent {
       config: AgentConfig[F]
   )(implicit monad: MonadError[F]): Agent[F] =
     new Agent[F](agentBackend, config)(monad)
+
+  // Top-level (not inner) classes so matches on them are runtime-checkable — inner classes trigger
+  // "outer reference cannot be checked" warnings on Scala 2.13.
+  private[agent] sealed trait IterationOutcome
+  private[agent] final case class ContinueLoop(
+      history: ConversationHistory,
+      records: Seq[ToolCallRecord],
+      usage: TokenUsage,
+      llmCalls: Seq[LlmCallUsage]
+  ) extends IterationOutcome
+  private[agent] final case class Finished(result: AgentResult[String]) extends IterationOutcome
 }

--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -104,13 +104,13 @@ class Agent[F[_]](
       val parsed: Either[AgentFailure, T] = res.finishReason match {
         case FinishReason.NaturalStop =>
           decode[T](res.finalAnswer).left.map(e => AgentParseError(res.finalAnswer, e))
-        case FinishReason.MaxIterations =>
-          // The last iteration forces a no-tools, schema-guided answer, so it may still be valid.
+        case FinishReason.MaxIterations | FinishReason.BudgetExceeded =>
+          // A forced final iteration withholds tools and keeps schema guidance, so the answer may still be valid.
           decode[T](res.finalAnswer).left.map(e => AgentIncomplete(res.finalAnswer, res.finishReason, Some(e)))
         case FinishReason.TokenLimit | FinishReason.Error(_) =>
           Left(AgentIncomplete(res.finalAnswer, res.finishReason, parseError = None))
       }
-      AgentResult(parsed, res.iterations, res.toolCalls, res.finishReason)
+      AgentResult(parsed, res.iterations, res.toolCalls, res.finishReason, res.usage, res.llmCalls)
     }
 
   private def runToolCalls(

--- a/core/src/main/scala/sttp/ai/core/agent/AgentBackend.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentBackend.scala
@@ -47,7 +47,9 @@ trait AgentBackend[F[_]] {
 case class AgentResponse(
     textContent: String,
     toolCalls: Seq[ToolCall],
-    stopReason: StopReason
+    stopReason: StopReason,
+    usage: Option[TokenUsage] = None,
+    model: Option[String] = None
 )
 
 /** Represents why the LLM stopped generating.

--- a/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
@@ -53,8 +53,10 @@ final class AgentBuilder[F[_], M <: AIModel] private (
   ): AgentBuilder[F, M] =
     withConfig(config.copy(responseSchema = Some(ResponseSchema.derived[T](Some(description)))))
 
+  @deprecated("Use interceptor(...) with an AgentInterceptor overriding aroundToolCall", "0.8.0")
   def hookBeforeToolCall(hook: ToolCall => F[Unit]): AgentBuilder[F, M] = withConfig(config.copy(beforeToolCall = Some(hook)))
 
+  @deprecated("Use interceptor(...) with an AgentInterceptor overriding aroundToolCall", "0.8.0")
   def hookAfterToolCall(hook: ToolCallRecord => F[Unit]): AgentBuilder[F, M] = withConfig(config.copy(afterToolCall = Some(hook)))
 
   /** Appends an interceptor. Interceptors wrap stages in list order: the first added is outermost. */

--- a/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
@@ -53,14 +53,8 @@ final class AgentBuilder[F[_], M <: AIModel] private (
   ): AgentBuilder[F, M] =
     withConfig(config.copy(responseSchema = Some(ResponseSchema.derived[T](Some(description)))))
 
-  @deprecated("Use interceptor(...) with an AgentInterceptor overriding aroundToolCall", "0.8.0")
-  def hookBeforeToolCall(hook: ToolCall => F[Unit]): AgentBuilder[F, M] = withConfig(config.copy(beforeToolCall = Some(hook)))
-
-  @deprecated("Use interceptor(...) with an AgentInterceptor overriding aroundToolCall", "0.8.0")
-  def hookAfterToolCall(hook: ToolCallRecord => F[Unit]): AgentBuilder[F, M] = withConfig(config.copy(afterToolCall = Some(hook)))
-
   /** Appends an interceptor. Interceptors wrap stages in list order: the first added is outermost. */
-  def interceptor(value: AgentInterceptor[F]): AgentBuilder[F, M] =
+  def addInterceptor(value: AgentInterceptor[F]): AgentBuilder[F, M] =
     withConfig(config.copy(interceptors = config.interceptors :+ value))
 
   /** Replaces the interceptor list. */

--- a/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
@@ -57,6 +57,14 @@ final class AgentBuilder[F[_], M <: AIModel] private (
 
   def hookAfterToolCall(hook: ToolCallRecord => F[Unit]): AgentBuilder[F, M] = withConfig(config.copy(afterToolCall = Some(hook)))
 
+  /** Appends an interceptor. Interceptors wrap stages in list order: the first added is outermost. */
+  def interceptor(value: AgentInterceptor[F]): AgentBuilder[F, M] =
+    withConfig(config.copy(interceptors = config.interceptors :+ value))
+
+  /** Replaces the interceptor list. */
+  def interceptors(values: Seq[AgentInterceptor[F]]): AgentBuilder[F, M] =
+    withConfig(config.copy(interceptors = values))
+
   def build: Agent[F] = Agent(makeBackend(config), config)
 }
 

--- a/core/src/main/scala/sttp/ai/core/agent/AgentConfig.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentConfig.scala
@@ -8,7 +8,9 @@ case class AgentConfig[F[_]](
     userTools: Seq[AgentTool[F, _]] = Seq.empty[AgentTool[F, _]],
     exceptionHandler: ExceptionHandler = ExceptionHandler.default,
     responseSchema: Option[ResponseSchema[_]] = None,
+    @deprecated("Use interceptors instead: an AgentInterceptor overriding aroundToolCall", "0.8.0")
     beforeToolCall: Option[ToolCall => F[Unit]] = None,
+    @deprecated("Use interceptors instead: an AgentInterceptor overriding aroundToolCall", "0.8.0")
     afterToolCall: Option[ToolCallRecord => F[Unit]] = None,
     interceptors: Seq[AgentInterceptor[F]] = Seq.empty[AgentInterceptor[F]]
 ) {

--- a/core/src/main/scala/sttp/ai/core/agent/AgentConfig.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentConfig.scala
@@ -9,7 +9,8 @@ case class AgentConfig[F[_]](
     exceptionHandler: ExceptionHandler = ExceptionHandler.default,
     responseSchema: Option[ResponseSchema[_]] = None,
     beforeToolCall: Option[ToolCall => F[Unit]] = None,
-    afterToolCall: Option[ToolCallRecord => F[Unit]] = None
+    afterToolCall: Option[ToolCallRecord => F[Unit]] = None,
+    interceptors: Seq[AgentInterceptor[F]] = Seq.empty[AgentInterceptor[F]]
 ) {
   val systemPrompt: Option[String] = systemPromptBuilder.map(_.apply(SystemPromptParameters(maxIterations)))
 }

--- a/core/src/main/scala/sttp/ai/core/agent/AgentConfig.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentConfig.scala
@@ -8,10 +8,6 @@ case class AgentConfig[F[_]](
     userTools: Seq[AgentTool[F, _]] = Seq.empty[AgentTool[F, _]],
     exceptionHandler: ExceptionHandler = ExceptionHandler.default,
     responseSchema: Option[ResponseSchema[_]] = None,
-    @deprecated("Use interceptors instead: an AgentInterceptor overriding aroundToolCall", "0.8.0")
-    beforeToolCall: Option[ToolCall => F[Unit]] = None,
-    @deprecated("Use interceptors instead: an AgentInterceptor overriding aroundToolCall", "0.8.0")
-    afterToolCall: Option[ToolCallRecord => F[Unit]] = None,
     interceptors: Seq[AgentInterceptor[F]] = Seq.empty[AgentInterceptor[F]]
 ) {
   val systemPrompt: Option[String] = systemPromptBuilder.map(_.apply(SystemPromptParameters(maxIterations)))

--- a/core/src/main/scala/sttp/ai/core/agent/AgentInterceptor.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentInterceptor.scala
@@ -87,7 +87,8 @@ object LoopDecision {
 
   /** Force a graceful final answer: `instruction` is injected as a user message, tools are withheld (the existing last-iteration
     * mechanism), and the run finishes with `finishReason = cause`. If the loop is simultaneously at its forced last iteration,
-    * `MaxIterations` takes precedence as the reported reason.
+    * `MaxIterations` takes precedence as the reported reason. If the forced-final LLM response itself stops with `StopReason.MaxTokens`,
+    * that check precedes the `FinishNow` cause and the run reports `FinishReason.TokenLimit` instead.
     */
   final case class FinishNow(cause: FinishReason, instruction: String) extends LoopDecision
 }

--- a/core/src/main/scala/sttp/ai/core/agent/AgentInterceptor.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentInterceptor.scala
@@ -1,0 +1,93 @@
+package sttp.ai.core.agent
+
+/** Middleware for the agent loop. Interceptors wrap iterations, LLM calls, and tool executions (onion-style, like sttp backend wrappers),
+  * and can steer the loop via [[decide]].
+  *
+  * Contracts:
+  *   - `next` is by-name: with `F = Identity`, `F[A] = A`, so a strict parameter would run the stage before the interceptor could act.
+  *     Interceptors that skip calling `next` short-circuit the stage.
+  *   - Exceptions raised by interceptor code propagate in `F` and fail the run. Interceptors are trusted infrastructure; their errors are
+  *     never swallowed.
+  *   - [[decide]] is pure: it is a judgment over already-accumulated state, consulted before each iteration. Effects belong in the
+  *     `around*` methods.
+  */
+trait AgentInterceptor[F[_]] {
+
+  /** Wraps one full loop iteration (LLM call + any tool executions). `A` is the loop's internal outcome type, opaque on purpose. */
+  def aroundIteration[A](ctx: IterationContext)(next: => F[A]): F[A] = next
+
+  /** Wraps a single LLM request. The returned [[AgentResponse]] carries provider-reported `usage` and `model` when available. */
+  def aroundLlmCall(ctx: LlmCallContext)(next: => F[AgentResponse]): F[AgentResponse] = next
+
+  /** Wraps a single tool execution (input decoding, tool body, error handling). */
+  def aroundToolCall(ctx: ToolCallContext)(next: => F[ToolCallRecord]): F[ToolCallRecord] = next
+
+  /** Consulted by the loop before each iteration. Return [[LoopDecision.FinishNow]] to force a graceful final answer. */
+  def decide(state: AgentRunState): LoopDecision = LoopDecision.Continue
+}
+
+object AgentInterceptor {
+
+  /** An interceptor that does nothing: all stages pass through, `decide` always continues. */
+  def noop[F[_]]: AgentInterceptor[F] = new AgentInterceptor[F] {}
+
+  /** Composes interceptors: the FIRST interceptor in the list is OUTERMOST for `around*` stages; for `decide`, interceptors are consulted
+    * in list order and the first [[LoopDecision.FinishNow]] wins.
+    */
+  def compose[F[_]](interceptors: Seq[AgentInterceptor[F]]): AgentInterceptor[F] =
+    interceptors.reduceOption(combine[F]).getOrElse(noop[F])
+
+  private def combine[F[_]](outer: AgentInterceptor[F], inner: AgentInterceptor[F]): AgentInterceptor[F] =
+    new AgentInterceptor[F] {
+      override def aroundIteration[A](ctx: IterationContext)(next: => F[A]): F[A] =
+        outer.aroundIteration(ctx)(inner.aroundIteration(ctx)(next))
+
+      override def aroundLlmCall(ctx: LlmCallContext)(next: => F[AgentResponse]): F[AgentResponse] =
+        outer.aroundLlmCall(ctx)(inner.aroundLlmCall(ctx)(next))
+
+      override def aroundToolCall(ctx: ToolCallContext)(next: => F[ToolCallRecord]): F[ToolCallRecord] =
+        outer.aroundToolCall(ctx)(inner.aroundToolCall(ctx)(next))
+
+      override def decide(state: AgentRunState): LoopDecision =
+        outer.decide(state) match {
+          case finish: LoopDecision.FinishNow => finish
+          case LoopDecision.Continue          => inner.decide(state)
+        }
+    }
+}
+
+/** Loop position of the iteration being wrapped. */
+final case class IterationContext(iterationInfo: IterationInfo)
+
+/** What the loop is about to send to the LLM. */
+final case class LlmCallContext(history: ConversationHistory, includeTools: Boolean, iterationInfo: IterationInfo)
+
+/** The tool call about to be executed, and the 1-based iteration it belongs to. */
+final case class ToolCallContext(toolCall: ToolCall, iteration: Int)
+
+/** Accumulated run state visible to [[AgentInterceptor.decide]].
+  *
+  * @param iterationsCompleted
+  *   number of fully completed iterations (0 before the first)
+  * @param llmCalls
+  *   per-call usage breakdown; enables per-model cost budgets when the run mixes models
+  */
+final case class AgentRunState(
+    iterationsCompleted: Int,
+    maxIterations: Int,
+    usage: TokenUsage,
+    llmCalls: Seq[LlmCallUsage]
+)
+
+/** What the loop should do next, as judged by an interceptor before an iteration. */
+sealed trait LoopDecision
+
+object LoopDecision {
+  case object Continue extends LoopDecision
+
+  /** Force a graceful final answer: `instruction` is injected as a user message, tools are withheld (the existing last-iteration
+    * mechanism), and the run finishes with `finishReason = cause`. If the loop is simultaneously at its forced last iteration,
+    * `MaxIterations` takes precedence as the reported reason.
+    */
+  final case class FinishNow(cause: FinishReason, instruction: String) extends LoopDecision
+}

--- a/core/src/main/scala/sttp/ai/core/agent/AgentInterceptor.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentInterceptor.scala
@@ -1,5 +1,7 @@
 package sttp.ai.core.agent
 
+import scala.annotation.unused
+
 /** Middleware for the agent loop. Interceptors wrap iterations, LLM calls, and tool executions (onion-style, like sttp backend wrappers),
   * and can steer the loop via [[decide]].
   *
@@ -15,13 +17,13 @@ package sttp.ai.core.agent
 trait AgentInterceptor[F[_]] {
 
   /** Wraps one full loop iteration (LLM call + any tool executions). `A` is the loop's internal outcome type, opaque on purpose. */
-  def aroundIteration[A](ctx: IterationContext)(next: => F[A]): F[A] = next
+  def aroundIteration[A](@unused ctx: IterationContext)(next: => F[A]): F[A] = next
 
   /** Wraps a single LLM request. The returned [[AgentResponse]] carries provider-reported `usage` and `model` when available. */
-  def aroundLlmCall(ctx: LlmCallContext)(next: => F[AgentResponse]): F[AgentResponse] = next
+  def aroundLlmCall(@unused ctx: LlmCallContext)(next: => F[AgentResponse]): F[AgentResponse] = next
 
   /** Wraps a single tool execution (input decoding, tool body, error handling). */
-  def aroundToolCall(ctx: ToolCallContext)(next: => F[ToolCallRecord]): F[ToolCallRecord] = next
+  def aroundToolCall(@unused ctx: ToolCallContext)(next: => F[ToolCallRecord]): F[ToolCallRecord] = next
 
   /** Consulted by the loop before each iteration. Return [[LoopDecision.FinishNow]] to force a graceful final answer. */
   def decide(state: AgentRunState): LoopDecision = LoopDecision.Continue
@@ -70,6 +72,9 @@ final case class ToolCallContext(toolCall: ToolCall, iteration: Int)
   *
   * @param iterationsCompleted
   *   number of fully completed iterations (0 before the first)
+  * @param maxIterations
+  *   the run's configured iteration cap ([[AgentConfig.maxIterations]]), so steering logic can act relative to the remaining allowance
+  *   (e.g. finish early once 80% of iterations are used) without holding a reference to the config
   * @param llmCalls
   *   per-call usage breakdown; enables per-model cost budgets when the run mixes models
   */
@@ -91,5 +96,5 @@ object LoopDecision {
     * `MaxIterations` takes precedence as the reported reason. If the forced-final LLM response itself stops with `StopReason.MaxTokens`,
     * that check precedes the `FinishNow` cause and the run reports `FinishReason.TokenLimit` instead.
     */
-  final case class FinishNow(cause: FinishReason, instruction: String) extends LoopDecision
+  final case class FinishNow(cause: FinishReason.ForcedStop, instruction: String) extends LoopDecision
 }

--- a/core/src/main/scala/sttp/ai/core/agent/AgentInterceptor.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentInterceptor.scala
@@ -5,7 +5,8 @@ package sttp.ai.core.agent
   *
   * Contracts:
   *   - `next` is by-name: with `F = Identity`, `F[A] = A`, so a strict parameter would run the stage before the interceptor could act.
-  *     Interceptors that skip calling `next` short-circuit the stage.
+  *     Interceptors that skip calling `next` short-circuit the stage. Call `next` at most once: evaluating it again re-executes the stage
+  *     (re-sending the LLM request or re-running the tool under `Identity`, and building a duplicated effect under lazy `F`).
   *   - Exceptions raised by interceptor code propagate in `F` and fail the run. Interceptors are trusted infrastructure; their errors are
   *     never swallowed.
   *   - [[decide]] is pure: it is a judgment over already-accumulated state, consulted before each iteration. Effects belong in the

--- a/core/src/main/scala/sttp/ai/core/agent/AgentResult.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentResult.scala
@@ -6,6 +6,9 @@ object FinishReason {
   case object MaxIterations extends FinishReason
   case object NaturalStop extends FinishReason
   case object TokenLimit extends FinishReason
+
+  /** An [[AgentInterceptor]] budget was exhausted and the loop forced a graceful final answer. */
+  case object BudgetExceeded extends FinishReason
   case class Error(message: String) extends FinishReason
 }
 
@@ -21,7 +24,9 @@ final case class AgentResult[T](
     finalAnswer: T,
     iterations: Int,
     toolCalls: Seq[ToolCallRecord],
-    finishReason: FinishReason
+    finishReason: FinishReason,
+    usage: TokenUsage = TokenUsage.Zero,
+    llmCalls: Seq[LlmCallUsage] = Seq.empty
 )
 
 sealed trait AgentFailure {

--- a/core/src/main/scala/sttp/ai/core/agent/AgentResult.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentResult.scala
@@ -7,8 +7,18 @@ object FinishReason {
   case object NaturalStop extends FinishReason
   case object TokenLimit extends FinishReason
 
+  /** Reasons an [[AgentInterceptor]] may force a graceful final answer via [[LoopDecision.FinishNow]]. Narrowing the `FinishNow` cause to
+    * this subtype keeps interceptors from misreporting loop-owned reasons (`NaturalStop`, `TokenLimit`, ...), which would silently change
+    * how `runAs` parses the answer.
+    */
+  sealed trait ForcedStop extends FinishReason
+
   /** An [[AgentInterceptor]] budget was exhausted and the loop forced a graceful final answer. */
-  case object BudgetExceeded extends FinishReason
+  case object BudgetExceeded extends ForcedStop
+
+  /** A custom [[AgentInterceptor]] forced a graceful final answer for a reason of its own (e.g. a wall-clock deadline). */
+  final case class Custom(reason: String) extends ForcedStop
+
   case class Error(message: String) extends FinishReason
 }
 

--- a/core/src/main/scala/sttp/ai/core/agent/IterationInfo.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/IterationInfo.scala
@@ -6,11 +6,14 @@ package sttp.ai.core.agent
   *   1-based index of the loop iteration this request belongs to
   * @param maxIterations
   *   the configured maximum number of iterations
+  * @param forcedFinal
+  *   true when an [[AgentInterceptor]] forced this iteration to be the final one via [[LoopDecision.FinishNow]] (e.g. a budget breach)
   */
-final case class IterationInfo(iteration: Int, maxIterations: Int) {
+final case class IterationInfo(iteration: Int, maxIterations: Int, forcedFinal: Boolean = false) {
 
-  /** True on the forced-final iteration, where tools are withheld and the model must produce a final answer. Note that the loop cannot know
-    * in advance which iteration produces the final answer when the model stops naturally — this flags only the forced last iteration.
+  /** True on any final iteration where tools are withheld and the model must produce a final answer — whether the iteration cap was reached
+    * or an interceptor forced the finish ([[forcedFinal]]). Note that the loop cannot know in advance which iteration produces the final
+    * answer when the model stops naturally — this flags only forced final iterations.
     */
-  def isLastIteration: Boolean = iteration >= maxIterations
+  def isLastIteration: Boolean = iteration >= maxIterations || forcedFinal
 }

--- a/core/src/main/scala/sttp/ai/core/agent/TokenUsage.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/TokenUsage.scala
@@ -1,0 +1,48 @@
+package sttp.ai.core.agent
+
+/** A count of LLM tokens. A dedicated type so token counts cannot be confused with other numeric quantities (costs, iteration counts). */
+final case class Tokens(value: Long) extends AnyVal {
+  def +(other: Tokens): Tokens = Tokens(value + other.value)
+  def <(other: Tokens): Boolean = value < other.value
+  def <=(other: Tokens): Boolean = value <= other.value
+  def >(other: Tokens): Boolean = value > other.value
+  def >=(other: Tokens): Boolean = value >= other.value
+}
+
+object Tokens {
+  val Zero: Tokens = Tokens(0L)
+}
+
+/** Provider-normalized token usage of one or more LLM calls.
+  *
+  * @param inputTokens
+  *   ALL prompt-side tokens, cached tokens included
+  * @param outputTokens
+  *   ALL completion-side tokens, reasoning tokens included
+  * @param cachedInputTokens
+  *   informational subset of [[inputTokens]] served from a provider cache
+  * @param reasoningTokens
+  *   informational subset of [[outputTokens]] spent on reasoning/thinking, where the provider reports it
+  */
+final case class TokenUsage(
+    inputTokens: Tokens,
+    outputTokens: Tokens,
+    cachedInputTokens: Tokens,
+    reasoningTokens: Tokens
+) {
+  def totalTokens: Tokens = inputTokens + outputTokens
+
+  def +(other: TokenUsage): TokenUsage = TokenUsage(
+    inputTokens = inputTokens + other.inputTokens,
+    outputTokens = outputTokens + other.outputTokens,
+    cachedInputTokens = cachedInputTokens + other.cachedInputTokens,
+    reasoningTokens = reasoningTokens + other.reasoningTokens
+  )
+}
+
+object TokenUsage {
+  val Zero: TokenUsage = TokenUsage(Tokens.Zero, Tokens.Zero, Tokens.Zero, Tokens.Zero)
+}
+
+/** Usage of a single LLM call, with the model that served it (as reported by the provider) for per-model cost calculation. */
+final case class LlmCallUsage(model: Option[String], usage: TokenUsage)

--- a/core/src/main/scala/sttp/ai/core/agent/TokenUsage.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/TokenUsage.scala
@@ -16,19 +16,23 @@ object Tokens {
 /** Provider-normalized token usage of one or more LLM calls.
   *
   * @param inputTokens
-  *   ALL prompt-side tokens, cached tokens included
+  *   ALL prompt-side tokens — cached reads and cache writes included
   * @param outputTokens
   *   ALL completion-side tokens, reasoning tokens included
   * @param cachedInputTokens
-  *   informational subset of [[inputTokens]] served from a provider cache
+  *   informational subset of [[inputTokens]] served from a provider cache (cache reads)
   * @param reasoningTokens
   *   informational subset of [[outputTokens]] spent on reasoning/thinking, where the provider reports it
+  * @param cacheWriteInputTokens
+  *   informational subset of [[inputTokens]] written to a provider cache (cache writes, e.g. Claude's `cache_creation_input_tokens`); often
+  *   billed at a premium over the plain input rate
   */
 final case class TokenUsage(
     inputTokens: Tokens,
     outputTokens: Tokens,
     cachedInputTokens: Tokens,
-    reasoningTokens: Tokens
+    reasoningTokens: Tokens,
+    cacheWriteInputTokens: Tokens = Tokens.Zero
 ) {
   def totalTokens: Tokens = inputTokens + outputTokens
 
@@ -36,12 +40,13 @@ final case class TokenUsage(
     inputTokens = inputTokens + other.inputTokens,
     outputTokens = outputTokens + other.outputTokens,
     cachedInputTokens = cachedInputTokens + other.cachedInputTokens,
-    reasoningTokens = reasoningTokens + other.reasoningTokens
+    reasoningTokens = reasoningTokens + other.reasoningTokens,
+    cacheWriteInputTokens = cacheWriteInputTokens + other.cacheWriteInputTokens
   )
 }
 
 object TokenUsage {
-  val Zero: TokenUsage = TokenUsage(Tokens.Zero, Tokens.Zero, Tokens.Zero, Tokens.Zero)
+  val Zero: TokenUsage = TokenUsage(Tokens.Zero, Tokens.Zero, Tokens.Zero, Tokens.Zero, Tokens.Zero)
 }
 
 /** Usage of a single LLM call, with the model that served it (as reported by the provider) for per-model cost calculation. */

--- a/core/src/main/scala/sttp/ai/core/agent/interceptor/BudgetInterceptor.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/interceptor/BudgetInterceptor.scala
@@ -1,0 +1,79 @@
+package sttp.ai.core.agent.interceptor
+
+import sttp.ai.core.agent._
+
+/** Price of one model per million tokens, in the currency of the user's choosing (consistent across the table).
+  *
+  * @param cachedInputPerMTok
+  *   when set, cached input tokens are priced at this rate instead of [[inputPerMTok]]
+  */
+final case class ModelPrice(
+    inputPerMTok: BigDecimal,
+    outputPerMTok: BigDecimal,
+    cachedInputPerMTok: Option[BigDecimal] = None
+)
+
+/** A monetary cost. The unit is whatever currency the [[PriceTable]] was written in. */
+final case class Cost(value: BigDecimal) extends AnyVal {
+  def >=(other: Cost): Boolean = value >= other.value
+}
+
+/** User-supplied per-model prices, keyed by the provider-reported model id (e.g. "gpt-4o-mini").
+  *
+  * The library ships NO prices: they change frequently and vary by provider, tier, and region.
+  */
+final case class PriceTable(prices: Map[String, ModelPrice]) {
+
+  /** Total cost of the given calls. IMPORTANT: calls whose model id is absent from the table (or not reported by the provider) contribute
+    * ZERO — a cost budget silently under-counts unknown models rather than failing the run. Prefer a token budget when the models in play
+    * are not all priced.
+    */
+  def costOf(calls: Seq[LlmCallUsage]): Cost = Cost(calls.map(costOfCall).sum)
+
+  private def costOfCall(call: LlmCallUsage): BigDecimal =
+    call.model.flatMap(prices.get) match {
+      case None        => BigDecimal(0)
+      case Some(price) =>
+        val cachedInput = BigDecimal(call.usage.cachedInputTokens.value)
+        val uncachedInput = BigDecimal(math.max(call.usage.inputTokens.value - call.usage.cachedInputTokens.value, 0L))
+        val output = BigDecimal(call.usage.outputTokens.value)
+        (uncachedInput * price.inputPerMTok +
+          cachedInput * price.cachedInputPerMTok.getOrElse(price.inputPerMTok) +
+          output * price.outputPerMTok) / 1000000
+    }
+}
+
+/** Ends the agent loop gracefully when a token or cost budget is exhausted.
+  *
+  * Overrides only [[AgentInterceptor.decide]]: when `state.usage.totalTokens >= maxTotalTokens` or the [[PriceTable]]-computed cost of
+  * `state.llmCalls` reaches `maxCost`, the loop injects `instruction` as a user message, withholds tools, and finishes with
+  * [[FinishReason.BudgetExceeded]] — mirroring the existing last-iteration behavior instead of failing abruptly.
+  *
+  * The cost check requires BOTH `maxCost` and `priceTable`; otherwise it is skipped. See [[PriceTable.costOf]] for the unknown-model
+  * caveat.
+  */
+final class BudgetInterceptor[F[_]](
+    maxTotalTokens: Option[Tokens] = None,
+    maxCost: Option[Cost] = None,
+    priceTable: Option[PriceTable] = None,
+    instruction: String = BudgetInterceptor.defaultInstruction
+) extends AgentInterceptor[F] {
+
+  override def decide(state: AgentRunState): LoopDecision = {
+    val tokensExceeded = maxTotalTokens.exists(limit => state.usage.totalTokens >= limit)
+    val costExceeded = (maxCost, priceTable) match {
+      case (Some(limit), Some(table)) => table.costOf(state.llmCalls) >= limit
+      case _                          => false
+    }
+    if (tokensExceeded || costExceeded) LoopDecision.FinishNow(FinishReason.BudgetExceeded, instruction)
+    else LoopDecision.Continue
+  }
+}
+
+object BudgetInterceptor {
+
+  /** Mirrors the last-iteration rule in the default agent system prompt. */
+  val defaultInstruction: String =
+    "The resource budget for this task is exhausted. Provide your final answer now based on the information gathered so far, " +
+      "even if the result is partial, approximate, or only a summary."
+}

--- a/core/src/main/scala/sttp/ai/core/agent/interceptor/BudgetInterceptor.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/interceptor/BudgetInterceptor.scala
@@ -49,8 +49,8 @@ final case class PriceTable(prices: Map[String, ModelPrice]) {
   * `state.llmCalls` reaches `maxCost`, the loop injects `instruction` as a user message, withholds tools, and finishes with
   * [[FinishReason.BudgetExceeded]] — mirroring the existing last-iteration behavior instead of failing abruptly.
   *
-  * The cost check requires BOTH `maxCost` and `priceTable`; otherwise it is skipped. See [[PriceTable.costOf]] for the unknown-model
-  * caveat.
+  * The cost check requires BOTH `maxCost` and `priceTable`: setting `maxCost` without a `priceTable` fails at construction with an
+  * `IllegalArgumentException`, since such a budget could never trigger. See [[PriceTable.costOf]] for the unknown-model caveat.
   */
 final class BudgetInterceptor[F[_]](
     maxTotalTokens: Option[Tokens] = None,
@@ -58,6 +58,11 @@ final class BudgetInterceptor[F[_]](
     priceTable: Option[PriceTable] = None,
     instruction: String = BudgetInterceptor.defaultInstruction
 ) extends AgentInterceptor[F] {
+
+  require(
+    maxCost.isEmpty || priceTable.nonEmpty,
+    "maxCost requires a priceTable; without one the cost budget can never trigger"
+  )
 
   override def decide(state: AgentRunState): LoopDecision = {
     val tokensExceeded = maxTotalTokens.exists(limit => state.usage.totalTokens >= limit)

--- a/core/src/main/scala/sttp/ai/core/agent/interceptor/BudgetInterceptor.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/interceptor/BudgetInterceptor.scala
@@ -5,12 +5,16 @@ import sttp.ai.core.agent._
 /** Price of one model per million tokens, in the currency of the user's choosing (consistent across the table).
   *
   * @param cachedInputPerMTok
-  *   when set, cached input tokens are priced at this rate instead of [[inputPerMTok]]
+  *   when set, cached input tokens (cache reads) are priced at this rate instead of [[inputPerMTok]]
+  * @param cacheWriteInputPerMTok
+  *   when set, cache-write input tokens (e.g. Claude's `cache_creation_input_tokens`, typically billed at a premium) are priced at this
+  *   rate instead of [[inputPerMTok]]
   */
 final case class ModelPrice(
     inputPerMTok: BigDecimal,
     outputPerMTok: BigDecimal,
-    cachedInputPerMTok: Option[BigDecimal] = None
+    cachedInputPerMTok: Option[BigDecimal] = None,
+    cacheWriteInputPerMTok: Option[BigDecimal] = None
 )
 
 /** A monetary cost. The unit is whatever currency the [[PriceTable]] was written in. */
@@ -35,10 +39,14 @@ final case class PriceTable(prices: Map[String, ModelPrice]) {
       case None        => BigDecimal(0)
       case Some(price) =>
         val cachedInput = BigDecimal(call.usage.cachedInputTokens.value)
-        val uncachedInput = BigDecimal(math.max(call.usage.inputTokens.value - call.usage.cachedInputTokens.value, 0L))
+        val cacheWriteInput = BigDecimal(call.usage.cacheWriteInputTokens.value)
+        val plainInput = BigDecimal(
+          math.max(call.usage.inputTokens.value - call.usage.cachedInputTokens.value - call.usage.cacheWriteInputTokens.value, 0L)
+        )
         val output = BigDecimal(call.usage.outputTokens.value)
-        (uncachedInput * price.inputPerMTok +
+        (plainInput * price.inputPerMTok +
           cachedInput * price.cachedInputPerMTok.getOrElse(price.inputPerMTok) +
+          cacheWriteInput * price.cacheWriteInputPerMTok.getOrElse(price.inputPerMTok) +
           output * price.outputPerMTok) / 1000000
     }
 }
@@ -60,6 +68,10 @@ final class BudgetInterceptor[F[_]](
 ) extends AgentInterceptor[F] {
 
   require(
+    maxTotalTokens.nonEmpty || maxCost.nonEmpty,
+    "BudgetInterceptor needs at least one limit: set maxTotalTokens and/or maxCost"
+  )
+  require(
     maxCost.isEmpty || priceTable.nonEmpty,
     "maxCost requires a priceTable; without one the cost budget can never trigger"
   )
@@ -76,6 +88,13 @@ final class BudgetInterceptor[F[_]](
 }
 
 object BudgetInterceptor {
+
+  def apply[F[_]](
+      maxTotalTokens: Option[Tokens] = None,
+      maxCost: Option[Cost] = None,
+      priceTable: Option[PriceTable] = None,
+      instruction: String = defaultInstruction
+  ): BudgetInterceptor[F] = new BudgetInterceptor[F](maxTotalTokens, maxCost, priceTable, instruction)
 
   /** Mirrors the last-iteration rule in the default agent system prompt. */
   val defaultInstruction: String =

--- a/core/src/main/scala/sttp/ai/core/agent/interceptor/LoggingInterceptor.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/interceptor/LoggingInterceptor.scala
@@ -1,0 +1,43 @@
+package sttp.ai.core.agent.interceptor
+
+import sttp.ai.core.agent._
+import sttp.monad.MonadError
+import sttp.monad.syntax.MonadErrorOps
+
+/** Severity of a [[LoggingInterceptor]] message. A minimal in-house ADT so core gains no logging dependency. */
+sealed trait LogLevel
+
+object LogLevel {
+  case object Debug extends LogLevel
+  case object Info extends LogLevel
+  case object Warn extends LogLevel
+}
+
+/** Logs agent-loop activity through a user-supplied sink, keeping core free of logging dependencies and the effect referentially
+  * transparent. Bridge examples (slf4j/log4cats, otel4s, ZIO logging) are in the interceptors documentation page.
+  */
+final class LoggingInterceptor[F[_]](sink: (LogLevel, String) => F[Unit])(implicit monad: MonadError[F]) extends AgentInterceptor[F] {
+
+  override def aroundIteration[A](ctx: IterationContext)(next: => F[A]): F[A] = {
+    val position = s"${ctx.iterationInfo.iteration}/${ctx.iterationInfo.maxIterations}"
+    sink(LogLevel.Debug, s"Iteration $position started").flatMap { _ =>
+      next.flatMap(result => sink(LogLevel.Debug, s"Iteration $position finished").map(_ => result))
+    }
+  }
+
+  override def aroundLlmCall(ctx: LlmCallContext)(next: => F[AgentResponse]): F[AgentResponse] =
+    next.flatMap { response =>
+      val model = response.model.getOrElse("unknown")
+      val usage = response.usage.getOrElse(TokenUsage.Zero)
+      sink(
+        LogLevel.Info,
+        s"LLM call (iteration ${ctx.iterationInfo.iteration}, model $model): " +
+          s"input=${usage.inputTokens.value} output=${usage.outputTokens.value} tokens"
+      ).map(_ => response)
+    }
+
+  override def aroundToolCall(ctx: ToolCallContext)(next: => F[ToolCallRecord]): F[ToolCallRecord] =
+    sink(LogLevel.Info, s"Tool call started: ${ctx.toolCall.toolName}").flatMap { _ =>
+      next.flatMap(record => sink(LogLevel.Info, s"Tool call finished: ${record.toolName}").map(_ => record))
+    }
+}

--- a/core/src/main/scala/sttp/ai/core/agent/interceptor/LoggingInterceptor.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/interceptor/LoggingInterceptor.scala
@@ -14,7 +14,8 @@ object LogLevel {
 }
 
 /** Logs agent-loop activity through a user-supplied sink, keeping core free of logging dependencies and the effect referentially
-  * transparent. Bridge examples (slf4j/log4cats, otel4s, ZIO logging) are in the interceptors documentation page.
+  * transparent. Failed LLM calls and tool executions are logged at [[LogLevel.Warn]] before the error propagates. Bridge examples
+  * (slf4j/log4cats, otel4s, ZIO logging) are in the interceptors documentation page.
   */
 final class LoggingInterceptor[F[_]](sink: (LogLevel, String) => F[Unit])(implicit monad: MonadError[F]) extends AgentInterceptor[F] {
 
@@ -26,18 +27,34 @@ final class LoggingInterceptor[F[_]](sink: (LogLevel, String) => F[Unit])(implic
   }
 
   override def aroundLlmCall(ctx: LlmCallContext)(next: => F[AgentResponse]): F[AgentResponse] =
-    next.flatMap { response =>
-      val model = response.model.getOrElse("unknown")
-      val usage = response.usage.getOrElse(TokenUsage.Zero)
-      sink(
-        LogLevel.Info,
-        s"LLM call (iteration ${ctx.iterationInfo.iteration}, model $model): " +
-          s"input=${usage.inputTokens.value} output=${usage.outputTokens.value} tokens"
-      ).map(_ => response)
-    }
+    next
+      .handleError { case e: Throwable =>
+        sink(LogLevel.Warn, s"LLM call failed (iteration ${ctx.iterationInfo.iteration}): ${e.getMessage}")
+          .flatMap(_ => monad.error[AgentResponse](e))
+      }
+      .flatMap { response =>
+        val model = response.model.getOrElse("unknown")
+        val usage = response.usage.getOrElse(TokenUsage.Zero)
+        sink(
+          LogLevel.Info,
+          s"LLM call (iteration ${ctx.iterationInfo.iteration}, model $model): " +
+            s"input=${usage.inputTokens.value} output=${usage.outputTokens.value} tokens"
+        ).map(_ => response)
+      }
 
   override def aroundToolCall(ctx: ToolCallContext)(next: => F[ToolCallRecord]): F[ToolCallRecord] =
     sink(LogLevel.Info, s"Tool call started: ${ctx.toolCall.toolName}").flatMap { _ =>
-      next.flatMap(record => sink(LogLevel.Info, s"Tool call finished: ${record.toolName}").map(_ => record))
+      next
+        .handleError { case e: Throwable =>
+          sink(LogLevel.Warn, s"Tool call failed: ${ctx.toolCall.toolName}: ${e.getMessage}")
+            .flatMap(_ => monad.error[ToolCallRecord](e))
+        }
+        .flatMap(record => sink(LogLevel.Info, s"Tool call finished: ${record.toolName}").map(_ => record))
     }
+}
+
+object LoggingInterceptor {
+
+  def apply[F[_]](sink: (LogLevel, String) => F[Unit])(implicit monad: MonadError[F]): LoggingInterceptor[F] =
+    new LoggingInterceptor[F](sink)
 }

--- a/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorComposeSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorComposeSpec.scala
@@ -49,16 +49,14 @@ class AgentInterceptorComposeSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "return the first FinishNow in list order" in {
-    // Uses NaturalStop as the cause because FinishReason.BudgetExceeded is only added in Task 6;
-    // FinishNow accepts any FinishReason.
     val first = new AgentInterceptor[Identity] {
-      override def decide(s: AgentRunState): LoopDecision = LoopDecision.FinishNow(FinishReason.NaturalStop, "first")
+      override def decide(s: AgentRunState): LoopDecision = LoopDecision.FinishNow(FinishReason.Custom("deadline"), "first")
     }
     val second = new AgentInterceptor[Identity] {
-      override def decide(s: AgentRunState): LoopDecision = LoopDecision.FinishNow(FinishReason.NaturalStop, "second")
+      override def decide(s: AgentRunState): LoopDecision = LoopDecision.FinishNow(FinishReason.BudgetExceeded, "second")
     }
     val composed = AgentInterceptor.compose(Seq(AgentInterceptor.noop[Identity], first, second))
-    composed.decide(state()) shouldBe LoopDecision.FinishNow(FinishReason.NaturalStop, "first")
+    composed.decide(state()) shouldBe LoopDecision.FinishNow(FinishReason.Custom("deadline"), "first")
   }
 
   it should "not evaluate next when an interceptor short-circuits" in {

--- a/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorComposeSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorComposeSpec.scala
@@ -1,0 +1,81 @@
+package sttp.ai.core.agent
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.shared.Identity
+
+class AgentInterceptorComposeSpec extends AnyFlatSpec with Matchers {
+
+  private def state(iterations: Int = 0): AgentRunState =
+    AgentRunState(iterationsCompleted = iterations, maxIterations = 10, usage = TokenUsage.Zero, llmCalls = Seq.empty)
+
+  private class Recording(name: String, log: collection.mutable.Buffer[String]) extends AgentInterceptor[Identity] {
+    override def aroundIteration[A](ctx: IterationContext)(next: => Identity[A]): Identity[A] = {
+      log += s"$name:iter:before"
+      val result = next
+      log += s"$name:iter:after"
+      result
+    }
+    override def aroundLlmCall(ctx: LlmCallContext)(next: => Identity[AgentResponse]): Identity[AgentResponse] = {
+      log += s"$name:llm:before"
+      val result = next
+      log += s"$name:llm:after"
+      result
+    }
+    override def aroundToolCall(ctx: ToolCallContext)(next: => Identity[ToolCallRecord]): Identity[ToolCallRecord] = {
+      log += s"$name:tool:before"
+      val result = next
+      log += s"$name:tool:after"
+      result
+    }
+  }
+
+  "AgentInterceptor.compose" should "nest around* with the first interceptor outermost" in {
+    val log = collection.mutable.Buffer.empty[String]
+    val composed = AgentInterceptor.compose(Seq(new Recording("a", log), new Recording("b", log)))
+
+    composed.aroundIteration(IterationContext(IterationInfo(1, 10))) {
+      log += "body"
+      42
+    } shouldBe 42
+
+    log.toList shouldBe List("a:iter:before", "b:iter:before", "body", "b:iter:after", "a:iter:after")
+  }
+
+  it should "return Continue when all interceptors continue" in {
+    val log = collection.mutable.Buffer.empty[String]
+    val composed = AgentInterceptor.compose(Seq(new Recording("a", log), new Recording("b", log)))
+    composed.decide(state()) shouldBe LoopDecision.Continue
+  }
+
+  it should "return the first FinishNow in list order" in {
+    // Uses NaturalStop as the cause because FinishReason.BudgetExceeded is only added in Task 6;
+    // FinishNow accepts any FinishReason.
+    val first = new AgentInterceptor[Identity] {
+      override def decide(s: AgentRunState): LoopDecision = LoopDecision.FinishNow(FinishReason.NaturalStop, "first")
+    }
+    val second = new AgentInterceptor[Identity] {
+      override def decide(s: AgentRunState): LoopDecision = LoopDecision.FinishNow(FinishReason.NaturalStop, "second")
+    }
+    val composed = AgentInterceptor.compose(Seq(AgentInterceptor.noop[Identity], first, second))
+    composed.decide(state()) shouldBe LoopDecision.FinishNow(FinishReason.NaturalStop, "first")
+  }
+
+  it should "not evaluate next when an interceptor short-circuits" in {
+    var evaluated = false
+    val shortCircuit = new AgentInterceptor[Identity] {
+      override def aroundIteration[A](ctx: IterationContext)(next: => Identity[A]): Identity[A] =
+        throw new RuntimeException("boom")
+    }
+    val composed = AgentInterceptor.compose(Seq(shortCircuit))
+    a[RuntimeException] should be thrownBy
+      composed.aroundIteration(IterationContext(IterationInfo(1, 10))) { evaluated = true; 1 }
+    evaluated shouldBe false
+  }
+
+  it should "compose an empty list into a pass-through" in {
+    val composed = AgentInterceptor.compose(Seq.empty[AgentInterceptor[Identity]])
+    composed.aroundIteration(IterationContext(IterationInfo(1, 10)))(7) shouldBe 7
+    composed.decide(state()) shouldBe LoopDecision.Continue
+  }
+}

--- a/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorLoopSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorLoopSpec.scala
@@ -217,4 +217,42 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
     result.toolCalls should have size 1 // only the first iteration's tool call
     result.finalAnswer shouldBe "dummy result" // extractFinalAnswer fallback: last tool result
   }
+
+  it should "enforce a token budget end-to-end via BudgetInterceptor" in {
+    import sttp.ai.core.agent.interceptor.BudgetInterceptor
+    val stub = new StubAgentBackend(
+      Seq(
+        toolResponse("call_1", Some(usage(100, 20))),
+        toolResponse("call_2", Some(usage(100, 20))),
+        finalResponse("partial answer", Some(usage(50, 10)))
+      )
+    )
+    val budget = new BudgetInterceptor[Identity](maxTotalTokens = Some(Tokens(200L)))
+    val result = build(stub, Seq(budget)).run("Test")(backend)
+
+    result.finishReason shouldBe FinishReason.BudgetExceeded
+    result.finalAnswer shouldBe "partial answer"
+    result.iterations shouldBe 3 // breach detected after call 2 (240 >= 200), forced final on iteration 3
+    stub.receivedIncludeTools shouldBe Seq(true, true, false)
+    stub.receivedHistories.last.entries should contain(ConversationEntry.UserPrompt(BudgetInterceptor.defaultInstruction))
+  }
+
+  it should "let runAs parse a budget-forced final answer like a max-iterations one" in {
+    import sttp.ai.core.agent.interceptor.BudgetInterceptor
+    case class Out(x: Int)
+    implicit val outCodec: Codec[Out] = deriveCodec
+
+    val stub = new StubAgentBackend(
+      Seq(
+        toolResponse("call_1", Some(usage(100, 20))),
+        finalResponse("""{"x": 5}""", Some(usage(50, 10)))
+      )
+    )
+    val budget = new BudgetInterceptor[Identity](maxTotalTokens = Some(Tokens(100L)))
+    val result = build(stub, Seq(budget)).runAs[Out]("Test")(backend)
+
+    result.finishReason shouldBe FinishReason.BudgetExceeded
+    result.finalAnswer shouldBe Right(Out(5)) // BudgetExceeded is parse-attempted, not rejected outright
+    result.usage shouldBe usage(150, 30)
+  }
 }

--- a/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorLoopSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorLoopSpec.scala
@@ -153,4 +153,65 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
     agent.run("Test")(backend).finalAnswer shouldBe "done"
     log.toList shouldBe List("interceptor:in", "hook:before:dummy", "hook:after:dummy", "interceptor:out")
   }
+
+  private def finishAfter(calls: Int, cause: FinishReason, instruction: String): AgentInterceptor[Identity] =
+    new AgentInterceptor[Identity] {
+      override def decide(state: AgentRunState): LoopDecision =
+        if (state.llmCalls.size >= calls) LoopDecision.FinishNow(cause, instruction) else LoopDecision.Continue
+    }
+
+  it should "force a graceful final answer when decide returns FinishNow" in {
+    val stub = new StubAgentBackend(
+      Seq(
+        toolResponse("call_1", Some(usage(100, 20))),
+        finalResponse("budget answer", Some(usage(50, 10)))
+      )
+    )
+    val steer = finishAfter(1, FinishReason.BudgetExceeded, "BUDGET EXHAUSTED - answer now")
+    val result = build(stub, Seq(steer)).run("Test")(backend)
+
+    result.finishReason shouldBe FinishReason.BudgetExceeded
+    result.finalAnswer shouldBe "budget answer"
+    result.iterations shouldBe 2
+    // The forced-final request withheld tools and contained the injected instruction:
+    stub.receivedIncludeTools shouldBe Seq(true, false)
+    stub.receivedHistories.last.entries should contain(ConversationEntry.UserPrompt("BUDGET EXHAUSTED - answer now"))
+    // Usage includes the forced-final call:
+    result.usage shouldBe usage(150, 30)
+  }
+
+  it should "report MaxIterations when FinishNow coincides with the forced last iteration" in {
+    val stub = new StubAgentBackend(
+      Seq(
+        toolResponse("call_1", Some(usage(10, 5))),
+        finalResponse("last answer", Some(usage(10, 5)))
+      )
+    )
+    val steer = finishAfter(1, FinishReason.BudgetExceeded, "answer now")
+    val agent = AgentBuilder[Identity, TestModel.type](_ => stub)(IdentityMonad)
+      .maxIterations(2) // iteration 2 is the forced last iteration AND the FinishNow iteration
+      .tools(dummyTool)
+      .interceptors(Seq(steer))
+      .build
+
+    val result = agent.run("Test")(backend)
+    result.finishReason shouldBe FinishReason.MaxIterations
+    result.finalAnswer shouldBe "last answer"
+  }
+
+  it should "not consult tools nor execute spurious tool calls on a FinishNow iteration" in {
+    val stub = new StubAgentBackend(
+      Seq(
+        toolResponse("call_1", Some(usage(10, 5))),
+        // model misbehaves and still asks for a tool on the forced-final call; it must not be executed
+        toolResponse("call_2", Some(usage(10, 5)))
+      )
+    )
+    val steer = finishAfter(1, FinishReason.BudgetExceeded, "answer now")
+    val result = build(stub, Seq(steer)).run("Test")(backend)
+
+    result.finishReason shouldBe FinishReason.BudgetExceeded
+    result.toolCalls should have size 1 // only the first iteration's tool call
+    result.finalAnswer shouldBe "dummy result" // extractFinalAnswer fallback: last tool result
+  }
 }

--- a/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorLoopSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorLoopSpec.scala
@@ -237,6 +237,18 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
     stub.receivedHistories.last.entries should contain(ConversationEntry.UserPrompt(BudgetInterceptor.defaultInstruction))
   }
 
+  it should "force a graceful final answer via FinishNow before the first LLM call" in {
+    val stub = new StubAgentBackend(Seq(finalResponse("immediate answer", Some(usage(10, 5)))))
+    val steer = finishAfter(0, FinishReason.BudgetExceeded, "answer immediately")
+    val result = build(stub, Seq(steer)).run("Test")(backend)
+
+    result.finishReason shouldBe FinishReason.BudgetExceeded
+    result.finalAnswer shouldBe "immediate answer"
+    result.iterations shouldBe 1
+    stub.receivedIncludeTools shouldBe Seq(false)
+    stub.receivedHistories.last.entries should contain(ConversationEntry.UserPrompt("answer immediately"))
+  }
+
   it should "let runAs parse a budget-forced final answer like a max-iterations one" in {
     import sttp.ai.core.agent.interceptor.BudgetInterceptor
     case class Out(x: Int)

--- a/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorLoopSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorLoopSpec.scala
@@ -1,0 +1,156 @@
+package sttp.ai.core.agent
+
+import io.circe.Codec
+import io.circe.generic.semiauto.deriveCodec
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.core.model.{AIModel, Capability}
+import sttp.client4.testing.SyncBackendStub
+import sttp.monad.IdentityMonad
+import sttp.shared.Identity
+import sttp.tapir.Schema
+
+class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
+
+  case object TestModel extends AIModel with Capability.ToolCalling {
+    val value: String = "test-model"
+  }
+
+  class StubAgentBackend(responses: Seq[AgentResponse]) extends AgentBackend[Identity] {
+    private var callCount = 0
+    var receivedHistories: Seq[ConversationHistory] = Seq.empty
+    var receivedIncludeTools: Seq[Boolean] = Seq.empty
+
+    override def tools: Seq[AgentTool[Identity, _]] = Seq.empty
+    override def systemPrompt: Option[String] = None
+
+    override def sendRequest(
+        history: ConversationHistory,
+        backend: sttp.client4.Backend[Identity],
+        includeTools: Boolean,
+        iterationInfo: IterationInfo
+    ): Identity[AgentResponse] = {
+      receivedHistories = receivedHistories :+ history
+      receivedIncludeTools = receivedIncludeTools :+ includeTools
+      val response = if (callCount < responses.length) responses(callCount) else responses.last
+      callCount += 1
+      response
+    }
+  }
+
+  private val backend = SyncBackendStub
+
+  case class DummyInput()
+  implicit val dummyInputCodec: Codec[DummyInput] = deriveCodec
+  implicit val dummyInputSchema: Schema[DummyInput] = Schema.derived
+
+  private val dummyTool = AgentTool.fromFunction("dummy", "Dummy tool")((_: DummyInput) => "dummy result")
+
+  private def usage(in: Long, out: Long): TokenUsage =
+    TokenUsage(Tokens(in), Tokens(out), Tokens.Zero, Tokens.Zero)
+
+  private def toolResponse(id: String, u: Option[TokenUsage], model: Option[String] = Some("test-model")): AgentResponse =
+    AgentResponse("", Seq(ToolCall(id, "dummy", "{}")), StopReason.ToolUse, usage = u, model = model)
+
+  private def finalResponse(text: String, u: Option[TokenUsage]): AgentResponse =
+    AgentResponse(text, Seq.empty, StopReason.EndTurn, usage = u, model = Some("test-model"))
+
+  private def build(stub: StubAgentBackend, interceptors: Seq[AgentInterceptor[Identity]]): Agent[Identity] =
+    AgentBuilder[Identity, TestModel.type](_ => stub)(IdentityMonad)
+      .maxIterations(5)
+      .tools(dummyTool)
+      .interceptors(interceptors)
+      .build
+
+  "Agent with interceptors" should "accumulate usage and per-call breakdown into AgentResult" in {
+    val stub = new StubAgentBackend(
+      Seq(
+        toolResponse("call_1", Some(usage(100, 20))),
+        toolResponse("call_2", None), // a call with no reported usage contributes Zero
+        finalResponse("done", Some(usage(50, 10)))
+      )
+    )
+    val result = build(stub, Seq.empty).run("Test")(backend)
+
+    result.finalAnswer shouldBe "done"
+    result.usage shouldBe usage(150, 30)
+    result.llmCalls shouldBe Seq(
+      LlmCallUsage(Some("test-model"), usage(100, 20)),
+      LlmCallUsage(Some("test-model"), TokenUsage.Zero),
+      LlmCallUsage(Some("test-model"), usage(50, 10))
+    )
+  }
+
+  it should "invoke around stages in onion order for each stage kind" in {
+    val log = collection.mutable.Buffer.empty[String]
+    class Rec(name: String) extends AgentInterceptor[Identity] {
+      override def aroundIteration[A](ctx: IterationContext)(next: => Identity[A]): Identity[A] = {
+        log += s"$name:iter(${ctx.iterationInfo.iteration}):in"; val r = next; log += s"$name:iter(${ctx.iterationInfo.iteration}):out"; r
+      }
+      override def aroundLlmCall(ctx: LlmCallContext)(next: => Identity[AgentResponse]): Identity[AgentResponse] = {
+        log += s"$name:llm:in"; val r = next; log += s"$name:llm:out"; r
+      }
+      override def aroundToolCall(ctx: ToolCallContext)(next: => Identity[ToolCallRecord]): Identity[ToolCallRecord] = {
+        log += s"$name:tool(${ctx.toolCall.toolName}):in"; val r = next; log += s"$name:tool(${ctx.toolCall.toolName}):out"; r
+      }
+    }
+    val stub = new StubAgentBackend(
+      Seq(toolResponse("call_1", Some(usage(1, 1))), finalResponse("done", Some(usage(1, 1))))
+    )
+    build(stub, Seq(new Rec("a"), new Rec("b"))).run("Test")(backend).finalAnswer shouldBe "done"
+
+    log.toList shouldBe List(
+      "a:iter(1):in",
+      "b:iter(1):in",
+      "a:llm:in",
+      "b:llm:in",
+      "b:llm:out",
+      "a:llm:out",
+      "a:tool(dummy):in",
+      "b:tool(dummy):in",
+      "b:tool(dummy):out",
+      "a:tool(dummy):out",
+      "b:iter(1):out",
+      "a:iter(1):out",
+      "a:iter(2):in",
+      "b:iter(2):in",
+      "a:llm:in",
+      "b:llm:in",
+      "b:llm:out",
+      "a:llm:out",
+      "b:iter(2):out",
+      "a:iter(2):out"
+    )
+  }
+
+  it should "fail the run when an interceptor throws" in {
+    val boom = new AgentInterceptor[Identity] {
+      override def aroundLlmCall(ctx: LlmCallContext)(next: => Identity[AgentResponse]): Identity[AgentResponse] =
+        throw new IllegalStateException("interceptor failure")
+    }
+    val stub = new StubAgentBackend(Seq(finalResponse("done", None)))
+    an[IllegalStateException] should be thrownBy build(stub, Seq(boom)).run("Test")(backend)
+  }
+
+  it should "still run legacy hooks, innermost relative to interceptors" in {
+    val log = collection.mutable.Buffer.empty[String]
+    val outer = new AgentInterceptor[Identity] {
+      override def aroundToolCall(ctx: ToolCallContext)(next: => Identity[ToolCallRecord]): Identity[ToolCallRecord] = {
+        log += "interceptor:in"; val r = next; log += "interceptor:out"; r
+      }
+    }
+    val stub = new StubAgentBackend(
+      Seq(toolResponse("call_1", None), finalResponse("done", None))
+    )
+    val agent = AgentBuilder[Identity, TestModel.type](_ => stub)(IdentityMonad)
+      .maxIterations(5)
+      .tools(dummyTool)
+      .interceptors(Seq(outer))
+      .hookBeforeToolCall { tc => log += s"hook:before:${tc.toolName}"; () }
+      .hookAfterToolCall { rec => log += s"hook:after:${rec.toolName}"; () }
+      .build
+
+    agent.run("Test")(backend).finalAnswer shouldBe "done"
+    log.toList shouldBe List("interceptor:in", "hook:before:dummy", "hook:after:dummy", "interceptor:out")
+  }
+}

--- a/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorLoopSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorLoopSpec.scala
@@ -10,6 +10,9 @@ import sttp.monad.IdentityMonad
 import sttp.shared.Identity
 import sttp.tapir.Schema
 
+import scala.annotation.nowarn
+
+@nowarn("cat=deprecation")
 class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
 
   case object TestModel extends AIModel with Capability.ToolCalling {

--- a/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorLoopSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorLoopSpec.scala
@@ -10,9 +10,6 @@ import sttp.monad.IdentityMonad
 import sttp.shared.Identity
 import sttp.tapir.Schema
 
-import scala.annotation.nowarn
-
-@nowarn("cat=deprecation")
 class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
 
   case object TestModel extends AIModel with Capability.ToolCalling {
@@ -23,6 +20,7 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
     private var callCount = 0
     var receivedHistories: Seq[ConversationHistory] = Seq.empty
     var receivedIncludeTools: Seq[Boolean] = Seq.empty
+    var receivedIterationInfos: Seq[IterationInfo] = Seq.empty
 
     override def tools: Seq[AgentTool[Identity, _]] = Seq.empty
     override def systemPrompt: Option[String] = None
@@ -35,6 +33,7 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
     ): Identity[AgentResponse] = {
       receivedHistories = receivedHistories :+ history
       receivedIncludeTools = receivedIncludeTools :+ includeTools
+      receivedIterationInfos = receivedIterationInfos :+ iterationInfo
       val response = if (callCount < responses.length) responses(callCount) else responses.last
       callCount += 1
       response
@@ -135,29 +134,20 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
     an[IllegalStateException] should be thrownBy build(stub, Seq(boom)).run("Test")(backend)
   }
 
-  it should "still run legacy hooks, innermost relative to interceptors" in {
-    val log = collection.mutable.Buffer.empty[String]
-    val outer = new AgentInterceptor[Identity] {
-      override def aroundToolCall(ctx: ToolCallContext)(next: => Identity[ToolCallRecord]): Identity[ToolCallRecord] = {
-        log += "interceptor:in"; val r = next; log += "interceptor:out"; r
-      }
+  it should "let an interceptor short-circuit the LLM call by not evaluating next" in {
+    val cached = finalResponse("cached answer", Some(usage(1, 1)))
+    val shortCircuit = new AgentInterceptor[Identity] {
+      override def aroundLlmCall(ctx: LlmCallContext)(next: => Identity[AgentResponse]): Identity[AgentResponse] = cached
     }
-    val stub = new StubAgentBackend(
-      Seq(toolResponse("call_1", None), finalResponse("done", None))
-    )
-    val agent = AgentBuilder[Identity, TestModel.type](_ => stub)(IdentityMonad)
-      .maxIterations(5)
-      .tools(dummyTool)
-      .interceptors(Seq(outer))
-      .hookBeforeToolCall { tc => log += s"hook:before:${tc.toolName}"; () }
-      .hookAfterToolCall { rec => log += s"hook:after:${rec.toolName}"; () }
-      .build
+    val stub = new StubAgentBackend(Seq(finalResponse("real answer", None)))
+    val result = build(stub, Seq(shortCircuit)).run("Test")(backend)
 
-    agent.run("Test")(backend).finalAnswer shouldBe "done"
-    log.toList shouldBe List("interceptor:in", "hook:before:dummy", "hook:after:dummy", "interceptor:out")
+    result.finalAnswer shouldBe "cached answer"
+    result.usage shouldBe usage(1, 1)
+    stub.receivedHistories shouldBe empty // the backend was never reached
   }
 
-  private def finishAfter(calls: Int, cause: FinishReason, instruction: String): AgentInterceptor[Identity] =
+  private def finishAfter(calls: Int, cause: FinishReason.ForcedStop, instruction: String): AgentInterceptor[Identity] =
     new AgentInterceptor[Identity] {
       override def decide(state: AgentRunState): LoopDecision =
         if (state.llmCalls.size >= calls) LoopDecision.FinishNow(cause, instruction) else LoopDecision.Continue
@@ -179,6 +169,10 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
     // The forced-final request withheld tools and contained the injected instruction:
     stub.receivedIncludeTools shouldBe Seq(true, false)
     stub.receivedHistories.last.entries should contain(ConversationEntry.UserPrompt("BUDGET EXHAUSTED - answer now"))
+    // No iteration marker on the forced-final request — it would contradict the injected instruction:
+    stub.receivedHistories.last.entries.collect { case m: ConversationEntry.IterationMarker => m } shouldBe empty
+    // The backend sees the forced final via IterationInfo, so modelForIteration can pick the stronger model:
+    stub.receivedIterationInfos.map(_.isLastIteration) shouldBe Seq(false, true)
     // Usage includes the forced-final call:
     result.usage shouldBe usage(150, 30)
   }
@@ -266,5 +260,59 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
     result.finishReason shouldBe FinishReason.BudgetExceeded
     result.finalAnswer shouldBe Right(Out(5)) // BudgetExceeded is parse-attempted, not rejected outright
     result.usage shouldBe usage(150, 30)
+  }
+
+  it should "wrap stages and accumulate usage under a lazy effect type (Future)" in {
+    import scala.concurrent.duration.DurationInt
+    import scala.concurrent.{Await, ExecutionContext, Future}
+    implicit val ec: ExecutionContext = ExecutionContext.global
+    implicit val futureMonad: sttp.monad.MonadError[Future] = new sttp.monad.FutureMonad()
+
+    class FutureStubBackend(responses: Seq[AgentResponse]) extends AgentBackend[Future] {
+      private var callCount = 0
+      override def tools: Seq[AgentTool[Future, _]] = Seq.empty
+      override def systemPrompt: Option[String] = None
+      override def sendRequest(
+          history: ConversationHistory,
+          backend: sttp.client4.Backend[Future],
+          includeTools: Boolean,
+          iterationInfo: IterationInfo
+      ): Future[AgentResponse] = {
+        val response = if (callCount < responses.length) responses(callCount) else responses.last
+        callCount += 1
+        Future.successful(response)
+      }
+    }
+
+    val log = collection.mutable.Buffer.empty[String]
+    val recording = new AgentInterceptor[Future] {
+      override def aroundLlmCall(ctx: LlmCallContext)(next: => Future[AgentResponse]): Future[AgentResponse] = {
+        log += "llm:in"
+        next.map { r => log += "llm:out"; r }
+      }
+      override def aroundToolCall(ctx: ToolCallContext)(next: => Future[ToolCallRecord]): Future[ToolCallRecord] = {
+        log += "tool:in"
+        next.map { r => log += "tool:out"; r }
+      }
+    }
+
+    val futureTool = AgentTool.fromFunctionF[Future, DummyInput]("dummy", "Dummy tool")(_ => Future.successful("dummy result"))
+    val stub = new FutureStubBackend(
+      Seq(
+        toolResponse("call_1", Some(usage(100, 20))),
+        finalResponse("done", Some(usage(50, 10)))
+      )
+    )
+    val agent = AgentBuilder[Future, TestModel.type](_ => stub)
+      .maxIterations(5)
+      .tools(futureTool)
+      .interceptors(Seq(recording))
+      .build
+
+    val result = Await.result(agent.run("Test")(sttp.client4.testing.BackendStub[Future](futureMonad)), 10.seconds)
+
+    result.finalAnswer shouldBe "done"
+    result.usage shouldBe usage(150, 30)
+    log.toList shouldBe List("llm:in", "llm:out", "tool:in", "tool:out", "llm:in", "llm:out")
   }
 }

--- a/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
@@ -621,17 +621,6 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     budgetResult.finishReason shouldBe FinishReason.BudgetExceeded
   }
 
-  "runAs" should "attempt to parse a budget-forced final answer like a max-iterations one" in {
-    case class Out(x: Int)
-    implicit val outCodec: Codec[Out] = deriveCodec
-
-    // Directly exercise the runAs classification: build a result with BudgetExceeded and valid JSON.
-    // (The loop-level budget path is covered in Task 9; here we only pin the FinishReason classification.)
-    val agent = agentBuilder(AgentResponse("""{"x": 5}""", Seq.empty, StopReason.EndTurn)).build
-    val ok = agent.runAs[Out]("Test")(backend)
-    ok.finalAnswer shouldBe Right(Out(5))
-  }
-
   "AgentBuilder" should "append with interceptor() and replace with interceptors()" in {
     val a = AgentInterceptor.noop[Identity]
     val b = AgentInterceptor.noop[Identity]

--- a/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
@@ -631,4 +631,16 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     val ok = agent.runAs[Out]("Test")(backend)
     ok.finalAnswer shouldBe Right(Out(5))
   }
+
+  "AgentBuilder" should "append with interceptor() and replace with interceptors()" in {
+    val a = AgentInterceptor.noop[Identity]
+    val b = AgentInterceptor.noop[Identity]
+    val c = AgentInterceptor.noop[Identity]
+
+    val appended = agentBuilder(AgentResponse("done", Seq.empty, StopReason.EndTurn)).interceptor(a).interceptor(b)
+    appended.config.interceptors shouldBe Seq(a, b)
+
+    val replaced = appended.interceptors(Seq(c))
+    replaced.config.interceptors shouldBe Seq(c)
+  }
 }

--- a/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
@@ -538,8 +538,16 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     result.iterations shouldBe 1
   }
 
-  "Agent with hooks" should "invoke afterToolCall once per tool call" in {
+  "Agent with a tool-call interceptor" should "see every tool call, including failing and unknown ones" in {
     val results = scala.collection.mutable.ListBuffer.empty[Any]
+    val recording = new AgentInterceptor[Identity] {
+      override def aroundToolCall(ctx: ToolCallContext)(next: => Identity[ToolCallRecord]): Identity[ToolCallRecord] = {
+        results += ctx.toolCall
+        val record = next
+        results += record
+        record
+      }
+    }
 
     runLoop(
       agentBuilder(
@@ -555,12 +563,7 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
         AgentResponse("Done", Seq.empty, StopReason.EndTurn)
       ).tools(calculatorTool)
         .exceptionHandler(ExceptionHandler.sendAllToLLM)
-        .hookBeforeToolCall { (c: ToolCall) =>
-          results += c; ()
-        }
-        .hookAfterToolCall { (r: ToolCallRecord) =>
-          results += r; ()
-        }
+        .addInterceptor(recording)
     )
 
     results should contain inOrderOnly (
@@ -580,24 +583,17 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
   }
 
   "AgentBuilder" should "accumulate configuration into the built config" in {
-    val before: ToolCall => Identity[Unit] = _ => ()
-    val after: ToolCallRecord => Identity[Unit] = _ => ()
-
     val config = agentBuilder()
       .maxIterations(7)
       .systemPrompt("custom")
       .tools(calculatorTool)
       .exceptionHandler(ExceptionHandler.sendAllToLLM)
-      .hookBeforeToolCall(before)
-      .hookAfterToolCall(after)
       .config
 
     config.maxIterations shouldBe 7
     config.systemPrompt.value shouldBe "custom"
     config.userTools should contain only calculatorTool
     config.exceptionHandler shouldBe ExceptionHandler.sendAllToLLM
-    config.beforeToolCall.value shouldBe before
-    config.afterToolCall.value shouldBe after
   }
 
   it should "derive the default system prompt from the final maxIterations" in {
@@ -621,12 +617,12 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     budgetResult.finishReason shouldBe FinishReason.BudgetExceeded
   }
 
-  "AgentBuilder" should "append with interceptor() and replace with interceptors()" in {
+  "AgentBuilder" should "append with addInterceptor() and replace with interceptors()" in {
     val a = AgentInterceptor.noop[Identity]
     val b = AgentInterceptor.noop[Identity]
     val c = AgentInterceptor.noop[Identity]
 
-    val appended = agentBuilder(AgentResponse("done", Seq.empty, StopReason.EndTurn)).interceptor(a).interceptor(b)
+    val appended = agentBuilder(AgentResponse("done", Seq.empty, StopReason.EndTurn)).addInterceptor(a).addInterceptor(b)
     appended.config.interceptors shouldBe Seq(a, b)
 
     val replaced = appended.interceptors(Seq(c))

--- a/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
@@ -611,4 +611,24 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
 
     responseSchema.value.description shouldBe Some("the weather report")
   }
+
+  "AgentResult usage" should "default to Zero for backward-compatible construction" in {
+    val result = AgentResult("answer", 1, Seq.empty, FinishReason.NaturalStop)
+    result.usage shouldBe TokenUsage.Zero
+    result.llmCalls shouldBe empty
+
+    val budgetResult = AgentResult("partial", 2, Seq.empty, FinishReason.BudgetExceeded)
+    budgetResult.finishReason shouldBe FinishReason.BudgetExceeded
+  }
+
+  "runAs" should "attempt to parse a budget-forced final answer like a max-iterations one" in {
+    case class Out(x: Int)
+    implicit val outCodec: Codec[Out] = deriveCodec
+
+    // Directly exercise the runAs classification: build a result with BudgetExceeded and valid JSON.
+    // (The loop-level budget path is covered in Task 9; here we only pin the FinishReason classification.)
+    val agent = agentBuilder(AgentResponse("""{"x": 5}""", Seq.empty, StopReason.EndTurn)).build
+    val ok = agent.runAs[Out]("Test")(backend)
+    ok.finalAnswer shouldBe Right(Out(5))
+  }
 }

--- a/core/src/test/scala/sttp/ai/core/agent/TokenUsageSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/TokenUsageSpec.scala
@@ -1,0 +1,32 @@
+package sttp.ai.core.agent
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class TokenUsageSpec extends AnyFlatSpec with Matchers {
+
+  "Tokens" should "add and compare" in {
+    Tokens(3L) + Tokens(4L) shouldBe Tokens(7L)
+    Tokens(0L) shouldBe Tokens.Zero
+    (Tokens(5L) >= Tokens(5L)) shouldBe true
+    (Tokens(4L) >= Tokens(5L)) shouldBe false
+    (Tokens(4L) < Tokens(5L)) shouldBe true
+    (Tokens(5L) <= Tokens(5L)) shouldBe true
+    (Tokens(6L) > Tokens(5L)) shouldBe true
+  }
+
+  "TokenUsage" should "accumulate field-wise and derive totalTokens" in {
+    val a = TokenUsage(Tokens(10L), Tokens(5L), Tokens(2L), Tokens(1L))
+    val b = TokenUsage(Tokens(20L), Tokens(7L), Tokens(3L), Tokens(4L))
+    val sum = a + b
+    sum shouldBe TokenUsage(Tokens(30L), Tokens(12L), Tokens(5L), Tokens(5L))
+    sum.totalTokens shouldBe Tokens(42L)
+  }
+
+  it should "treat Zero as identity" in {
+    val a = TokenUsage(Tokens(10L), Tokens(5L), Tokens(2L), Tokens(1L))
+    a + TokenUsage.Zero shouldBe a
+    TokenUsage.Zero + a shouldBe a
+    TokenUsage.Zero.totalTokens shouldBe Tokens.Zero
+  }
+}

--- a/core/src/test/scala/sttp/ai/core/agent/TokenUsageSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/TokenUsageSpec.scala
@@ -16,15 +16,15 @@ class TokenUsageSpec extends AnyFlatSpec with Matchers {
   }
 
   "TokenUsage" should "accumulate field-wise and derive totalTokens" in {
-    val a = TokenUsage(Tokens(10L), Tokens(5L), Tokens(2L), Tokens(1L))
-    val b = TokenUsage(Tokens(20L), Tokens(7L), Tokens(3L), Tokens(4L))
+    val a = TokenUsage(Tokens(10L), Tokens(5L), Tokens(2L), Tokens(1L), Tokens(3L))
+    val b = TokenUsage(Tokens(20L), Tokens(7L), Tokens(3L), Tokens(4L), Tokens(2L))
     val sum = a + b
-    sum shouldBe TokenUsage(Tokens(30L), Tokens(12L), Tokens(5L), Tokens(5L))
+    sum shouldBe TokenUsage(Tokens(30L), Tokens(12L), Tokens(5L), Tokens(5L), Tokens(5L))
     sum.totalTokens shouldBe Tokens(42L)
   }
 
   it should "treat Zero as identity" in {
-    val a = TokenUsage(Tokens(10L), Tokens(5L), Tokens(2L), Tokens(1L))
+    val a = TokenUsage(Tokens(10L), Tokens(5L), Tokens(2L), Tokens(1L), Tokens(3L))
     a + TokenUsage.Zero shouldBe a
     TokenUsage.Zero + a shouldBe a
     TokenUsage.Zero.totalTokens shouldBe Tokens.Zero

--- a/core/src/test/scala/sttp/ai/core/agent/integration/AgentIntegrationSpecBase.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/integration/AgentIntegrationSpecBase.scala
@@ -110,6 +110,8 @@ abstract class AgentIntegrationSpecBase extends AnyFlatSpec with Matchers {
     assertToolCalled(result, "calculator", minTimes = 3)
     assertContainsAny(result.finalAnswer, "130", "one hundred thirty", "hundred and thirty")
     result.finishReason shouldBe FinishReason.NaturalStop
+    result.usage.totalTokens.value should be > 0L
+    result.llmCalls should not be empty
     ()
   }
 

--- a/core/src/test/scala/sttp/ai/core/agent/interceptor/BudgetInterceptorSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/interceptor/BudgetInterceptorSpec.scala
@@ -1,0 +1,67 @@
+package sttp.ai.core.agent.interceptor
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.core.agent._
+import sttp.shared.Identity
+
+class BudgetInterceptorSpec extends AnyFlatSpec with Matchers {
+
+  private def usage(in: Long, out: Long, cached: Long = 0L): TokenUsage =
+    TokenUsage(Tokens(in), Tokens(out), Tokens(cached), Tokens.Zero)
+
+  private def state(calls: LlmCallUsage*): AgentRunState = {
+    val total = calls.map(_.usage).foldLeft(TokenUsage.Zero)(_ + _)
+    AgentRunState(iterationsCompleted = calls.size, maxIterations = 10, usage = total, llmCalls = calls)
+  }
+
+  "BudgetInterceptor token budget" should "continue below the limit and finish at or above it" in {
+    val budget = new BudgetInterceptor[Identity](maxTotalTokens = Some(Tokens(200L)))
+
+    budget.decide(state(LlmCallUsage(Some("m"), usage(100, 50)))) shouldBe LoopDecision.Continue
+    budget.decide(state(LlmCallUsage(Some("m"), usage(150, 50)))) shouldBe
+      LoopDecision.FinishNow(FinishReason.BudgetExceeded, BudgetInterceptor.defaultInstruction)
+  }
+
+  it should "use a custom instruction" in {
+    val budget = new BudgetInterceptor[Identity](maxTotalTokens = Some(Tokens(1L)), instruction = "STOP NOW")
+    budget.decide(state(LlmCallUsage(Some("m"), usage(1, 1)))) shouldBe
+      LoopDecision.FinishNow(FinishReason.BudgetExceeded, "STOP NOW")
+  }
+
+  "PriceTable" should "price uncached input, cached input, and output per million tokens" in {
+    val table = PriceTable(
+      Map("m" -> ModelPrice(inputPerMTok = BigDecimal(2), outputPerMTok = BigDecimal(10), cachedInputPerMTok = Some(BigDecimal("0.5"))))
+    )
+    // 1M input of which 400k cached, 200k output:
+    // uncached 600k * 2/M = 1.2, cached 400k * 0.5/M = 0.2, output 200k * 10/M = 2.0 => 3.4
+    val cost = table.costOf(Seq(LlmCallUsage(Some("m"), usage(1000000L, 200000L, cached = 400000L))))
+    cost shouldBe Cost(BigDecimal("3.4"))
+  }
+
+  it should "fall back to the input rate for cached tokens when no cached rate is set" in {
+    val table = PriceTable(Map("m" -> ModelPrice(inputPerMTok = BigDecimal(2), outputPerMTok = BigDecimal(10))))
+    val cost = table.costOf(Seq(LlmCallUsage(Some("m"), usage(1000000L, 0L, cached = 400000L))))
+    cost shouldBe Cost(BigDecimal(2)) // whole input priced at 2/M
+  }
+
+  it should "contribute zero for calls with unknown or absent model ids" in {
+    val table = PriceTable(Map("known" -> ModelPrice(BigDecimal(2), BigDecimal(10))))
+    table.costOf(Seq(LlmCallUsage(Some("unknown"), usage(1000000L, 1000000L)))) shouldBe Cost(BigDecimal(0))
+    table.costOf(Seq(LlmCallUsage(None, usage(1000000L, 1000000L)))) shouldBe Cost(BigDecimal(0))
+  }
+
+  "BudgetInterceptor cost budget" should "finish when the priced calls reach the limit" in {
+    val table = PriceTable(Map("m" -> ModelPrice(BigDecimal(2), BigDecimal(10))))
+    val budget = new BudgetInterceptor[Identity](maxCost = Some(Cost(BigDecimal(3))), priceTable = Some(table))
+
+    budget.decide(state(LlmCallUsage(Some("m"), usage(500000L, 100000L)))) shouldBe LoopDecision.Continue // 1 + 1 = 2
+    budget.decide(state(LlmCallUsage(Some("m"), usage(500000L, 300000L)))) shouldBe // 1 + 3 = 4 >= 3
+      LoopDecision.FinishNow(FinishReason.BudgetExceeded, BudgetInterceptor.defaultInstruction)
+  }
+
+  it should "skip the cost check when no price table is configured" in {
+    val budget = new BudgetInterceptor[Identity](maxCost = Some(Cost(BigDecimal(0))))
+    budget.decide(state(LlmCallUsage(Some("m"), usage(1000000L, 1000000L)))) shouldBe LoopDecision.Continue
+  }
+}

--- a/core/src/test/scala/sttp/ai/core/agent/interceptor/BudgetInterceptorSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/interceptor/BudgetInterceptorSpec.scala
@@ -45,6 +45,23 @@ class BudgetInterceptorSpec extends AnyFlatSpec with Matchers {
     cost shouldBe Cost(BigDecimal(2)) // whole input priced at 2/M
   }
 
+  it should "price each call against its own model's rates when calls span multiple models" in {
+    val table = PriceTable(
+      Map(
+        "a" -> ModelPrice(inputPerMTok = BigDecimal(2), outputPerMTok = BigDecimal(10)),
+        "b" -> ModelPrice(inputPerMTok = BigDecimal(4), outputPerMTok = BigDecimal(20))
+      )
+    )
+    val cost = table.costOf(
+      Seq(
+        LlmCallUsage(Some("a"), usage(1000000L, 100000L)), // 2 + 1 = 3
+        LlmCallUsage(Some("b"), usage(500000L, 100000L)), // 2 + 2 = 4
+        LlmCallUsage(Some("unknown"), usage(1000000L, 1000000L)) // 0
+      )
+    )
+    cost shouldBe Cost(BigDecimal(7))
+  }
+
   it should "contribute zero for calls with unknown or absent model ids" in {
     val table = PriceTable(Map("known" -> ModelPrice(BigDecimal(2), BigDecimal(10))))
     table.costOf(Seq(LlmCallUsage(Some("unknown"), usage(1000000L, 1000000L)))) shouldBe Cost(BigDecimal(0))

--- a/core/src/test/scala/sttp/ai/core/agent/interceptor/BudgetInterceptorSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/interceptor/BudgetInterceptorSpec.scala
@@ -80,4 +80,30 @@ class BudgetInterceptorSpec extends AnyFlatSpec with Matchers {
   it should "reject maxCost without a priceTable at construction" in {
     an[IllegalArgumentException] should be thrownBy new BudgetInterceptor[Identity](maxCost = Some(Cost(BigDecimal(0))))
   }
+
+  it should "reject a configuration with no limit at all at construction" in {
+    an[IllegalArgumentException] should be thrownBy new BudgetInterceptor[Identity]()
+  }
+
+  "PriceTable cache-write pricing" should "price cache-write tokens at the dedicated rate when set" in {
+    val table = PriceTable(
+      Map("m" -> ModelPrice(inputPerMTok = BigDecimal(2), outputPerMTok = BigDecimal(10), cacheWriteInputPerMTok = Some(BigDecimal(5))))
+    )
+    // 1M input of which 400k cache-write, no output:
+    // plain 600k * 2/M = 1.2, cache-write 400k * 5/M = 2.0 => 3.2
+    val call = LlmCallUsage(
+      Some("m"),
+      TokenUsage(Tokens(1000000L), Tokens.Zero, Tokens.Zero, Tokens.Zero, cacheWriteInputTokens = Tokens(400000L))
+    )
+    table.costOf(Seq(call)) shouldBe Cost(BigDecimal("3.2"))
+  }
+
+  it should "fall back to the input rate for cache-write tokens when no dedicated rate is set" in {
+    val table = PriceTable(Map("m" -> ModelPrice(inputPerMTok = BigDecimal(2), outputPerMTok = BigDecimal(10))))
+    val call = LlmCallUsage(
+      Some("m"),
+      TokenUsage(Tokens(1000000L), Tokens.Zero, Tokens.Zero, Tokens.Zero, cacheWriteInputTokens = Tokens(400000L))
+    )
+    table.costOf(Seq(call)) shouldBe Cost(BigDecimal(2)) // whole input priced at 2/M
+  }
 }

--- a/core/src/test/scala/sttp/ai/core/agent/interceptor/BudgetInterceptorSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/interceptor/BudgetInterceptorSpec.scala
@@ -77,8 +77,7 @@ class BudgetInterceptorSpec extends AnyFlatSpec with Matchers {
       LoopDecision.FinishNow(FinishReason.BudgetExceeded, BudgetInterceptor.defaultInstruction)
   }
 
-  it should "skip the cost check when no price table is configured" in {
-    val budget = new BudgetInterceptor[Identity](maxCost = Some(Cost(BigDecimal(0))))
-    budget.decide(state(LlmCallUsage(Some("m"), usage(1000000L, 1000000L)))) shouldBe LoopDecision.Continue
+  it should "reject maxCost without a priceTable at construction" in {
+    an[IllegalArgumentException] should be thrownBy new BudgetInterceptor[Identity](maxCost = Some(Cost(BigDecimal(0))))
   }
 }

--- a/core/src/test/scala/sttp/ai/core/agent/interceptor/LoggingInterceptorSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/interceptor/LoggingInterceptorSpec.scala
@@ -49,4 +49,30 @@ class LoggingInterceptorSpec extends AnyFlatSpec with Matchers {
     log(0)._2 should include("calculator")
     log(1)._2 should include("calculator")
   }
+
+  it should "log a failed tool call at Warn and propagate the error" in {
+    val log = collection.mutable.Buffer.empty[(LogLevel, String)]
+    val ctx = ToolCallContext(ToolCall("id1", "calculator", "{}"), 1)
+
+    an[IllegalStateException] should be thrownBy {
+      newLogger(log).aroundToolCall(ctx)(throw new IllegalStateException("tool blew up")): Unit
+    }
+
+    log.map(_._1).toList shouldBe List(LogLevel.Info, LogLevel.Warn)
+    log(1)._2 should include("calculator")
+    log(1)._2 should include("tool blew up")
+  }
+
+  it should "log a failed LLM call at Warn and propagate the error" in {
+    val log = collection.mutable.Buffer.empty[(LogLevel, String)]
+    val ctx = LlmCallContext(ConversationHistory.empty, includeTools = true, IterationInfo(3, 5))
+
+    an[IllegalStateException] should be thrownBy {
+      newLogger(log).aroundLlmCall(ctx)(throw new IllegalStateException("api down")): Unit
+    }
+
+    log.map(_._1).toList shouldBe List(LogLevel.Warn)
+    log(0)._2 should include("iteration 3")
+    log(0)._2 should include("api down")
+  }
 }

--- a/core/src/test/scala/sttp/ai/core/agent/interceptor/LoggingInterceptorSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/interceptor/LoggingInterceptorSpec.scala
@@ -1,0 +1,52 @@
+package sttp.ai.core.agent.interceptor
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.core.agent._
+import sttp.shared.Identity
+
+class LoggingInterceptorSpec extends AnyFlatSpec with Matchers {
+
+  private def newLogger(log: collection.mutable.Buffer[(LogLevel, String)]): LoggingInterceptor[Identity] =
+    new LoggingInterceptor[Identity]((level, msg) => { log += ((level, msg)); () })(sttp.monad.IdentityMonad)
+
+  "LoggingInterceptor" should "log iteration start and end at Debug" in {
+    val log = collection.mutable.Buffer.empty[(LogLevel, String)]
+    newLogger(log).aroundIteration(IterationContext(IterationInfo(2, 5)))(42) shouldBe 42
+
+    log.map(_._1).toList shouldBe List(LogLevel.Debug, LogLevel.Debug)
+    log(0)._2 should include("2/5")
+    log(0)._2 should include("started")
+    log(1)._2 should include("finished")
+  }
+
+  it should "log LLM call completion with model and usage at Info" in {
+    val log = collection.mutable.Buffer.empty[(LogLevel, String)]
+    val response = AgentResponse(
+      "hi",
+      Seq.empty,
+      StopReason.EndTurn,
+      usage = Some(TokenUsage(Tokens(100L), Tokens(30L), Tokens.Zero, Tokens.Zero)),
+      model = Some("test-model")
+    )
+    val ctx = LlmCallContext(ConversationHistory.empty, includeTools = true, IterationInfo(1, 5))
+    newLogger(log).aroundLlmCall(ctx)(response) shouldBe response
+
+    log should have size 1
+    log(0)._1 shouldBe LogLevel.Info
+    log(0)._2 should include("test-model")
+    log(0)._2 should include("100")
+    log(0)._2 should include("30")
+  }
+
+  it should "log tool call start and finish at Info" in {
+    val log = collection.mutable.Buffer.empty[(LogLevel, String)]
+    val record = ToolCallRecord("id1", "calculator", "{}", "42", 1)
+    val ctx = ToolCallContext(ToolCall("id1", "calculator", "{}"), 1)
+    newLogger(log).aroundToolCall(ctx)(record) shouldBe record
+
+    log.map(_._1).toList shouldBe List(LogLevel.Info, LogLevel.Info)
+    log(0)._2 should include("calculator")
+    log(1)._2 should include("calculator")
+  }
+}

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -117,7 +117,13 @@ val pick: IterationInfo => ChatCompletionModel & Capability.ToolCalling =
 Note: `isLastIteration` flags only the *forced* last iteration (`maxIterations` reached). The loop cannot know in
 advance on which iteration the model will answer naturally.
 
-## Hooks
+## Hooks (deprecated)
+
+```{warning}
+`hookBeforeToolCall` and `hookAfterToolCall` are deprecated since 0.8.0 and will be removed in the following
+release. Use [interceptors](interceptors.md) instead — an `AgentInterceptor` overriding `aroundToolCall` replaces
+both hooks and composes with other middleware. See the [migration section](interceptors.md#migrating-from-the-tool-call-hooks).
+```
 
 The loop can invoke optional effectful hooks around each tool call. Both run inside the agent loop, so an error in either hook interrupts the run.
 

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -114,46 +114,9 @@ val pick: IterationInfo => ChatCompletionModel & Capability.ToolCalling =
   info => if info.isLastIteration then ChatCompletionModel.GPT5 else ChatCompletionModel.GPT4oMini
 ```
 
-Note: `isLastIteration` flags only the *forced* last iteration (`maxIterations` reached). The loop cannot know in
+Note: `isLastIteration` is true on the *forced* last iteration (`maxIterations` reached) and on an
+interceptor-forced final iteration (e.g. a [budget](interceptors.md) breach). The loop cannot know in
 advance on which iteration the model will answer naturally.
-
-## Hooks (deprecated)
-
-```{warning}
-`hookBeforeToolCall` and `hookAfterToolCall` are deprecated since 0.8.0 and will be removed in the following
-release. Use [interceptors](interceptors.md) instead — an `AgentInterceptor` overriding `aroundToolCall` replaces
-both hooks and composes with other middleware. See the [migration section](interceptors.md#migrating-from-the-tool-call-hooks).
-```
-
-The loop can invoke optional effectful hooks around each tool call. Both run inside the agent loop, so an error in either hook interrupts the run.
-
-### beforeToolCall
-
-If defined, the loop invokes `beforeToolCall` once before each tool call is executed, passing the pending `ToolCall`.
-
-```scala
-val agent = OpenAIAgent.builder[IO](OpenAI.fromEnv, "gpt-4o-mini")
-  .maxIterations(10)
-  .tools(tool1, tool2)
-  .hookBeforeToolCall(call => IO.println(s"calling ${call.toolName}(${call.input})"))
-  .build
-```
-
-`ToolCall` carries `id`, `toolName`, and `input`.
-
-### afterToolCall
-
-If defined, the loop invokes `afterToolCall` once after each tool call, passing the `ToolCallRecord`.
-
-```scala
-val agent = OpenAIAgent.builder[IO](OpenAI.fromEnv, "gpt-4o-mini")
-  .maxIterations(10)
-  .tools(tool1, tool2)
-  .hookAfterToolCall(call => IO.println(s"[step ${call.iteration}] ${call.toolName} -> ${call.output}"))
-  .build
-```
-
-`ToolCallRecord` carries `id`, `toolName`, `input`, `output` (the successful output, or the error message fed back to the LLM on failure), and `iteration`.
 
 ## Exception Handling
 

--- a/docs/agents/interceptors.md
+++ b/docs/agents/interceptors.md
@@ -22,10 +22,14 @@ val timing = new AgentInterceptor[Identity]:
 
 Rules of the trade:
 
-- `next` is by-name — don't force it before you mean to run the stage.
+- `next` is by-name — don't force it before you mean to run the stage, and call it at most once. Skipping it
+  short-circuits the stage.
 - Exceptions thrown by interceptor code fail the whole run; they are never swallowed.
 - `decide` is pure: it judges the accumulated `AgentRunState` before each iteration and can return
-  `LoopDecision.FinishNow(cause, instruction)` to force a graceful final answer.
+  `LoopDecision.FinishNow(cause, instruction)` to force a graceful final answer. The cause is a
+  `FinishReason.ForcedStop` — `BudgetExceeded` or `Custom("your reason")` — so interceptors cannot misreport
+  loop-owned reasons like `NaturalStop`. On a forced-final iteration the backend's `IterationInfo.isLastIteration`
+  is true, so per-iteration model selection picks the same (usually stronger) model as for a regular last iteration.
 
 ## Composition and ordering
 
@@ -40,10 +44,12 @@ import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionMo
 import sttp.monad.IdentityMonad
 import sttp.shared.Identity
 
+given sttp.monad.MonadError[Identity] = IdentityMonad
+
 val agent = OpenAIAgent
   .synchronous("api-key", ChatCompletionModel.GPT4oMini)
-  .interceptor(new LoggingInterceptor[Identity]((level, msg) => println(s"[$level] $msg"))(IdentityMonad))
-  .interceptor(new BudgetInterceptor[Identity](maxTotalTokens = Some(Tokens(200_000L))))
+  .addInterceptor(LoggingInterceptor[Identity]((level, msg) => println(s"[$level] $msg")))
+  .addInterceptor(BudgetInterceptor[Identity](maxTotalTokens = Some(Tokens(200_000L))))
   .build
 ```
 
@@ -61,8 +67,13 @@ def report(result: AgentResult[String]): Unit =
   }
 ```
 
-`AgentResult.finishReason` reports why the loop stopped: `NaturalStop`, `MaxIterations`, `TokenLimit`,
-`BudgetExceeded`, or `Error`.
+`AgentResult.finishReason` reports why the loop stopped: `NaturalStop`, `MaxIterations`, `TokenLimit`, `Error`, or
+an interceptor-forced stop (`BudgetExceeded`, or `Custom(reason)` from your own steering interceptor).
+
+Provider notes: cached input tokens are reported in `cachedInputTokens` (reads) and `cacheWriteInputTokens`
+(writes, e.g. Claude's `cache_creation_input_tokens`) — both are subsets of `inputTokens`. Gemini reports thought
+tokens separately from output; the mapping folds them into `outputTokens` (with `reasoningTokens` as the subset),
+so `totalTokens` matches the provider-reported total.
 
 ## Budgets
 
@@ -78,16 +89,19 @@ val prices = PriceTable(Map(
   "gpt-4o-mini" -> ModelPrice(inputPerMTok = BigDecimal("0.15"), outputPerMTok = BigDecimal("0.60"))
 ))
 
-val budget = new BudgetInterceptor[Identity](
+val budget = BudgetInterceptor[Identity](
   maxTotalTokens = Some(Tokens(200_000L)),
   maxCost = Some(Cost(BigDecimal("2.50"))),
   priceTable = Some(prices)
 )
 ```
 
-The library ships no prices — supply your own table, keyed by the provider-reported model id. **Calls whose model id
-is missing from the table contribute zero to the cost check**; prefer `maxTotalTokens` (which needs no table) when
-not every model in play is priced.
+The library ships no prices — supply your own table, keyed by the provider-reported model id. `ModelPrice` takes
+optional dedicated rates for cache reads (`cachedInputPerMTok`) and cache writes (`cacheWriteInputPerMTok`, which
+some providers bill at a premium); both default to the plain input rate. **Calls whose model id is missing from the
+table contribute zero to the cost check**; prefer `maxTotalTokens` (which needs no table) when not every model in
+play is priced. A `BudgetInterceptor` with no limit at all, or `maxCost` without a `priceTable`, fails fast at
+construction.
 
 Budgets are soft by one LLM call: a breach is detected at the next iteration boundary, and the forced final answer
 itself is one more (tool-free) LLM call whose usage also counts. Size limits with that headroom in mind — a
@@ -147,8 +161,8 @@ class TracingInterceptor[F[_]: Tracer] extends AgentInterceptor[F]:
 
 ## Migrating from the tool-call hooks
 
-`hookBeforeToolCall` / `hookAfterToolCall` are deprecated (since 0.8.0) and will be removed in the following release.
-They keep working for now and run innermost (closest to the tool call). The equivalent interceptor:
+The 0.5.x–0.7.x `hookBeforeToolCall` / `hookAfterToolCall` builder methods (and the corresponding `AgentConfig`
+fields) were removed in 0.8.0. The equivalent interceptor:
 
 ```scala mdoc:compile-only
 import sttp.ai.core.agent.*

--- a/docs/agents/interceptors.md
+++ b/docs/agents/interceptors.md
@@ -1,0 +1,151 @@
+# Interceptors
+
+Interceptors are composable middleware for the agent loop: they wrap iterations, LLM calls, and tool executions
+(onion-style, like sttp backend wrappers), observe provider-reported token usage, and can end the loop gracefully
+when a budget is exhausted.
+
+## Writing an interceptor
+
+Extend `AgentInterceptor[F]` and override only the stages you need. All methods default to pass-through.
+
+```scala mdoc:compile-only
+import sttp.ai.core.agent.*
+import sttp.shared.Identity
+
+val timing = new AgentInterceptor[Identity]:
+  override def aroundToolCall(ctx: ToolCallContext)(next: => Identity[ToolCallRecord]): Identity[ToolCallRecord] =
+    val start = System.nanoTime()
+    val record = next
+    println(s"${ctx.toolCall.toolName} took ${(System.nanoTime() - start) / 1000000} ms")
+    record
+```
+
+Rules of the trade:
+
+- `next` is by-name — don't force it before you mean to run the stage.
+- Exceptions thrown by interceptor code fail the whole run; they are never swallowed.
+- `decide` is pure: it judges the accumulated `AgentRunState` before each iteration and can return
+  `LoopDecision.FinishNow(cause, instruction)` to force a graceful final answer.
+
+## Composition and ordering
+
+Add interceptors on the builder. The first added is outermost for `around*` stages; for `decide`, interceptors are
+consulted in order and the first `FinishNow` wins:
+
+```scala mdoc:compile-only
+import sttp.ai.core.agent.*
+import sttp.ai.core.agent.interceptor.*
+import sttp.ai.openai.agent.OpenAIAgent
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
+import sttp.monad.IdentityMonad
+import sttp.shared.Identity
+
+val agent = OpenAIAgent
+  .synchronous("api-key", ChatCompletionModel.GPT4oMini)
+  .interceptor(new LoggingInterceptor[Identity]((level, msg) => println(s"[$level] $msg"))(IdentityMonad))
+  .interceptor(new BudgetInterceptor[Identity](maxTotalTokens = Some(Tokens(200_000L))))
+  .build
+```
+
+## Usage accounting
+
+Every LLM call's provider-reported usage lands on the response and accumulates into the result:
+
+```scala mdoc:compile-only
+import sttp.ai.core.agent.*
+
+def report(result: AgentResult[String]): Unit =
+  println(s"total tokens: ${result.usage.totalTokens.value}")
+  result.llmCalls.foreach { call =>
+    println(s"${call.model.getOrElse("?")}: in=${call.usage.inputTokens.value} out=${call.usage.outputTokens.value}")
+  }
+```
+
+`AgentResult.finishReason` reports why the loop stopped: `NaturalStop`, `MaxIterations`, `TokenLimit`,
+`BudgetExceeded`, or `Error`.
+
+## Budgets
+
+`BudgetInterceptor` ends the loop gracefully — it injects a final-answer instruction and withholds tools, mirroring
+the last-iteration behavior — instead of failing:
+
+```scala mdoc:compile-only
+import sttp.ai.core.agent.*
+import sttp.ai.core.agent.interceptor.*
+import sttp.shared.Identity
+
+val prices = PriceTable(Map(
+  "gpt-4o-mini" -> ModelPrice(inputPerMTok = BigDecimal("0.15"), outputPerMTok = BigDecimal("0.60"))
+))
+
+val budget = new BudgetInterceptor[Identity](
+  maxTotalTokens = Some(Tokens(200_000L)),
+  maxCost = Some(Cost(BigDecimal("2.50"))),
+  priceTable = Some(prices)
+)
+```
+
+The library ships no prices — supply your own table, keyed by the provider-reported model id. **Calls whose model id
+is missing from the table contribute zero to the cost check**; prefer `maxTotalTokens` (which needs no table) when
+not every model in play is priced.
+
+## Bridging the logging sink
+
+`LoggingInterceptor` takes a sink `(LogLevel, String) => F[Unit]`, so core needs no logging dependency. It requires
+an implicit `MonadError[F]` in scope (for `Identity`, `sttp.monad.IdentityMonad`).
+
+slf4j via log4cats:
+
+```scala
+import cats.effect.IO
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import sttp.ai.core.agent.interceptor.{LoggingInterceptor, LogLevel}
+
+val logger = Slf4jLogger.getLogger[IO]
+val logging = new LoggingInterceptor[IO]({
+  case (LogLevel.Debug, msg) => logger.debug(msg)
+  case (LogLevel.Info, msg)  => logger.info(msg)
+  case (LogLevel.Warn, msg)  => logger.warn(msg)
+})
+```
+
+ZIO logging:
+
+```scala
+import sttp.ai.core.agent.interceptor.{LoggingInterceptor, LogLevel}
+import zio.*
+
+val logging = new LoggingInterceptor[Task]({
+  case (LogLevel.Debug, msg) => ZIO.logDebug(msg)
+  case (LogLevel.Info, msg)  => ZIO.logInfo(msg)
+  case (LogLevel.Warn, msg)  => ZIO.logWarning(msg)
+})
+```
+
+For tracing (otel4s, ZIO Telemetry), wrap stages in spans with a custom interceptor instead of the logging sink:
+
+```scala
+import org.typelevel.otel4s.trace.Tracer
+import sttp.ai.core.agent.*
+
+class TracingInterceptor[F[_]: Tracer] extends AgentInterceptor[F]:
+  override def aroundLlmCall(ctx: LlmCallContext)(next: => F[AgentResponse]): F[AgentResponse] =
+    Tracer[F].span("agent.llm-call").surround(next)
+```
+
+## Migrating from the tool-call hooks
+
+`hookBeforeToolCall` / `hookAfterToolCall` are deprecated (since 0.8.0) and will be removed in the following release.
+They keep working for now and run innermost (closest to the tool call). The equivalent interceptor:
+
+```scala mdoc:compile-only
+import sttp.ai.core.agent.*
+import sttp.shared.Identity
+
+val hooks = new AgentInterceptor[Identity]:
+  override def aroundToolCall(ctx: ToolCallContext)(next: => Identity[ToolCallRecord]): Identity[ToolCallRecord] =
+    println(s"before ${ctx.toolCall.toolName}")
+    val record = next
+    println(s"after ${record.toolName}")
+    record
+```

--- a/docs/agents/interceptors.md
+++ b/docs/agents/interceptors.md
@@ -89,6 +89,10 @@ The library ships no prices — supply your own table, keyed by the provider-rep
 is missing from the table contribute zero to the cost check**; prefer `maxTotalTokens` (which needs no table) when
 not every model in play is priced.
 
+Budgets are soft by one LLM call: a breach is detected at the next iteration boundary, and the forced final answer
+itself is one more (tool-free) LLM call whose usage also counts. Size limits with that headroom in mind — a
+`maxTotalTokens` of 200k may end the run at roughly 200k plus one final call.
+
 ## Bridging the logging sink
 
 `LoggingInterceptor` takes a sink `(LogLevel, String) => F[Unit]`, so core needs no logging dependency. It requires
@@ -100,6 +104,10 @@ slf4j via log4cats:
 import cats.effect.IO
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import sttp.ai.core.agent.interceptor.{LoggingInterceptor, LogLevel}
+import sttp.client4.impl.cats.CatsMonadAsyncError
+import sttp.monad.MonadError
+
+given MonadError[IO] = new CatsMonadAsyncError[IO]()
 
 val logger = Slf4jLogger.getLogger[IO]
 val logging = new LoggingInterceptor[IO]({
@@ -113,7 +121,11 @@ ZIO logging:
 
 ```scala
 import sttp.ai.core.agent.interceptor.{LoggingInterceptor, LogLevel}
+import sttp.client4.impl.zio.RIOMonadAsyncError
+import sttp.monad.MonadError
 import zio.*
+
+given MonadError[Task] = new RIOMonadAsyncError[Any]()
 
 val logging = new LoggingInterceptor[Task]({
   case (LogLevel.Debug, msg) => ZIO.logDebug(msg)

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,7 @@ sttp-ai implements the native APIs of all three major providers — OpenAI, Clau
 
    agents/quickstart
    agents/configuration
+   agents/interceptors
    agents/tools
    agents/mcp
    agents/custom-backends

--- a/gemini/src/main/scala/sttp/ai/gemini/agent/GeminiAgent.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/agent/GeminiAgent.scala
@@ -110,11 +110,16 @@ private[gemini] class GeminiAgentBackend[F[_]](
                 ToolCall(fc.id, fc.name, arguments.noSpaces)
               }
               val usage = response.usage.map { u =>
+                // Gemini reports thought tokens SEPARATELY from total_output_tokens (verified live: total_tokens =
+                // input + output + thought), so they are added here to honor TokenUsage's "output includes reasoning"
+                // invariant. total_tool_use_tokens (server-side tool execution) is not folded in; when present, the
+                // provider's total_tokens may exceed the normalized totalTokens.
+                val thoughtTokens = Tokens(u.totalThoughtTokens.getOrElse(0L))
                 TokenUsage(
                   inputTokens = Tokens(u.totalInputTokens.getOrElse(0L)),
-                  outputTokens = Tokens(u.totalOutputTokens.getOrElse(0L)),
+                  outputTokens = Tokens(u.totalOutputTokens.getOrElse(0L)) + thoughtTokens,
                   cachedInputTokens = Tokens(u.totalCachedTokens.getOrElse(0L)),
-                  reasoningTokens = Tokens(u.totalThoughtTokens.getOrElse(0L))
+                  reasoningTokens = thoughtTokens
                 )
               }
               monad.unit(

--- a/gemini/src/main/scala/sttp/ai/gemini/agent/GeminiAgent.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/agent/GeminiAgent.scala
@@ -109,7 +109,23 @@ private[gemini] class GeminiAgentBackend[F[_]](
                 val arguments = if (fc.arguments.isNull) Json.obj() else fc.arguments
                 ToolCall(fc.id, fc.name, arguments.noSpaces)
               }
-              monad.unit(AgentResponse(response.outputText, toolCalls, mapStopReason(response, toolCalls.nonEmpty)))
+              val usage = response.usage.map { u =>
+                TokenUsage(
+                  inputTokens = Tokens(u.totalInputTokens.getOrElse(0L)),
+                  outputTokens = Tokens(u.totalOutputTokens.getOrElse(0L)),
+                  cachedInputTokens = Tokens(u.totalCachedTokens.getOrElse(0L)),
+                  reasoningTokens = Tokens(u.totalThoughtTokens.getOrElse(0L))
+                )
+              }
+              monad.unit(
+                AgentResponse(
+                  response.outputText,
+                  toolCalls,
+                  mapStopReason(response, toolCalls.nonEmpty),
+                  usage = usage,
+                  model = response.model
+                )
+              )
             }
 
           case Left(error) =>

--- a/gemini/src/test/scala/sttp/ai/gemini/agent/GeminiAgentBackendSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/agent/GeminiAgentBackendSpec.scala
@@ -353,7 +353,9 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     response.usage shouldBe Some(
       TokenUsage(
         inputTokens = Tokens(100L),
-        outputTokens = Tokens(30L),
+        // total_output_tokens (30) + total_thought_tokens (10): Gemini reports thought tokens separately,
+        // and TokenUsage.outputTokens includes reasoning.
+        outputTokens = Tokens(40L),
         cachedInputTokens = Tokens(40L),
         reasoningTokens = Tokens(10L)
       )

--- a/gemini/src/test/scala/sttp/ai/gemini/agent/GeminiAgentBackendSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/agent/GeminiAgentBackendSpec.scala
@@ -325,6 +325,41 @@ class GeminiAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
     capturedModels.get() shouldBe Vector("gemini-2.5-flash-lite", "gemini-2.5-pro")
   }
 
+  it should "surface provider-reported usage and model on AgentResponse" in {
+    val responseJson =
+      """{
+        |  "id": "int_1",
+        |  "status": "completed",
+        |  "model": "gemini-2.5-flash",
+        |  "steps": [],
+        |  "usage": {
+        |    "total_input_tokens": 100,
+        |    "total_output_tokens": 30,
+        |    "total_tokens": 130,
+        |    "total_cached_tokens": 40,
+        |    "total_thought_tokens": 10
+        |  }
+        |}""".stripMargin
+    val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF(_ => ResponseStub.adjust(responseJson, StatusCode.Ok))
+
+    val response = newBackend(Seq.empty).sendRequest(
+      ConversationHistory.withInitialPrompt("hello"),
+      httpStub,
+      includeTools = false,
+      IterationInfo(1, 10)
+    )
+
+    response.model shouldBe Some("gemini-2.5-flash")
+    response.usage shouldBe Some(
+      TokenUsage(
+        inputTokens = Tokens(100L),
+        outputTokens = Tokens(30L),
+        cachedInputTokens = Tokens(40L),
+        reasoningTokens = Tokens(10L)
+      )
+    )
+  }
+
   it should "build typed and mixed-model agents through GeminiAgent" in {
     GeminiAgent.synchronous(GeminiConfig(apiKey = "test-key"), GeminiModel.Gemini25Flash): Unit
     GeminiAgent.synchronous(

--- a/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
+++ b/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
@@ -119,7 +119,14 @@ private[openai] class OpenAIAgentBackend[F[_]](
           .map(mapOpenAIStopReason)
           .getOrElse(StopReason.EndTurn)
 
-        monad.unit(AgentResponse(textContent, toolCalls, stopReason))
+        val usage = TokenUsage(
+          inputTokens = Tokens(response.usage.promptTokens.toLong),
+          outputTokens = Tokens(response.usage.completionTokens.toLong),
+          cachedInputTokens = Tokens(response.usage.promptTokensDetails.flatMap(_.cachedTokens).getOrElse(0).toLong),
+          reasoningTokens = Tokens(response.usage.completionTokensDetails.flatMap(_.reasoningTokens).getOrElse(0).toLong)
+        )
+
+        monad.unit(AgentResponse(textContent, toolCalls, stopReason, usage = Some(usage), model = Some(response.model)))
 
       case Left(error) =>
         monad.error(

--- a/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/agent/OpenAIAgentBackendSpec.scala
@@ -109,4 +109,46 @@ class OpenAIAgentBackendSpec extends AnyFlatSpec with Matchers with EitherValues
 
     capturedModels.get() shouldBe Vector("gpt-4o-mini", "gpt-4.1")
   }
+
+  it should "surface provider-reported usage and model on AgentResponse" in {
+    val responseJson =
+      """{
+        |  "id": "chatcmpl-1",
+        |  "object": "chat.completion",
+        |  "created": 1,
+        |  "model": "gpt-4o-mini",
+        |  "choices": [
+        |    {
+        |      "index": 0,
+        |      "message": { "role": "assistant", "content": "hi" },
+        |      "finish_reason": "stop"
+        |    }
+        |  ],
+        |  "usage": {
+        |    "prompt_tokens": 100,
+        |    "completion_tokens": 30,
+        |    "total_tokens": 130,
+        |    "prompt_tokens_details": { "cached_tokens": 40 },
+        |    "completion_tokens_details": { "reasoning_tokens": 10 }
+        |  }
+        |}""".stripMargin
+    val httpStub = DefaultSyncBackend.stub.whenAnyRequest.thenRespondF(_ => ResponseStub.adjust(responseJson, StatusCode.Ok))
+
+    val response = backend(strictTools = true).sendRequest(
+      ConversationHistory.withInitialPrompt("hello"),
+      httpStub,
+      includeTools = false,
+      IterationInfo(1, 10)
+    )
+
+    response.model shouldBe Some("gpt-4o-mini")
+    response.usage shouldBe Some(
+      sttp.ai.core.agent.TokenUsage(
+        inputTokens = sttp.ai.core.agent.Tokens(100L),
+        outputTokens = sttp.ai.core.agent.Tokens(30L),
+        cachedInputTokens = sttp.ai.core.agent.Tokens(40L),
+        reasoningTokens = sttp.ai.core.agent.Tokens(10L)
+      )
+    )
+  }
 }


### PR DESCRIPTION
## Description

Generalizes the ad-hoc agent hooks (`beforeToolCall`, `afterToolCall`) into a composable `AgentInterceptor[F]` middleware that wraps iterations, LLM calls, and tool executions — with LLM-call visibility and budget enforcement as the first built-in deliverables.

### AgentInterceptor[F]

```scala
trait AgentInterceptor[F[_]] {
  def aroundIteration[A](ctx: IterationContext)(next: => F[A]): F[A] = next
  def aroundLlmCall(ctx: LlmCallContext)(next: => F[AgentResponse]): F[AgentResponse] = next
  def aroundToolCall(ctx: ToolCallContext)(next: => F[ToolCallRecord]): F[ToolCallRecord] = next
  def decide(state: AgentRunState): LoopDecision = LoopDecision.Continue
}
```

- Wrap-style (onion) composition like sttp backend wrappers: `agent.interceptor(a).interceptor(b)` — first added is outermost; for `decide`, the first `FinishNow` wins.
- `next` is by-name so interceptors work under `Identity` as well as lazy effect types (contract: call `next` at most once).
- `decide` is pure and consulted before each iteration; returning `LoopDecision.FinishNow(cause, instruction)` injects the instruction as a user message and withholds tools — mirroring the existing last-iteration behavior — instead of failing abruptly.

### Usage accounting

- `AgentResponse` now carries provider-reported `usage: Option[TokenUsage]` and `model: Option[String]`; all three backends (OpenAI, Claude incl. cache fields, Gemini) populate them.
- New `Tokens` value class and provider-normalized `TokenUsage` (input includes cached; output includes reasoning; cached/reasoning as informational subsets).
- `AgentResult` accumulates `usage: TokenUsage` and a per-call `llmCalls: Seq[LlmCallUsage]` breakdown (model id + usage per call, enabling per-model cost math for mixed-model runs).
- `FinishReason` gains `BudgetExceeded`; `runAs` treats budget-forced answers like max-iterations ones (parse-attempted).

### Built-in interceptors (`sttp.ai.core.agent.interceptor`)

- **`BudgetInterceptor`** — `maxTotalTokens` and/or `maxCost` with a user-supplied `PriceTable` (the library ships no prices). On breach it forces a graceful final answer with `FinishReason.BudgetExceeded`. Setting `maxCost` without a `priceTable` fails fast at construction; calls whose model id is missing from the table contribute zero to the cost check (documented loudly); the token budget needs no table. Budgets are soft by one LLM call (the forced final answer) — documented.
- **`LoggingInterceptor`** — pluggable sink `(LogLevel, String) => F[Unit]`, no logging dependency in core; docs show slf4j/log4cats, ZIO logging, and otel4s bridges.

### Compatibility

- ⚠️ **Binary compatibility break** (0.8.0): `AgentResponse`, `AgentResult`, and `AgentConfig` constructors gained fields. All new fields are defaulted, so **source compatibility is preserved** for typical usage, including external `AgentBackend` implementations. One source-level exception: `FinishReason` (sealed) gained the `BudgetEe with exhaustive matches on `FinishReason` must add a case.
- `beforeToolCall`/`afterToolCall` (config fields) and `hookBeforeToolCall`/`hookAfterToolCall` (builder) are `@deprecated` since 0.8.0 and adapt internally to an interceptor running innermost — behavior unchanged for one release,    removal planned for the next.
                                                                                                                                                                                                                                          ### Docs
                                                                                                                                                                                                                                          New page `docs/agents/interceptors.md` (registered in the toctree): writing interceptors, composition/o and price-table caveats, logging bridges, hook migration. The existing hooks section in`docs/agents/configuration.md` now carries a deprecation admonition.                                                                                                                                                                      
### Testing                                                                                                                                                                                                                               
- New unit suites: `TokenUsageSpec`, `AgentInterceptorComposeSpec`, `AgentInterceptorLoopSpec` (onion ordering, usage accumulation, steering incl. iteration-0 FinishNow, maxIterations precedence, legacy-hook interleaving, interceptor error propagation), `BudgetInterceptorSpec` (incl. multi-model cost math), `LoggingInterceptorSpec`.
- Provider backend specs assert the exact usage mappings against stubbed JSON.
- One cheap assertion added to the shared agent integration base (`usage.totalTokens > 0`) — no new API
- Full suite green on Scala 2.13 and 3 JVM rows; `compileDocumentation` passes.
- **Live-validated against real APIs:** Claude 8/8 (including an end-to-end budget-forced graceful stop), Gemini 7/7, OpenAI 6/7 — the one OpenAI failure (`runAs[T]` expecting `NaturalStop`) reproduces