### PR TITLE
Feature/typed agent io

### DIFF
--- a/agent-testkit/src/main/scala/sttp/ai/core/agent/testing/ScriptedAgent.scala
+++ b/agent-testkit/src/main/scala/sttp/ai/core/agent/testing/ScriptedAgent.scala
@@ -13,6 +13,7 @@ import sttp.shared.Identity
   * )
   * val agent = script.builder.tools(calculatorTool).build
   * val result = agent.run("What is 1 + 2?")(SyncBackendStub)
+  * // result.finalAnswer: Either[AgentFailure, String]
   * script.requests // one RecordedRequest per model round-trip
   * }}}
   *
@@ -26,7 +27,7 @@ final class ScriptedAgent[F[_]] private (script: Seq[AgentResponse])(implicit mo
   private var backends: Vector[ScriptedAgentBackend[F]] = Vector.empty
 
   /** A standard [[AgentBuilder]] wired to this script — a drop-in replacement for e.g. `OpenAIAgent.builder(...)`. */
-  def builder: AgentBuilder[F, ScriptedModel.type] = AgentBuilder[F, ScriptedModel.type] { config =>
+  def builder: AgentBuilder[F, ScriptedModel.type, String, String] = AgentBuilder[F, ScriptedModel.type] { config =>
     val backend = new ScriptedAgentBackend[F](script, config.userTools, config.systemPrompt, config.responseSchema)
     synchronized {
       backends = backends :+ backend

--- a/agent-testkit/src/test/scala/sttp/ai/core/agent/testing/AgentMatchersSpec.scala
+++ b/agent-testkit/src/test/scala/sttp/ai/core/agent/testing/AgentMatchersSpec.scala
@@ -5,7 +5,7 @@ import io.circe.generic.semiauto.deriveCodec
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import sttp.ai.core.agent.{AgentResult, AgentTool, FinishReason}
+import sttp.ai.core.agent.{AgentFailure, AgentResult, AgentTool, FinishReason}
 import sttp.client4.testing.SyncBackendStub
 import sttp.shared.Identity
 import sttp.tapir.Schema
@@ -20,7 +20,7 @@ class AgentMatchersSpec extends AnyFlatSpec with Matchers with AgentMatchers {
     s"Result: ${input.a + input.b}"
   }
 
-  private val (script, result): (ScriptedAgent[Identity], AgentResult[String]) = {
+  private val (script, result): (ScriptedAgent[Identity], AgentResult[Either[AgentFailure, String]]) = {
     val s = ScriptedAgent.synchronous(
       ScriptedResponse.toolCall("calculator", """{"a": 1, "b": 2}"""),
       ScriptedResponse.text("The answer is 3")

--- a/agent-testkit/src/test/scala/sttp/ai/core/agent/testing/ScriptedAgentSpec.scala
+++ b/agent-testkit/src/test/scala/sttp/ai/core/agent/testing/ScriptedAgentSpec.scala
@@ -5,7 +5,7 @@ import io.circe.generic.semiauto.deriveCodec
 import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import sttp.ai.core.agent.{AgentTool, ConversationEntry, FinishReason, ResponseSchema}
+import sttp.ai.core.agent.{AgentIncomplete, AgentTool, ConversationEntry, FinishReason, ResponseSchema}
 import sttp.client4.testing.{BackendStub, SyncBackendStub}
 import sttp.monad.MonadError
 import sttp.tapir.Schema
@@ -37,7 +37,7 @@ class ScriptedAgentSpec extends AnyFlatSpec with Matchers with OptionValues {
 
     val result = agent.run("What is 1 + 2?")(httpBackend)
 
-    result.finalAnswer shouldBe "The answer is 3"
+    result.finalAnswer shouldBe Right("The answer is 3")
     result.finishReason shouldBe FinishReason.NaturalStop
     result.iterations shouldBe 2
     result.toolCalls should have size 1
@@ -66,7 +66,7 @@ class ScriptedAgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     val result = script.builder.tools(calculatorTool).maxIterations(2).build.run("add 1 and 2")(httpBackend)
 
     script.requests.map(_.includeTools) shouldBe Seq(true, false)
-    result.finalAnswer shouldBe "partial answer"
+    result.finalAnswer shouldBe Right("partial answer")
     result.finishReason shouldBe FinishReason.MaxIterations
   }
 
@@ -79,10 +79,10 @@ class ScriptedAgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     intercept[ScriptExhaustedException](agent.run("add 1 and 2")(httpBackend))
   }
 
-  it should "support runAs with a decoded final answer" in {
+  it should "support a typed run with a decoded final answer" in {
     val script = ScriptedAgent.synchronous(ScriptedResponse.text("""{"value": 3}"""))
 
-    val result = script.builder.build.runAs[Answer]("compute")(httpBackend)
+    val result = script.builder.deriveResponseSchema[Answer].build.run("compute")(httpBackend)
 
     result.finalAnswer shouldBe Right(Answer(3))
   }
@@ -90,7 +90,7 @@ class ScriptedAgentSpec extends AnyFlatSpec with Matchers with OptionValues {
   it should "record the configured response schema" in {
     val script = ScriptedAgent.synchronous(ScriptedResponse.text("""{"value": 3}"""))
 
-    script.builder.deriveResponseSchema[Answer].build.runAs[Answer]("compute")(httpBackend)
+    script.builder.deriveResponseSchema[Answer].build.run("compute")(httpBackend)
 
     script.responseSchemaSent should not be empty
     script.responseSchemaSent.value.schema shouldBe ResponseSchema.derived[Answer]().schema
@@ -106,8 +106,8 @@ class ScriptedAgentSpec extends AnyFlatSpec with Matchers with OptionValues {
   it should "give each build a fresh script cursor and accumulate recordings" in {
     val script = ScriptedAgent.synchronous(ScriptedResponse.text("hi"))
 
-    script.builder.build.run("first")(httpBackend).finalAnswer shouldBe "hi"
-    script.builder.build.run("second")(httpBackend).finalAnswer shouldBe "hi"
+    script.builder.build.run("first")(httpBackend).finalAnswer shouldBe Right("hi")
+    script.builder.build.run("second")(httpBackend).finalAnswer shouldBe Right("hi")
 
     script.requests should have size 2
   }
@@ -117,7 +117,7 @@ class ScriptedAgentSpec extends AnyFlatSpec with Matchers with OptionValues {
 
     val result = script.builder.build.run("go")(httpBackend)
 
-    result.finalAnswer shouldBe "truncated answer"
+    result.finalAnswer shouldBe Left(AgentIncomplete("truncated answer", FinishReason.TokenLimit, parseError = None))
     result.finishReason shouldBe FinishReason.TokenLimit
   }
 
@@ -130,7 +130,7 @@ class ScriptedAgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     val result = script.builder.tools(calculatorTool).build.run("add 1 and 2")(httpBackend)
 
     result.toolCalls.map(_.output) shouldBe Seq("Result: 3.0")
-    result.finalAnswer shouldBe "done"
+    result.finalAnswer shouldBe Right("done")
     script.requests.last.history.entries.collect { case ConversationEntry.AssistantResponse(content, _) =>
       content
     } should contain("thinking...")
@@ -170,7 +170,7 @@ class ScriptedAgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     val effect = script.builder.build.run("prompt")(BackendStub[Thunk](ThunkMonad))
     script.requests shouldBe empty
 
-    effect().finalAnswer shouldBe "hi"
+    effect().finalAnswer shouldBe Right("hi")
     script.requests should have size 1
   }
 }

--- a/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
+++ b/claude/src/main/scala/sttp/ai/claude/agent/ClaudeAgent.scala
@@ -130,7 +130,9 @@ object ClaudeAgent {
 
   final class BuilderPartiallyApplied[F[_]] private[ClaudeAgent] () {
 
-    def apply[M <: ClaudeModel](client: ClaudeClient, model: M)(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, M] =
+    def apply[M <: ClaudeModel](client: ClaudeClient, model: M)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M, String, String] =
       apply(client, (_: IterationInfo) => model)
 
     /** Selects the model per loop iteration (e.g. a cheap model for tool iterations, a stronger one for the forced-final synthesis). `M`
@@ -138,45 +140,53 @@ object ClaudeAgent {
       */
     def apply[M <: ClaudeModel](client: ClaudeClient, modelForIteration: IterationInfo => M)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, M] =
+    ): AgentBuilder[F, M, String, String] =
       AgentBuilder[F, M](config =>
         new ClaudeAgentBackend[F](client, modelForIteration, config.userTools, config.systemPrompt, config.responseSchema)
       )
 
     def apply(client: ClaudeClient, modelName: String)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, ClaudeModel.CustomClaudeModel] =
+    ): AgentBuilder[F, ClaudeModel.CustomClaudeModel, String, String] =
       apply(client, ClaudeModel.CustomClaudeModel(modelName))
 
-    def apply[M <: ClaudeModel](claudeConfig: ClaudeConfig, model: M)(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, M] =
+    def apply[M <: ClaudeModel](claudeConfig: ClaudeConfig, model: M)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M, String, String] =
       apply(ClaudeClient(claudeConfig), model)
 
     def apply[M <: ClaudeModel](claudeConfig: ClaudeConfig, modelForIteration: IterationInfo => M)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, M] =
+    ): AgentBuilder[F, M, String, String] =
       apply(ClaudeClient(claudeConfig), modelForIteration)
 
     def apply(claudeConfig: ClaudeConfig, modelName: String)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, ClaudeModel.CustomClaudeModel] =
+    ): AgentBuilder[F, ClaudeModel.CustomClaudeModel, String, String] =
       apply(ClaudeClient(claudeConfig), modelName)
   }
 
-  def synchronous[M <: ClaudeModel](client: ClaudeClient, model: M): AgentBuilder[Identity, M] =
+  def synchronous[M <: ClaudeModel](client: ClaudeClient, model: M): AgentBuilder[Identity, M, String, String] =
     builder[Identity](client, model)(IdentityMonad)
 
-  def synchronous[M <: ClaudeModel](client: ClaudeClient, modelForIteration: IterationInfo => M): AgentBuilder[Identity, M] =
+  def synchronous[M <: ClaudeModel](
+      client: ClaudeClient,
+      modelForIteration: IterationInfo => M
+  ): AgentBuilder[Identity, M, String, String] =
     builder[Identity](client, modelForIteration)(IdentityMonad)
 
-  def synchronous(client: ClaudeClient, modelName: String): AgentBuilder[Identity, ClaudeModel.CustomClaudeModel] =
+  def synchronous(client: ClaudeClient, modelName: String): AgentBuilder[Identity, ClaudeModel.CustomClaudeModel, String, String] =
     builder[Identity](client, modelName)(IdentityMonad)
 
-  def synchronous[M <: ClaudeModel](claudeConfig: ClaudeConfig, model: M): AgentBuilder[Identity, M] =
+  def synchronous[M <: ClaudeModel](claudeConfig: ClaudeConfig, model: M): AgentBuilder[Identity, M, String, String] =
     builder[Identity](claudeConfig, model)(IdentityMonad)
 
-  def synchronous[M <: ClaudeModel](claudeConfig: ClaudeConfig, modelForIteration: IterationInfo => M): AgentBuilder[Identity, M] =
+  def synchronous[M <: ClaudeModel](
+      claudeConfig: ClaudeConfig,
+      modelForIteration: IterationInfo => M
+  ): AgentBuilder[Identity, M, String, String] =
     builder[Identity](claudeConfig, modelForIteration)(IdentityMonad)
 
-  def synchronous(claudeConfig: ClaudeConfig, modelName: String): AgentBuilder[Identity, ClaudeModel.CustomClaudeModel] =
+  def synchronous(claudeConfig: ClaudeConfig, modelName: String): AgentBuilder[Identity, ClaudeModel.CustomClaudeModel, String, String] =
     builder[Identity](claudeConfig, modelName)(IdentityMonad)
 }

--- a/claude/src/test/scala/sttp/ai/claude/integration/ClaudeAgentIntegrationSpec.scala
+++ b/claude/src/test/scala/sttp/ai/claude/integration/ClaudeAgentIntegrationSpec.scala
@@ -13,7 +13,7 @@ class ClaudeAgentIntegrationSpec extends AgentIntegrationSpecBase {
   override def providerName: String = "Claude"
   override def apiKeyEnvVar: String = "ANTHROPIC_API_KEY"
 
-  override def createAgent(maxIterations: Int, tools: Seq[AgentTool[Identity, _]]): Agent[Identity] = {
+  override def createAgent(maxIterations: Int, tools: Seq[AgentTool[Identity, _]]): Agent[Identity, String, String] = {
     val config = ClaudeConfig.fromEnv
     val client = ClaudeClient(config)
     val agentConfig = AgentConfig[Identity](maxIterations = maxIterations, userTools = tools)
@@ -31,7 +31,7 @@ class ClaudeAgentIntegrationSpec extends AgentIntegrationSpecBase {
       maxIterations: Int,
       tools: Seq[AgentTool[Identity, _]],
       responseSchema: ResponseSchema[T]
-  ): Agent[Identity] =
+  ): Agent[Identity, String, T] =
     ClaudeAgent
       .synchronous(ClaudeConfig.fromEnv, "claude-haiku-4-5-20251001")
       .maxIterations(maxIterations)

--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -19,7 +19,8 @@ trait Agent[F[_], In, Out] { self =>
     * only when this agent's output type is `next`'s input type. If `this` fails (`Left`), `next` never runs. Metadata is aggregated:
     * iterations and usage summed, tool and LLM calls concatenated in stage order, `finishReason` taken from the last stage that ran.
     * `ToolCallRecord.iteration` stays stage-local. If `next` raises an error in `F`'s error channel, it propagates as a plain error and
-    * `this` stage's accumulated metadata (usage, tool calls) is not reported in that case.
+    * `this` stage's accumulated metadata (usage, tool calls) is not reported in that case. Interceptors are also stage-local: each agent
+    * runs with its own configured interceptors, so e.g. a budget interceptor on `next` does not observe this stage's token spend.
     */
   def andThen[Out2](next: Agent[F, Out, Out2]): Agent[F, In, Out2] = {
     val m = monad

--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -1,211 +1,26 @@
 package sttp.ai.core.agent
 
-import io.circe.Decoder
-import io.circe.parser.decode
 import sttp.client4.Backend
 import sttp.monad.MonadError
-import sttp.monad.syntax.MonadErrorOps
 
-class Agent[F[_]](
-    agentBackend: AgentBackend[F],
-    config: AgentConfig[F]
-)(implicit monad: MonadError[F]) {
-  import Agent.{ContinueLoop, Finished, IterationOutcome}
+/** An agent with typed input `In` and typed output `Out`, runnable against an sttp backend.
+  *
+  * The loop-based implementation is produced by [[AgentBuilder.build]]. API/transport errors surface in `F`'s error channel; agent-level
+  * outcomes (unparseable or incomplete answers) are `Left[AgentFailure]` values inside the result.
+  */
+trait Agent[F[_], In, Out] {
 
-  private val toolMap = config.userTools.map(t => t.name -> t).toMap
+  protected implicit def monad: MonadError[F]
 
-  private val interceptor: AgentInterceptor[F] = AgentInterceptor.compose(config.interceptors)
-
-  def run(
-      initialPrompt: String
-  )(backend: Backend[F]): F[AgentResult[String]] = {
-    val initialHistory = ConversationHistory.withInitialPrompt(initialPrompt)
-
-    def loop(
-        history: ConversationHistory,
-        iteration: Int,
-        records: Seq[ToolCallRecord],
-        usage: TokenUsage,
-        llmCalls: Seq[LlmCallUsage]
-    ): F[AgentResult[String]] =
-      // Safety net for maxIterations <= 0. For maxIterations >= 1 this is unreachable: the final-iteration branch
-      // below always returns at iteration == maxIterations - 1, so the loop never recurses past it.
-      if (iteration >= config.maxIterations) {
-        monad.unit(
-          AgentResult(extractFinalAnswer(history), iteration, records, FinishReason.MaxIterations, usage, llmCalls)
-        )
-      } else {
-        val decision = interceptor.decide(AgentRunState(iteration, config.maxIterations, usage, llmCalls))
-        val info = IterationInfo(iteration + 1, config.maxIterations, forcedFinal = decision != LoopDecision.Continue)
-        interceptor
-          .aroundIteration(IterationContext(info))(runIteration(history, iteration, records, usage, llmCalls, decision, backend))
-          .flatMap {
-            case ContinueLoop(h, r, u, lc) => loop(h, iteration + 1, r, u, lc)
-            case Finished(result)          => monad.unit(result)
-          }
-      }
-
-    loop(initialHistory, 0, Seq.empty, TokenUsage.Zero, Seq.empty)
-  }
-
-  private def runIteration(
-      history: ConversationHistory,
-      iteration: Int,
-      records: Seq[ToolCallRecord],
-      usage: TokenUsage,
-      llmCalls: Seq[LlmCallUsage],
-      decision: LoopDecision,
-      backend: Backend[F]
-  ): F[IterationOutcome] = {
-    val isLastByCount = iteration == config.maxIterations - 1
-    val forcedCause: Option[FinishReason.ForcedStop] = decision match {
-      case LoopDecision.FinishNow(cause, _) => Some(cause)
-      case LoopDecision.Continue            => None
-    }
-    val isFinalIteration = isLastByCount || forcedCause.nonEmpty
-
-    val requestHistory = decision match {
-      case LoopDecision.FinishNow(_, instruction) =>
-        // No iteration marker on a forced-final request: "[Iteration 3 of 10]" would contradict the injected instruction.
-        history.addUserPrompt(instruction)
-      case LoopDecision.Continue =>
-        if (iteration > 0) history.addIterationMarker(iteration + 1, config.maxIterations) else history
-    }
-
-    val info = IterationInfo(iteration + 1, config.maxIterations, forcedFinal = forcedCause.nonEmpty)
-    val includeTools = !isFinalIteration
-
-    interceptor
-      .aroundLlmCall(LlmCallContext(requestHistory, includeTools, info))(
-        agentBackend.sendRequest(requestHistory, backend, includeTools, info)
-      )
-      .flatMap { response =>
-        val callUsage = response.usage.getOrElse(TokenUsage.Zero)
-        val newUsage = usage + callUsage
-        val newLlmCalls = llmCalls :+ LlmCallUsage(response.model, callUsage)
-
-        if (response.stopReason == StopReason.MaxTokens) {
-          monad.unit(
-            Finished(AgentResult(response.textContent, iteration + 1, records, FinishReason.TokenLimit, newUsage, newLlmCalls))
-          )
-        } else if (isFinalIteration) {
-          // Tools were not offered on the final iteration, so any tool calls in the response are spurious and must not
-          // be executed. Force the final answer: prefer the model's text, fall back to the last tool result / assistant text.
-          val finalAnswer = if (response.textContent.nonEmpty) response.textContent else extractFinalAnswer(history)
-          // MaxIterations takes precedence when the forced last iteration and a FinishNow coincide.
-          val reason = if (isLastByCount) FinishReason.MaxIterations else forcedCause.getOrElse(FinishReason.MaxIterations)
-          monad.unit(Finished(AgentResult(finalAnswer, iteration + 1, records, reason, newUsage, newLlmCalls)))
-        } else if (response.toolCalls.isEmpty) {
-          // No tool calls - the agent has produced its final answer, so complete the loop.
-          monad.unit(
-            Finished(AgentResult(response.textContent, iteration + 1, records, FinishReason.NaturalStop, newUsage, newLlmCalls))
-          )
-        } else {
-          val updatedHistory = history.addAssistantResponse(response.textContent, response.toolCalls)
-          runToolCalls(response.toolCalls.toList, iteration + 1, updatedHistory, records).map { case (h, r) =>
-            ContinueLoop(h, r, newUsage, newLlmCalls)
-          }
-        }
-      }
-  }
-
-  def runAs[T](
-      initialPrompt: String
-  )(backend: Backend[F])(implicit r: Decoder[T]): F[AgentResult[Either[AgentFailure, T]]] =
-    monad.map(run(initialPrompt)(backend)) { res =>
-      val parsed: Either[AgentFailure, T] = res.finishReason match {
-        case FinishReason.NaturalStop =>
-          decode[T](res.finalAnswer).left.map(e => AgentParseError(res.finalAnswer, e))
-        case FinishReason.MaxIterations | _: FinishReason.ForcedStop =>
-          // A forced final iteration withholds tools and keeps schema guidance, so the answer may still be valid.
-          decode[T](res.finalAnswer).left.map(e => AgentIncomplete(res.finalAnswer, res.finishReason, Some(e)))
-        case FinishReason.TokenLimit | FinishReason.Error(_) =>
-          Left(AgentIncomplete(res.finalAnswer, res.finishReason, parseError = None))
-      }
-      AgentResult(parsed, res.iterations, res.toolCalls, res.finishReason, res.usage, res.llmCalls)
-    }
-
-  private def runToolCalls(
-      toolCalls: List[ToolCall],
-      iteration: Int,
-      history: ConversationHistory,
-      results: Seq[ToolCallRecord]
-  ): F[(ConversationHistory, Seq[ToolCallRecord])] =
-    toolCalls match {
-      case Nil              => monad.unit((history, results))
-      case toolCall :: rest =>
-        for {
-          result <- interceptor.aroundToolCall(ToolCallContext(toolCall, iteration))(runToolCall(toolCall, iteration))
-          updatedHistory = history.addToolResult(result)
-          acc <- runToolCalls(rest, iteration, updatedHistory, results :+ result)
-        } yield acc
-    }
-
-  private def runToolCall(
-      toolCall: ToolCall,
-      iteration: Int
-  ): F[ToolCallRecord] = {
-    val output = toolMap.get(toolCall.toolName) match {
-      case Some(tool) => executeTool(tool, toolCall)
-      case None       => monad.unit(s"Tool not found: ${toolCall.toolName}")
-    }
-
-    output.map { result =>
-      ToolCallRecord(
-        id = toolCall.id,
-        toolName = toolCall.toolName,
-        input = toolCall.input,
-        output = result,
-        iteration = iteration
-      )
-    }
-  }
-
-  private def executeTool[T](tool: AgentTool[F, T], toolCall: ToolCall): F[String] =
-    monad
-      .eval(decode[T](toolCall.input)(tool.codec).fold(throw _, identity))
-      .map[Either[String, T]](Right(_))
-      .handleError { case parseException: Exception =>
-        config.exceptionHandler.handleParseError(toolCall.toolName, toolCall.input, parseException) match {
-          case Left(errorMessage) => monad.unit(Left(errorMessage))
-          case Right(ex)          => monad.error(ex)
-        }
-      }
-      .flatMap {
-        case Left(errorMessage) => monad.unit(errorMessage)
-        case Right(typedInput)  =>
-          tool.execute(typedInput).handleError { case e: Exception =>
-            config.exceptionHandler.handleToolException(toolCall.toolName, e) match {
-              case Left(errorMessage) => monad.unit(errorMessage)
-              case Right(ex)          => monad.error(ex)
-            }
-          }
-      }
-
-  private def extractFinalAnswer(history: ConversationHistory): String =
-    history.entries.reverseIterator
-      .collectFirst {
-        case ConversationEntry.AssistantResponse(content, _) if content.nonEmpty => content
-        case ConversationEntry.ToolResult(_, _, result)                          => result
-      }
-      .getOrElse("No answer available")
+  def run(in: In)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out]]]
 }
 
 object Agent {
+
+  /** Constructs the loop-based agent with untyped (string) input and output — the shape produced by a fresh [[AgentBuilder]]. */
   def apply[F[_]](
       agentBackend: AgentBackend[F],
       config: AgentConfig[F]
-  )(implicit monad: MonadError[F]): Agent[F] =
-    new Agent[F](agentBackend, config)(monad)
-
-  // Top-level (not inner) classes so matches on them are runtime-checkable — inner classes trigger
-  // "outer reference cannot be checked" warnings on Scala 2.13.
-  private[agent] sealed trait IterationOutcome
-  private[agent] final case class ContinueLoop(
-      history: ConversationHistory,
-      records: Seq[ToolCallRecord],
-      usage: TokenUsage,
-      llmCalls: Seq[LlmCallUsage]
-  ) extends IterationOutcome
-  private[agent] final case class Finished(result: AgentResult[String]) extends IterationOutcome
+  )(implicit monad: MonadError[F]): Agent[F, String, String] =
+    new LoopAgent[F, String, String](agentBackend, config, identity, answer => Right(answer))
 }

--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -2,17 +2,79 @@ package sttp.ai.core.agent
 
 import sttp.client4.Backend
 import sttp.monad.MonadError
+import sttp.monad.syntax.MonadErrorOps
 
 /** An agent with typed input `In` and typed output `Out`, runnable against an sttp backend.
   *
   * The loop-based implementation is produced by [[AgentBuilder.build]]. API/transport errors surface in `F`'s error channel; agent-level
   * outcomes (unparseable or incomplete answers) are `Left[AgentFailure]` values inside the result.
   */
-trait Agent[F[_], In, Out] {
+trait Agent[F[_], In, Out] { self =>
 
   protected implicit def monad: MonadError[F]
 
   def run(in: In)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out]]]
+
+  /** Typed handoff: runs `this`, then feeds its `Out` to `next` as a fresh conversation (rendered by `next`'s input renderer). Compiles
+    * only when this agent's output type is `next`'s input type. If `this` fails (`Left`), `next` never runs. Metadata is aggregated:
+    * iterations and usage summed, tool and LLM calls concatenated in stage order, `finishReason` taken from the last stage that ran.
+    * `ToolCallRecord.iteration` stays stage-local.
+    */
+  def andThen[Out2](next: Agent[F, Out, Out2]): Agent[F, In, Out2] = {
+    val m = monad
+    new Agent[F, In, Out2] {
+      protected implicit def monad: MonadError[F] = m
+      def run(in: In)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out2]]] =
+        self.run(in)(backend).flatMap { first =>
+          first.finalAnswer match {
+            case Left(failure) =>
+              m.unit(
+                AgentResult[Either[AgentFailure, Out2]](
+                  Left(failure),
+                  first.iterations,
+                  first.toolCalls,
+                  first.finishReason,
+                  first.usage,
+                  first.llmCalls
+                )
+              )
+            case Right(out) =>
+              next.run(out)(backend).map { second =>
+                AgentResult(
+                  second.finalAnswer,
+                  first.iterations + second.iterations,
+                  first.toolCalls ++ second.toolCalls,
+                  second.finishReason,
+                  first.usage + second.usage,
+                  first.llmCalls ++ second.llmCalls
+                )
+              }
+          }
+        }
+    }
+  }
+
+  /** Adapts the output with a pure function, applied to `Right` results only; failures and metadata pass through untouched. */
+  def map[Out2](f: Out => Out2): Agent[F, In, Out2] = {
+    val m = monad
+    new Agent[F, In, Out2] {
+      protected implicit def monad: MonadError[F] = m
+      def run(in: In)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out2]]] =
+        self.run(in)(backend).map { res =>
+          AgentResult(res.finalAnswer.map(f), res.iterations, res.toolCalls, res.finishReason, res.usage, res.llmCalls)
+        }
+    }
+  }
+
+  /** Adapts the input with a pure function, applied before the agent runs. */
+  def contramap[In2](f: In2 => In): Agent[F, In2, Out] = {
+    val m = monad
+    new Agent[F, In2, Out] {
+      protected implicit def monad: MonadError[F] = m
+      def run(in: In2)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out]]] =
+        self.run(f(in))(backend)
+    }
+  }
 }
 
 object Agent {

--- a/core/src/main/scala/sttp/ai/core/agent/Agent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/Agent.scala
@@ -18,7 +18,8 @@ trait Agent[F[_], In, Out] { self =>
   /** Typed handoff: runs `this`, then feeds its `Out` to `next` as a fresh conversation (rendered by `next`'s input renderer). Compiles
     * only when this agent's output type is `next`'s input type. If `this` fails (`Left`), `next` never runs. Metadata is aggregated:
     * iterations and usage summed, tool and LLM calls concatenated in stage order, `finishReason` taken from the last stage that ran.
-    * `ToolCallRecord.iteration` stays stage-local.
+    * `ToolCallRecord.iteration` stays stage-local. If `next` raises an error in `F`'s error channel, it propagates as a plain error and
+    * `this` stage's accumulated metadata (usage, tool calls) is not reported in that case.
     */
   def andThen[Out2](next: Agent[F, Out, Out2]): Agent[F, In, Out2] = {
     val m = monad

--- a/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
@@ -1,71 +1,90 @@
 package sttp.ai.core.agent
 
 import io.circe.Codec
+import io.circe.parser.decode
 import sttp.ai.core.agent.AgentConfig.SystemPromptParameters
 import sttp.ai.core.model.{AIModel, Capability, Supports}
 import sttp.monad.MonadError
 import sttp.tapir.Schema
 
 /** Fluent agent configuration. `M` is the model (or family of models) the agent was created with; builder methods that need a model
-  * capability require `Supports[M, C]` evidence, so e.g. adding tools to an agent whose model cannot call tools fails at compile time.
+  * capability require `Supports[M, C]` evidence, so e.g. adding tools to an agent whose model cannot call tools fails at compile time. `In`
+  * and `Out` are the built agent's input and output types: a fresh builder starts at `String`/`String`; `inputRenderer` (and `input`, see
+  * Task 2) transition `In`, `responseSchema`/`deriveResponseSchema` transition `Out`.
   */
-final class AgentBuilder[F[_], M <: AIModel] private (
+final class AgentBuilder[F[_], M <: AIModel, In, Out] private (
     makeBackend: AgentConfig[F] => AgentBackend[F],
-    val config: AgentConfig[F]
+    val config: AgentConfig[F],
+    renderInput: In => String,
+    parseOutput: String => Either[io.circe.Error, Out]
 )(implicit monad: MonadError[F]) {
 
-  private def withConfig(next: AgentConfig[F]): AgentBuilder[F, M] =
-    new AgentBuilder[F, M](makeBackend, next)
+  private def withConfig(next: AgentConfig[F]): AgentBuilder[F, M, In, Out] =
+    new AgentBuilder[F, M, In, Out](makeBackend, next, renderInput, parseOutput)
 
-  def maxIterations(value: Int): AgentBuilder[F, M] = withConfig(config.copy(maxIterations = value))
+  def maxIterations(value: Int): AgentBuilder[F, M, In, Out] = withConfig(config.copy(maxIterations = value))
 
-  def systemPrompt(buildSystemPrompt: SystemPromptParameters => String): AgentBuilder[F, M] =
+  def systemPrompt(buildSystemPrompt: SystemPromptParameters => String): AgentBuilder[F, M, In, Out] =
     withConfig(config.copy(systemPromptBuilder = Some(buildSystemPrompt)))
 
-  def systemPrompt(prompt: String): AgentBuilder[F, M] = systemPrompt(_ => prompt)
+  def systemPrompt(prompt: String): AgentBuilder[F, M, In, Out] = systemPrompt(_ => prompt)
 
-  def tools(values: Seq[AgentTool[F, _]])(implicit ev: Supports[M, Capability.ToolCalling]): AgentBuilder[F, M] =
+  def tools(values: Seq[AgentTool[F, _]])(implicit ev: Supports[M, Capability.ToolCalling]): AgentBuilder[F, M, In, Out] =
     withConfig(config.copy(userTools = values))
 
-  def tools(first: AgentTool[F, _], rest: AgentTool[F, _]*)(implicit ev: Supports[M, Capability.ToolCalling]): AgentBuilder[F, M] =
+  def tools(first: AgentTool[F, _], rest: AgentTool[F, _]*)(implicit
+      ev: Supports[M, Capability.ToolCalling]
+  ): AgentBuilder[F, M, In, Out] =
     tools(first +: rest)
 
-  def addTool(tool: AgentTool[F, _])(implicit ev: Supports[M, Capability.ToolCalling]): AgentBuilder[F, M] =
+  def addTool(tool: AgentTool[F, _])(implicit ev: Supports[M, Capability.ToolCalling]): AgentBuilder[F, M, In, Out] =
     withConfig(config.copy(userTools = config.userTools :+ tool))
 
-  def exceptionHandler(handler: ExceptionHandler): AgentBuilder[F, M] = withConfig(config.copy(exceptionHandler = handler))
+  def exceptionHandler(handler: ExceptionHandler): AgentBuilder[F, M, In, Out] = withConfig(config.copy(exceptionHandler = handler))
 
-  def responseSchema(schema: ResponseSchema[_])(implicit ev: Supports[M, Capability.StructuredOutput]): AgentBuilder[F, M] =
-    withConfig(config.copy(responseSchema = Some(schema)))
+  /** Types the agent's input: `In2` is rendered into the initial user message with the given function. */
+  def inputRenderer[In2](render: In2 => String): AgentBuilder[F, M, In2, Out] =
+    new AgentBuilder[F, M, In2, Out](makeBackend, config, render, parseOutput)
+
+  /** Types the agent's output: the final answer is requested as structured output matching the schema and parsed with its codec. */
+  def responseSchema[T](schema: ResponseSchema[T])(implicit ev: Supports[M, Capability.StructuredOutput]): AgentBuilder[F, M, In, T] =
+    new AgentBuilder[F, M, In, T](
+      makeBackend,
+      config.copy(responseSchema = Some(schema)),
+      renderInput,
+      answer => decode[T](answer)(schema.codec)
+    )
 
   def deriveResponseSchema[T](implicit
       schema: Schema[T],
       codec: Codec[T],
       ev: Supports[M, Capability.StructuredOutput]
-  ): AgentBuilder[F, M] =
-    withConfig(config.copy(responseSchema = Some(ResponseSchema.derived[T](None))))
+  ): AgentBuilder[F, M, In, T] =
+    responseSchema(ResponseSchema.derived[T](None))
 
   // NOTE: the description field is only forwarded to OpenAI. Claude's structured-output `output_config` has no description field.
   def deriveResponseSchema[T](description: String)(implicit
       schema: Schema[T],
       codec: Codec[T],
       ev: Supports[M, Capability.StructuredOutput]
-  ): AgentBuilder[F, M] =
-    withConfig(config.copy(responseSchema = Some(ResponseSchema.derived[T](Some(description)))))
+  ): AgentBuilder[F, M, In, T] =
+    responseSchema(ResponseSchema.derived[T](Some(description)))
 
   /** Appends an interceptor. Interceptors wrap stages in list order: the first added is outermost. */
-  def addInterceptor(value: AgentInterceptor[F]): AgentBuilder[F, M] =
+  def addInterceptor(value: AgentInterceptor[F]): AgentBuilder[F, M, In, Out] =
     withConfig(config.copy(interceptors = config.interceptors :+ value))
 
   /** Replaces the interceptor list. */
-  def interceptors(values: Seq[AgentInterceptor[F]]): AgentBuilder[F, M] =
+  def interceptors(values: Seq[AgentInterceptor[F]]): AgentBuilder[F, M, In, Out] =
     withConfig(config.copy(interceptors = values))
 
-  def build: Agent[F] = Agent(makeBackend(config), config)
+  def build: Agent[F, In, Out] = new LoopAgent[F, In, Out](makeBackend(config), config, renderInput, parseOutput)
 }
 
 object AgentBuilder {
 
-  def apply[F[_], M <: AIModel](makeBackend: AgentConfig[F] => AgentBackend[F])(implicit monad: MonadError[F]): AgentBuilder[F, M] =
-    new AgentBuilder[F, M](makeBackend, AgentConfig[F]())
+  def apply[F[_], M <: AIModel](
+      makeBackend: AgentConfig[F] => AgentBackend[F]
+  )(implicit monad: MonadError[F]): AgentBuilder[F, M, String, String] =
+    new AgentBuilder[F, M, String, String](makeBackend, AgentConfig[F](), identity, answer => Right(answer))
 }

--- a/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
@@ -48,7 +48,10 @@ final class AgentBuilder[F[_], M <: AIModel, In, Out] private (
     new AgentBuilder[F, M, In2, Out](makeBackend, config, render, parseOutput)
 
   /** Types the agent's input: `In2` is rendered into the initial user message as compact JSON via its circe `Encoder`, wrapped in a small
-    * fixed envelope. Use [[inputRenderer]] to control the rendering explicitly.
+    * fixed envelope — the message is exactly `"Process the following input data (JSON):"`, a blank line, and the `noSpaces` JSON (useful
+    * when asserting on prompts in tests). Use [[inputRenderer]] to control the rendering explicitly. Note that `input[String]` would
+    * JSON-quote the value (`"..."`) inside the envelope — for plain string prompts keep the default `String` input, which renders identity,
+    * or use [[inputRenderer]].
     */
   def input[In2](implicit enc: Encoder[In2]): AgentBuilder[F, M, In2, Out] =
     inputRenderer[In2](in => AgentBuilder.renderJsonInput(enc(in)))

--- a/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
@@ -1,6 +1,7 @@
 package sttp.ai.core.agent
 
 import io.circe.Codec
+import io.circe.Encoder
 import io.circe.parser.decode
 import sttp.ai.core.agent.AgentConfig.SystemPromptParameters
 import sttp.ai.core.model.{AIModel, Capability, Supports}
@@ -46,6 +47,12 @@ final class AgentBuilder[F[_], M <: AIModel, In, Out] private (
   def inputRenderer[In2](render: In2 => String): AgentBuilder[F, M, In2, Out] =
     new AgentBuilder[F, M, In2, Out](makeBackend, config, render, parseOutput)
 
+  /** Types the agent's input: `In2` is rendered into the initial user message as compact JSON via its circe `Encoder`, wrapped in a small
+    * fixed envelope. Use [[inputRenderer]] to control the rendering explicitly.
+    */
+  def input[In2](implicit enc: Encoder[In2]): AgentBuilder[F, M, In2, Out] =
+    inputRenderer[In2](in => AgentBuilder.renderJsonInput(enc(in)))
+
   /** Types the agent's output: the final answer is requested as structured output matching the schema and parsed with its codec. */
   def responseSchema[T](schema: ResponseSchema[T])(implicit ev: Supports[M, Capability.StructuredOutput]): AgentBuilder[F, M, In, T] =
     new AgentBuilder[F, M, In, T](
@@ -87,4 +94,9 @@ object AgentBuilder {
       makeBackend: AgentConfig[F] => AgentBackend[F]
   )(implicit monad: MonadError[F]): AgentBuilder[F, M, String, String] =
     new AgentBuilder[F, M, String, String](makeBackend, AgentConfig[F](), identity, answer => Right(answer))
+
+  private[agent] def renderJsonInput(json: io.circe.Json): String =
+    s"""Process the following input data (JSON):
+       |
+       |${json.noSpaces}""".stripMargin
 }

--- a/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentBuilder.scala
@@ -10,8 +10,8 @@ import sttp.tapir.Schema
 
 /** Fluent agent configuration. `M` is the model (or family of models) the agent was created with; builder methods that need a model
   * capability require `Supports[M, C]` evidence, so e.g. adding tools to an agent whose model cannot call tools fails at compile time. `In`
-  * and `Out` are the built agent's input and output types: a fresh builder starts at `String`/`String`; `inputRenderer` (and `input`, see
-  * Task 2) transition `In`, `responseSchema`/`deriveResponseSchema` transition `Out`.
+  * and `Out` are the built agent's input and output types: a fresh builder starts at `String`/`String`; `inputRenderer` and `input`
+  * transition `In`, `responseSchema`/`deriveResponseSchema` transition `Out`.
   */
 final class AgentBuilder[F[_], M <: AIModel, In, Out] private (
     makeBackend: AgentConfig[F] => AgentBackend[F],

--- a/core/src/main/scala/sttp/ai/core/agent/AgentResult.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/AgentResult.scala
@@ -9,7 +9,7 @@ object FinishReason {
 
   /** Reasons an [[AgentInterceptor]] may force a graceful final answer via [[LoopDecision.FinishNow]]. Narrowing the `FinishNow` cause to
     * this subtype keeps interceptors from misreporting loop-owned reasons (`NaturalStop`, `TokenLimit`, ...), which would silently change
-    * how `runAs` parses the answer.
+    * how the typed `run` parses the answer.
     */
   sealed trait ForcedStop extends FinishReason
 

--- a/core/src/main/scala/sttp/ai/core/agent/LoopAgent.scala
+++ b/core/src/main/scala/sttp/ai/core/agent/LoopAgent.scala
@@ -1,0 +1,205 @@
+package sttp.ai.core.agent
+
+import io.circe.parser.decode
+import sttp.client4.Backend
+import sttp.monad.MonadError
+import sttp.monad.syntax.MonadErrorOps
+
+private[agent] class LoopAgent[F[_], In, Out](
+    agentBackend: AgentBackend[F],
+    config: AgentConfig[F],
+    renderInput: In => String,
+    parseOutput: String => Either[io.circe.Error, Out]
+)(implicit protected val monad: MonadError[F])
+    extends Agent[F, In, Out] {
+  import LoopAgent.{ContinueLoop, Finished, IterationOutcome}
+
+  private val toolMap = config.userTools.map(t => t.name -> t).toMap
+
+  private val interceptor: AgentInterceptor[F] = AgentInterceptor.compose(config.interceptors)
+
+  def run(in: In)(backend: Backend[F]): F[AgentResult[Either[AgentFailure, Out]]] =
+    runRaw(renderInput(in))(backend).map { res =>
+      val parsed: Either[AgentFailure, Out] = res.finishReason match {
+        case FinishReason.NaturalStop =>
+          parseOutput(res.finalAnswer).left.map(e => AgentParseError(res.finalAnswer, e))
+        case FinishReason.MaxIterations | _: FinishReason.ForcedStop =>
+          // A forced final iteration withholds tools and keeps schema guidance, so the answer may still be valid.
+          parseOutput(res.finalAnswer).left.map(e => AgentIncomplete(res.finalAnswer, res.finishReason, Some(e)))
+        case FinishReason.TokenLimit | FinishReason.Error(_) =>
+          Left(AgentIncomplete(res.finalAnswer, res.finishReason, parseError = None))
+      }
+      AgentResult(parsed, res.iterations, res.toolCalls, res.finishReason, res.usage, res.llmCalls)
+    }
+
+  private def runRaw(
+      initialPrompt: String
+  )(backend: Backend[F]): F[AgentResult[String]] = {
+    val initialHistory = ConversationHistory.withInitialPrompt(initialPrompt)
+
+    def loop(
+        history: ConversationHistory,
+        iteration: Int,
+        records: Seq[ToolCallRecord],
+        usage: TokenUsage,
+        llmCalls: Seq[LlmCallUsage]
+    ): F[AgentResult[String]] =
+      // Safety net for maxIterations <= 0. For maxIterations >= 1 this is unreachable: the final-iteration branch
+      // below always returns at iteration == maxIterations - 1, so the loop never recurses past it.
+      if (iteration >= config.maxIterations) {
+        monad.unit(
+          AgentResult(extractFinalAnswer(history), iteration, records, FinishReason.MaxIterations, usage, llmCalls)
+        )
+      } else {
+        val decision = interceptor.decide(AgentRunState(iteration, config.maxIterations, usage, llmCalls))
+        val info = IterationInfo(iteration + 1, config.maxIterations, forcedFinal = decision != LoopDecision.Continue)
+        interceptor
+          .aroundIteration(IterationContext(info))(runIteration(history, iteration, records, usage, llmCalls, decision, backend))
+          .flatMap {
+            case ContinueLoop(h, r, u, lc) => loop(h, iteration + 1, r, u, lc)
+            case Finished(result)          => monad.unit(result)
+          }
+      }
+
+    loop(initialHistory, 0, Seq.empty, TokenUsage.Zero, Seq.empty)
+  }
+
+  private def runIteration(
+      history: ConversationHistory,
+      iteration: Int,
+      records: Seq[ToolCallRecord],
+      usage: TokenUsage,
+      llmCalls: Seq[LlmCallUsage],
+      decision: LoopDecision,
+      backend: Backend[F]
+  ): F[IterationOutcome] = {
+    val isLastByCount = iteration == config.maxIterations - 1
+    val forcedCause: Option[FinishReason.ForcedStop] = decision match {
+      case LoopDecision.FinishNow(cause, _) => Some(cause)
+      case LoopDecision.Continue            => None
+    }
+    val isFinalIteration = isLastByCount || forcedCause.nonEmpty
+
+    val requestHistory = decision match {
+      case LoopDecision.FinishNow(_, instruction) =>
+        // No iteration marker on a forced-final request: "[Iteration 3 of 10]" would contradict the injected instruction.
+        history.addUserPrompt(instruction)
+      case LoopDecision.Continue =>
+        if (iteration > 0) history.addIterationMarker(iteration + 1, config.maxIterations) else history
+    }
+
+    val info = IterationInfo(iteration + 1, config.maxIterations, forcedFinal = forcedCause.nonEmpty)
+    val includeTools = !isFinalIteration
+
+    interceptor
+      .aroundLlmCall(LlmCallContext(requestHistory, includeTools, info))(
+        agentBackend.sendRequest(requestHistory, backend, includeTools, info)
+      )
+      .flatMap { response =>
+        val callUsage = response.usage.getOrElse(TokenUsage.Zero)
+        val newUsage = usage + callUsage
+        val newLlmCalls = llmCalls :+ LlmCallUsage(response.model, callUsage)
+
+        if (response.stopReason == StopReason.MaxTokens) {
+          monad.unit(
+            Finished(AgentResult(response.textContent, iteration + 1, records, FinishReason.TokenLimit, newUsage, newLlmCalls))
+          )
+        } else if (isFinalIteration) {
+          // Tools were not offered on the final iteration, so any tool calls in the response are spurious and must not
+          // be executed. Force the final answer: prefer the model's text, fall back to the last tool result / assistant text.
+          val finalAnswer = if (response.textContent.nonEmpty) response.textContent else extractFinalAnswer(history)
+          // MaxIterations takes precedence when the forced last iteration and a FinishNow coincide.
+          val reason = if (isLastByCount) FinishReason.MaxIterations else forcedCause.getOrElse(FinishReason.MaxIterations)
+          monad.unit(Finished(AgentResult(finalAnswer, iteration + 1, records, reason, newUsage, newLlmCalls)))
+        } else if (response.toolCalls.isEmpty) {
+          // No tool calls - the agent has produced its final answer, so complete the loop.
+          monad.unit(
+            Finished(AgentResult(response.textContent, iteration + 1, records, FinishReason.NaturalStop, newUsage, newLlmCalls))
+          )
+        } else {
+          val updatedHistory = history.addAssistantResponse(response.textContent, response.toolCalls)
+          runToolCalls(response.toolCalls.toList, iteration + 1, updatedHistory, records).map { case (h, r) =>
+            ContinueLoop(h, r, newUsage, newLlmCalls)
+          }
+        }
+      }
+  }
+
+  private def runToolCalls(
+      toolCalls: List[ToolCall],
+      iteration: Int,
+      history: ConversationHistory,
+      results: Seq[ToolCallRecord]
+  ): F[(ConversationHistory, Seq[ToolCallRecord])] =
+    toolCalls match {
+      case Nil              => monad.unit((history, results))
+      case toolCall :: rest =>
+        for {
+          result <- interceptor.aroundToolCall(ToolCallContext(toolCall, iteration))(runToolCall(toolCall, iteration))
+          updatedHistory = history.addToolResult(result)
+          acc <- runToolCalls(rest, iteration, updatedHistory, results :+ result)
+        } yield acc
+    }
+
+  private def runToolCall(
+      toolCall: ToolCall,
+      iteration: Int
+  ): F[ToolCallRecord] = {
+    val output = toolMap.get(toolCall.toolName) match {
+      case Some(tool) => executeTool(tool, toolCall)
+      case None       => monad.unit(s"Tool not found: ${toolCall.toolName}")
+    }
+
+    output.map { result =>
+      ToolCallRecord(
+        id = toolCall.id,
+        toolName = toolCall.toolName,
+        input = toolCall.input,
+        output = result,
+        iteration = iteration
+      )
+    }
+  }
+
+  private def executeTool[T](tool: AgentTool[F, T], toolCall: ToolCall): F[String] =
+    monad
+      .eval(decode[T](toolCall.input)(tool.codec).fold(throw _, identity))
+      .map[Either[String, T]](Right(_))
+      .handleError { case parseException: Exception =>
+        config.exceptionHandler.handleParseError(toolCall.toolName, toolCall.input, parseException) match {
+          case Left(errorMessage) => monad.unit(Left(errorMessage))
+          case Right(ex)          => monad.error(ex)
+        }
+      }
+      .flatMap {
+        case Left(errorMessage) => monad.unit(errorMessage)
+        case Right(typedInput)  =>
+          tool.execute(typedInput).handleError { case e: Exception =>
+            config.exceptionHandler.handleToolException(toolCall.toolName, e) match {
+              case Left(errorMessage) => monad.unit(errorMessage)
+              case Right(ex)          => monad.error(ex)
+            }
+          }
+      }
+
+  private def extractFinalAnswer(history: ConversationHistory): String =
+    history.entries.reverseIterator
+      .collectFirst {
+        case ConversationEntry.AssistantResponse(content, _) if content.nonEmpty => content
+        case ConversationEntry.ToolResult(_, _, result)                          => result
+      }
+      .getOrElse("No answer available")
+}
+
+object LoopAgent {
+  // Top-level (not inner) classes so matches on them are runtime-checkable — inner classes trigger
+  // "outer reference cannot be checked" warnings on Scala 2.13.
+  private[agent] sealed trait IterationOutcome
+  private[agent] final case class ContinueLoop(
+      history: ConversationHistory,
+      records: Seq[ToolCallRecord],
+      usage: TokenUsage,
+      llmCalls: Seq[LlmCallUsage]
+  ) extends IterationOutcome
+  private[agent] final case class Finished(result: AgentResult[String]) extends IterationOutcome
+}

--- a/core/src/test/scala/sttp/ai/core/agent/AgentBuilderCapabilitySpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentBuilderCapabilitySpec.scala
@@ -32,7 +32,7 @@ object AgentBuilderCapabilitySpecFixtures {
     ): Identity[AgentResponse] = AgentResponse("done", Seq.empty, StopReason.EndTurn)
   }
 
-  def newBuilder[M <: AIModel]: AgentBuilder[Identity, M] =
+  def newBuilder[M <: AIModel]: AgentBuilder[Identity, M, String, String] =
     AgentBuilder[Identity, M](_ => noopBackend)(IdentityMonad)
 
   case class Out(answer: String)

--- a/core/src/test/scala/sttp/ai/core/agent/AgentCompositionSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentCompositionSpec.scala
@@ -1,0 +1,147 @@
+package sttp.ai.core.agent
+
+import io.circe.Codec
+import io.circe.generic.semiauto.deriveCodec
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.core.model.{AIModel, Capability}
+import sttp.client4.testing.SyncBackendStub
+import sttp.monad.IdentityMonad
+import sttp.shared.Identity
+import sttp.tapir.Schema
+
+class AgentCompositionSpec extends AnyFlatSpec with Matchers {
+
+  case object TestModel extends AIModel with Capability.ToolCalling with Capability.StructuredOutput {
+    val value: String = "test-model"
+  }
+
+  class RecordingBackend(responses: AgentResponse*) extends AgentBackend[Identity] {
+    private var callCount = 0
+    var receivedHistories: Seq[ConversationHistory] = Seq.empty
+    override def tools: Seq[AgentTool[Identity, _]] = Seq.empty
+    override def systemPrompt: Option[String] = None
+    override def sendRequest(
+        history: ConversationHistory,
+        backend: sttp.client4.Backend[Identity],
+        includeTools: Boolean,
+        iterationInfo: IterationInfo
+    ): Identity[AgentResponse] = {
+      receivedHistories = receivedHistories :+ history
+      val response = if (callCount < responses.length) responses(callCount) else responses.last
+      callCount += 1
+      response
+    }
+  }
+
+  private val backend = SyncBackendStub
+
+  case class Location(city: String)
+  implicit val locationCodec: Codec[Location] = deriveCodec
+  implicit val locationSchema: Schema[Location] = Schema.derived
+
+  private def usage(in: Long, out: Long): TokenUsage = TokenUsage(Tokens(in), Tokens(out), Tokens.Zero, Tokens.Zero)
+
+  private def builder(stub: RecordingBackend) = AgentBuilder[Identity, TestModel.type](_ => stub)(IdentityMonad)
+
+  "andThen" should "feed A's typed output to B as a fresh conversation" in {
+    val stubA = new RecordingBackend(
+      AgentResponse("""{"city":"Paris"}""", Seq.empty, StopReason.EndTurn, usage = Some(usage(10, 5)), model = Some("m"))
+    )
+    val stubB = new RecordingBackend(
+      AgentResponse("Paris is lovely", Seq.empty, StopReason.EndTurn, usage = Some(usage(20, 8)), model = Some("m"))
+    )
+    val a: Agent[Identity, String, Location] = builder(stubA).deriveResponseSchema[Location].build
+    val b: Agent[Identity, Location, String] = builder(stubB).input[Location].build
+
+    val result = a.andThen(b).run("Where should I go?")(backend)
+
+    result.finalAnswer shouldBe Right("Paris is lovely")
+    // B starts fresh: exactly one request, whose only user prompt is B's rendering of A's output
+    stubB.receivedHistories should have size 1
+    stubB.receivedHistories.head.entries shouldBe Seq(
+      ConversationEntry.UserPrompt(
+        s"""Process the following input data (JSON):
+           |
+           |{"city":"Paris"}""".stripMargin
+      )
+    )
+  }
+
+  it should "aggregate metadata across both stages" in {
+    val stubA = new RecordingBackend(
+      AgentResponse("""{"city":"Paris"}""", Seq.empty, StopReason.EndTurn, usage = Some(usage(10, 5)), model = Some("m"))
+    )
+    val stubB = new RecordingBackend(
+      AgentResponse("done", Seq.empty, StopReason.EndTurn, usage = Some(usage(20, 8)), model = Some("m"))
+    )
+    val a = builder(stubA).deriveResponseSchema[Location].build
+    val b = builder(stubB).input[Location].build
+
+    val result = a.andThen(b).run("go")(backend)
+
+    result.iterations shouldBe 2
+    result.usage shouldBe usage(30, 13)
+    result.llmCalls should have size 2
+    result.finishReason shouldBe FinishReason.NaturalStop
+  }
+
+  it should "short-circuit when the first stage fails, never running the second" in {
+    val stubA = new RecordingBackend(
+      AgentResponse("""{"city":"Par""", Seq.empty, StopReason.MaxTokens, usage = Some(usage(10, 5)), model = Some("m"))
+    )
+    val stubB = new RecordingBackend(AgentResponse("unreachable", Seq.empty, StopReason.EndTurn))
+    val a = builder(stubA).deriveResponseSchema[Location].build
+    val b = builder(stubB).input[Location].build
+
+    val result = a.andThen(b).run("go")(backend)
+
+    result.finalAnswer shouldBe Left(AgentIncomplete("""{"city":"Par""", FinishReason.TokenLimit, parseError = None))
+    result.finishReason shouldBe FinishReason.TokenLimit
+    result.usage shouldBe usage(10, 5)
+    stubB.receivedHistories shouldBe empty
+  }
+
+  "map" should "transform Right results and leave failures untouched" in {
+    val ok = builder(new RecordingBackend(AgentResponse("""{"city":"Paris"}""", Seq.empty, StopReason.EndTurn)))
+      .deriveResponseSchema[Location]
+      .build
+      .map(_.city.toUpperCase)
+    ok.run("go")(backend).finalAnswer shouldBe Right("PARIS")
+
+    val failed = builder(new RecordingBackend(AgentResponse("cut", Seq.empty, StopReason.MaxTokens)))
+      .deriveResponseSchema[Location]
+      .build
+      .map(_.city.toUpperCase)
+    failed.run("go")(backend).finalAnswer shouldBe Left(AgentIncomplete("cut", FinishReason.TokenLimit, parseError = None))
+  }
+
+  "contramap" should "adapt the input before the agent runs" in {
+    val stub = new RecordingBackend(AgentResponse("ok", Seq.empty, StopReason.EndTurn))
+    val agent: Agent[Identity, Int, String] = builder(stub).build.contramap((n: Int) => s"count: $n")
+
+    agent.run(7)(backend).finalAnswer shouldBe Right("ok")
+    stub.receivedHistories.head.entries shouldBe Seq(ConversationEntry.UserPrompt("count: 7"))
+  }
+
+  "andThen with mismatched types" should "not compile" in
+    assertTypeError("""
+      val a: Agent[Identity, String, Location] = ???
+      val b: Agent[Identity, Int, String] = ???
+      a.andThen(b)
+    """)
+
+  "a three-stage chain" should "compose left to right" in {
+    val stubA = new RecordingBackend(AgentResponse("""{"city":"Paris"}""", Seq.empty, StopReason.EndTurn))
+    val stubB = new RecordingBackend(AgentResponse("nice", Seq.empty, StopReason.EndTurn))
+    val stubC = new RecordingBackend(AgentResponse("final", Seq.empty, StopReason.EndTurn))
+    val a = builder(stubA).deriveResponseSchema[Location].build
+    val b = builder(stubB).input[Location].build
+    val c = builder(stubC).build
+
+    val result = a.andThen(b).andThen(c).run("go")(backend)
+
+    result.finalAnswer shouldBe Right("final")
+    result.iterations shouldBe 3
+  }
+}

--- a/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorLoopSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentInterceptorLoopSpec.scala
@@ -12,7 +12,7 @@ import sttp.tapir.Schema
 
 class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
 
-  case object TestModel extends AIModel with Capability.ToolCalling {
+  case object TestModel extends AIModel with Capability.ToolCalling with Capability.StructuredOutput {
     val value: String = "test-model"
   }
 
@@ -57,7 +57,7 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
   private def finalResponse(text: String, u: Option[TokenUsage]): AgentResponse =
     AgentResponse(text, Seq.empty, StopReason.EndTurn, usage = u, model = Some("test-model"))
 
-  private def build(stub: StubAgentBackend, interceptors: Seq[AgentInterceptor[Identity]]): Agent[Identity] =
+  private def build(stub: StubAgentBackend, interceptors: Seq[AgentInterceptor[Identity]]): Agent[Identity, String, String] =
     AgentBuilder[Identity, TestModel.type](_ => stub)(IdentityMonad)
       .maxIterations(5)
       .tools(dummyTool)
@@ -74,7 +74,7 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
     )
     val result = build(stub, Seq.empty).run("Test")(backend)
 
-    result.finalAnswer shouldBe "done"
+    result.finalAnswer shouldBe Right("done")
     result.usage shouldBe usage(150, 30)
     result.llmCalls shouldBe Seq(
       LlmCallUsage(Some("test-model"), usage(100, 20)),
@@ -99,7 +99,7 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
     val stub = new StubAgentBackend(
       Seq(toolResponse("call_1", Some(usage(1, 1))), finalResponse("done", Some(usage(1, 1))))
     )
-    build(stub, Seq(new Rec("a"), new Rec("b"))).run("Test")(backend).finalAnswer shouldBe "done"
+    build(stub, Seq(new Rec("a"), new Rec("b"))).run("Test")(backend).finalAnswer shouldBe Right("done")
 
     log.toList shouldBe List(
       "a:iter(1):in",
@@ -142,7 +142,7 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
     val stub = new StubAgentBackend(Seq(finalResponse("real answer", None)))
     val result = build(stub, Seq(shortCircuit)).run("Test")(backend)
 
-    result.finalAnswer shouldBe "cached answer"
+    result.finalAnswer shouldBe Right("cached answer")
     result.usage shouldBe usage(1, 1)
     stub.receivedHistories shouldBe empty // the backend was never reached
   }
@@ -164,7 +164,7 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
     val result = build(stub, Seq(steer)).run("Test")(backend)
 
     result.finishReason shouldBe FinishReason.BudgetExceeded
-    result.finalAnswer shouldBe "budget answer"
+    result.finalAnswer shouldBe Right("budget answer")
     result.iterations shouldBe 2
     // The forced-final request withheld tools and contained the injected instruction:
     stub.receivedIncludeTools shouldBe Seq(true, false)
@@ -193,7 +193,7 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
 
     val result = agent.run("Test")(backend)
     result.finishReason shouldBe FinishReason.MaxIterations
-    result.finalAnswer shouldBe "last answer"
+    result.finalAnswer shouldBe Right("last answer")
   }
 
   it should "not consult tools nor execute spurious tool calls on a FinishNow iteration" in {
@@ -209,7 +209,7 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
 
     result.finishReason shouldBe FinishReason.BudgetExceeded
     result.toolCalls should have size 1 // only the first iteration's tool call
-    result.finalAnswer shouldBe "dummy result" // extractFinalAnswer fallback: last tool result
+    result.finalAnswer shouldBe Right("dummy result") // extractFinalAnswer fallback: last tool result
   }
 
   it should "enforce a token budget end-to-end via BudgetInterceptor" in {
@@ -225,7 +225,7 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
     val result = build(stub, Seq(budget)).run("Test")(backend)
 
     result.finishReason shouldBe FinishReason.BudgetExceeded
-    result.finalAnswer shouldBe "partial answer"
+    result.finalAnswer shouldBe Right("partial answer")
     result.iterations shouldBe 3 // breach detected after call 2 (240 >= 200), forced final on iteration 3
     stub.receivedIncludeTools shouldBe Seq(true, true, false)
     stub.receivedHistories.last.entries should contain(ConversationEntry.UserPrompt(BudgetInterceptor.defaultInstruction))
@@ -237,16 +237,17 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
     val result = build(stub, Seq(steer)).run("Test")(backend)
 
     result.finishReason shouldBe FinishReason.BudgetExceeded
-    result.finalAnswer shouldBe "immediate answer"
+    result.finalAnswer shouldBe Right("immediate answer")
     result.iterations shouldBe 1
     stub.receivedIncludeTools shouldBe Seq(false)
     stub.receivedHistories.last.entries should contain(ConversationEntry.UserPrompt("answer immediately"))
   }
 
-  it should "let runAs parse a budget-forced final answer like a max-iterations one" in {
+  it should "parse a budget-forced final answer like a max-iterations one" in {
     import sttp.ai.core.agent.interceptor.BudgetInterceptor
     case class Out(x: Int)
     implicit val outCodec: Codec[Out] = deriveCodec
+    implicit val outSchema: Schema[Out] = Schema.derived
 
     val stub = new StubAgentBackend(
       Seq(
@@ -255,7 +256,13 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
       )
     )
     val budget = new BudgetInterceptor[Identity](maxTotalTokens = Some(Tokens(100L)))
-    val result = build(stub, Seq(budget)).runAs[Out]("Test")(backend)
+    val result = AgentBuilder[Identity, TestModel.type](_ => stub)(IdentityMonad)
+      .maxIterations(5)
+      .tools(dummyTool)
+      .interceptors(Seq(budget))
+      .deriveResponseSchema[Out]
+      .build
+      .run("Test")(backend)
 
     result.finishReason shouldBe FinishReason.BudgetExceeded
     result.finalAnswer shouldBe Right(Out(5)) // BudgetExceeded is parse-attempted, not rejected outright
@@ -311,7 +318,7 @@ class AgentInterceptorLoopSpec extends AnyFlatSpec with Matchers {
 
     val result = Await.result(agent.run("Test")(sttp.client4.testing.BackendStub[Future](futureMonad)), 10.seconds)
 
-    result.finalAnswer shouldBe "done"
+    result.finalAnswer shouldBe Right("done")
     result.usage shouldBe usage(150, 30)
     log.toList shouldBe List("llm:in", "llm:out", "tool:in", "tool:out", "llm:in", "llm:out")
   }

--- a/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/AgentSpec.scala
@@ -5,7 +5,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
-import io.circe.parser.decode
 import sttp.ai.core.model.{AIModel, Capability}
 import sttp.client4.testing.SyncBackendStub
 import sttp.monad.IdentityMonad
@@ -61,10 +60,10 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     s"Result: ${input.a + input.b}"
   }
 
-  private def agentBuilder(responses: AgentResponse*): AgentBuilder[Identity, TestModel.type] =
+  private def agentBuilder(responses: AgentResponse*): AgentBuilder[Identity, TestModel.type, String, String] =
     AgentBuilder[Identity, TestModel.type](_ => new StubAgentBackend(responses))(IdentityMonad)
 
-  private def runLoop(builder: AgentBuilder[Identity, TestModel.type]): AgentResult[String] =
+  private def runLoop(builder: AgentBuilder[Identity, TestModel.type, String, String]): AgentResult[Either[AgentFailure, String]] =
     builder.build.run("Test")(backend)
 
   case class DummyInput()
@@ -116,14 +115,14 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     result.toolCalls should have size 2
     result.iterations shouldBe 3
     result.finishReason shouldBe FinishReason.MaxIterations
-    result.finalAnswer shouldBe "final answer"
+    result.finalAnswer shouldBe Right("final answer")
   }
 
   it should "complete the loop when the response has no tool calls and empty text" in {
     val result = runLoop(agentBuilder(AgentResponse("", Seq.empty, StopReason.EndTurn)))
 
     result.finishReason shouldBe FinishReason.NaturalStop
-    result.finalAnswer shouldBe ""
+    result.finalAnswer shouldBe Right("")
     result.iterations shouldBe 1
     result.toolCalls shouldBe empty
   }
@@ -296,7 +295,7 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     )
 
     result.finishReason shouldBe FinishReason.MaxIterations
-    result.finalAnswer shouldBe "Third response"
+    result.finalAnswer shouldBe Right("Third response")
     result.iterations shouldBe 3
   }
 
@@ -447,13 +446,13 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     ).deriveResponseSchema[WeatherSummary].build.run("What's the weather?")(backend)
 
     result.finishReason shouldBe FinishReason.NaturalStop: Unit
-    decode[WeatherSummary](result.finalAnswer) shouldBe Right(WeatherSummary("Krakow", 12.0, "sunny"))
+    result.finalAnswer shouldBe Right(WeatherSummary("Krakow", 12.0, "sunny"))
   }
 
-  "Agent.runAs[T]" should "return Right(T) when the model emits a well-formed structured payload" in {
+  "Agent typed run" should "return Right(T) when the model emits a well-formed structured payload" in {
     val result = agentBuilder(
       AgentResponse("""{"city":"Krakow","temp_c":12.0,"conditions":"sunny"}""", Seq.empty, StopReason.EndTurn)
-    ).deriveResponseSchema[WeatherSummary].build.runAs[WeatherSummary]("What's the weather?")(backend)
+    ).deriveResponseSchema[WeatherSummary].build.run("What's the weather?")(backend)
 
     result.finishReason shouldBe FinishReason.NaturalStop: Unit
     result.iterations shouldBe 1: Unit
@@ -463,7 +462,7 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
   it should "return Left(AgentParseError) preserving the trace when the answer can't be parsed as T" in {
     val result = agentBuilder(
       AgentResponse("""{"wrong":"shape"}""", Seq.empty, StopReason.EndTurn)
-    ).deriveResponseSchema[WeatherSummary].build.runAs[WeatherSummary]("What's the weather?")(backend)
+    ).deriveResponseSchema[WeatherSummary].build.run("What's the weather?")(backend)
 
     result.iterations shouldBe 1: Unit
     result.finishReason shouldBe FinishReason.NaturalStop: Unit
@@ -489,7 +488,7 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
       .tools(dummyTool)
       .deriveResponseSchema[WeatherSummary]
       .build
-      .runAs[WeatherSummary]("What's the weather?")(backend)
+      .run("What's the weather?")(backend)
 
     result.finishReason shouldBe FinishReason.MaxIterations: Unit
     result.finalAnswer shouldBe Right(WeatherSummary("Krakow", 12.0, "sunny"))
@@ -506,7 +505,7 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     ).tools(dummyTool)
       .deriveResponseSchema[WeatherSummary]
       .build
-      .runAs[WeatherSummary]("What's the weather?")(backend)
+      .run("What's the weather?")(backend)
 
     result.finishReason shouldBe FinishReason.MaxIterations: Unit
     result.finalAnswer.isLeft shouldBe true: Unit
@@ -522,7 +521,7 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
   it should "return Left(AgentIncomplete) without attempting a parse when the token limit is hit" in {
     val result = agentBuilder(
       AgentResponse("""{"city":"Krakow","temp_c":12.0,"conditions":"sunny"}""", Seq.empty, StopReason.MaxTokens)
-    ).deriveResponseSchema[WeatherSummary].build.runAs[WeatherSummary]("What's the weather?")(backend)
+    ).deriveResponseSchema[WeatherSummary].build.run("What's the weather?")(backend)
 
     result.finishReason shouldBe FinishReason.TokenLimit: Unit
     result.finalAnswer shouldBe Left(
@@ -534,7 +533,7 @@ class AgentSpec extends AnyFlatSpec with Matchers with OptionValues {
     val result = runLoop(agentBuilder(AgentResponse("partial answer", Seq.empty, StopReason.MaxTokens)))
 
     result.finishReason shouldBe FinishReason.TokenLimit
-    result.finalAnswer shouldBe "partial answer"
+    result.finalAnswer shouldBe Left(AgentIncomplete("partial answer", FinishReason.TokenLimit, parseError = None))
     result.iterations shouldBe 1
   }
 

--- a/core/src/test/scala/sttp/ai/core/agent/InputRenderingSpec.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/InputRenderingSpec.scala
@@ -1,0 +1,70 @@
+package sttp.ai.core.agent
+
+import io.circe.Codec
+import io.circe.generic.semiauto.deriveCodec
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.ai.core.model.{AIModel, Capability}
+import sttp.client4.testing.SyncBackendStub
+import sttp.monad.IdentityMonad
+import sttp.shared.Identity
+
+class InputRenderingSpec extends AnyFlatSpec with Matchers {
+
+  case object TestModel extends AIModel with Capability.ToolCalling with Capability.StructuredOutput {
+    val value: String = "test-model"
+  }
+
+  class RecordingBackend extends AgentBackend[Identity] {
+    var receivedHistories: Seq[ConversationHistory] = Seq.empty
+    override def tools: Seq[AgentTool[Identity, _]] = Seq.empty
+    override def systemPrompt: Option[String] = None
+    override def sendRequest(
+        history: ConversationHistory,
+        backend: sttp.client4.Backend[Identity],
+        includeTools: Boolean,
+        iterationInfo: IterationInfo
+    ): Identity[AgentResponse] = {
+      receivedHistories = receivedHistories :+ history
+      AgentResponse("ok", Seq.empty, StopReason.EndTurn)
+    }
+  }
+
+  case class CityQuery(city: String, days: Int)
+  implicit val cityQueryCodec: Codec[CityQuery] = deriveCodec
+
+  private def firstPrompt(stub: RecordingBackend): String =
+    stub.receivedHistories.head.entries.collectFirst { case ConversationEntry.UserPrompt(content) => content }.get
+
+  "input[In] (JSON default)" should "render the input as JSON inside the standard envelope" in {
+    val stub = new RecordingBackend
+    val agent = AgentBuilder[Identity, TestModel.type](_ => stub)(IdentityMonad).input[CityQuery].build
+
+    agent.run(CityQuery("Paris", 3))(SyncBackendStub): Unit
+
+    firstPrompt(stub) shouldBe
+      s"""Process the following input data (JSON):
+         |
+         |{"city":"Paris","days":3}""".stripMargin
+  }
+
+  "String input (default)" should "render identically with no envelope" in {
+    val stub = new RecordingBackend
+    val agent = AgentBuilder[Identity, TestModel.type](_ => stub)(IdentityMonad).build
+
+    agent.run("plain prompt")(SyncBackendStub): Unit
+
+    firstPrompt(stub) shouldBe "plain prompt"
+  }
+
+  "inputRenderer" should "use the explicit rendering" in {
+    val stub = new RecordingBackend
+    val agent = AgentBuilder[Identity, TestModel.type](_ => stub)(IdentityMonad)
+      .inputRenderer[CityQuery](q => s"Weather for ${q.city} over ${q.days} days, please.")
+      .build
+
+    agent.run(CityQuery("Paris", 3))(SyncBackendStub): Unit
+
+    firstPrompt(stub) shouldBe "Weather for Paris over 3 days, please."
+  }
+}

--- a/core/src/test/scala/sttp/ai/core/agent/integration/AgentIntegrationSpecBase.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/integration/AgentIntegrationSpecBase.scala
@@ -14,13 +14,13 @@ abstract class AgentIntegrationSpecBase extends AnyFlatSpec with Matchers {
 
   def providerName: String
   def apiKeyEnvVar: String
-  def createAgent(maxIterations: Int, tools: Seq[AgentTool[Identity, _]]): Agent[Identity]
+  def createAgent(maxIterations: Int, tools: Seq[AgentTool[Identity, _]]): Agent[Identity, String, String]
 
   def createTypedAgent[T](
       maxIterations: Int,
       tools: Seq[AgentTool[Identity, _]],
       responseSchema: ResponseSchema[T]
-  ): Agent[Identity] =
+  ): Agent[Identity, String, T] =
     cancel(s"$providerName typed agent factory not implemented for this spec")
 
   protected val maybeApiKey: Option[String] = sys.env.get(apiKeyEnvVar)
@@ -67,7 +67,10 @@ abstract class AgentIntegrationSpecBase extends AnyFlatSpec with Matchers {
     }
   }
 
-  protected def assertToolCalled(result: AgentResult[String], toolName: String, minTimes: Int = 1)(implicit
+  protected def answerOrFail(result: AgentResult[Either[AgentFailure, String]]): String =
+    result.finalAnswer.fold(f => fail(s"agent did not produce a final answer: $f"), identity)
+
+  protected def assertToolCalled(result: AgentResult[_], toolName: String, minTimes: Int = 1)(implicit
       prettifier: Prettifier,
       pos: source.Position
   ): Unit = {
@@ -78,13 +81,15 @@ abstract class AgentIntegrationSpecBase extends AnyFlatSpec with Matchers {
     )
   }
 
-  protected def assertMinIterations(result: AgentResult[String], min: Int)(implicit prettifier: Prettifier, pos: source.Position): Unit =
+  protected def assertMinIterations(result: AgentResult[_], min: Int)(implicit prettifier: Prettifier, pos: source.Position): Unit =
     assert(
       result.iterations >= min,
       s"Should have at least $min iterations, but had ${result.iterations}"
     )
 
-  def withAgent[T](maxIter: Int, tools: Seq[AgentTool[Identity, _]])(test: (Agent[Identity], Backend[Identity]) => T): T = {
+  def withAgent[T](maxIter: Int, tools: Seq[AgentTool[Identity, _]])(
+      test: (Agent[Identity, String, String], Backend[Identity]) => T
+  ): T = {
     if (maybeApiKey.isEmpty) {
       cancel(s"$apiKeyEnvVar not defined - skipping integration test")
     }
@@ -108,7 +113,7 @@ abstract class AgentIntegrationSpecBase extends AnyFlatSpec with Matchers {
 
     assertMinIterations(result, 3)
     assertToolCalled(result, "calculator", minTimes = 3)
-    assertContainsAny(result.finalAnswer, "130", "one hundred thirty", "hundred and thirty")
+    assertContainsAny(answerOrFail(result), "130", "one hundred thirty", "hundred and thirty")
     result.finishReason shouldBe FinishReason.NaturalStop
     result.usage.totalTokens.value should be > 0L
     result.llmCalls should not be empty
@@ -122,8 +127,8 @@ abstract class AgentIntegrationSpecBase extends AnyFlatSpec with Matchers {
 
     assertToolCalled(result, "get_weather", minTimes = 3)
     assertToolCalled(result, "calculator")
-    assertContainsAll(result.finalAnswer, "london", "paris", "berlin")
-    assertContainsAny(result.finalAnswer, "100", "one hundred")
+    assertContainsAll(answerOrFail(result), "london", "paris", "berlin")
+    assertContainsAny(answerOrFail(result), "100", "one hundred")
     ()
   }
 
@@ -138,8 +143,8 @@ abstract class AgentIntegrationSpecBase extends AnyFlatSpec with Matchers {
     assertMinIterations(result, 2)
     assertToolCalled(result, "calculator", minTimes = 2)
     assertToolCalled(result, "get_weather")
-    assertContainsAny(result.finalAnswer, "50", "fifty")
-    assertContainsAny(result.finalAnswer, "tokyo")
+    assertContainsAny(answerOrFail(result), "50", "fifty")
+    assertContainsAny(answerOrFail(result), "tokyo")
     ()
   }
 
@@ -152,7 +157,7 @@ abstract class AgentIntegrationSpecBase extends AnyFlatSpec with Matchers {
 
     assertMinIterations(result, 3)
     assertToolCalled(result, "calculator", minTimes = 3)
-    assertContainsAny(result.finalAnswer, "75", "seventy")
+    assertContainsAny(answerOrFail(result), "75", "seventy")
     ()
   }
 
@@ -175,7 +180,7 @@ abstract class AgentIntegrationSpecBase extends AnyFlatSpec with Matchers {
       assertToolCalled(result, "calculator", minTimes = 1)
       result.iterations shouldBe 2
       result.finishReason shouldBe FinishReason.MaxIterations
-      result.finalAnswer should not be empty
+      answerOrFail(result) should not be empty
       ()
     }
 
@@ -190,7 +195,7 @@ abstract class AgentIntegrationSpecBase extends AnyFlatSpec with Matchers {
       val rs = ResponseSchema.derived[TripSummary]()
       val agent = createTypedAgent(maxIterations = 6, tools = Seq(weatherTool, calculatorTool), responseSchema = rs)
 
-      val result = agent.runAs[TripSummary](
+      val result = agent.run(
         "What's the weather in Paris? Also, what is 15 multiplied by 3? Then summarise both into the structured response."
       )(backend)
 

--- a/core/src/test/scala/sttp/ai/core/agent/integration/AgentIntegrationSpecBase.scala
+++ b/core/src/test/scala/sttp/ai/core/agent/integration/AgentIntegrationSpecBase.scala
@@ -188,7 +188,7 @@ abstract class AgentIntegrationSpecBase extends AnyFlatSpec with Matchers {
   implicit val tripSummaryCodec: Codec[TripSummary] = deriveCodec
   implicit val tripSummarySchema: Schema[TripSummary] = Schema.derived
 
-  it should "return a typed structured answer via runAs[T]" in {
+  it should "return a typed structured answer via a typed run" in {
     if (maybeApiKey.isEmpty) cancel(s"$apiKeyEnvVar not defined - skipping integration test")
     val backend = DefaultSyncBackend()
     try {

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -10,7 +10,7 @@ val agent = OpenAIAgent
   .maxIterations(10)                               // Max reasoning steps
   .systemPrompt("Custom prompt")                   // Optional instructions
   .tools(tool1, tool2)                             // Your tools
-  .deriveResponseSchema[T]                          // Optional typed result (see runAs[T] below)
+  .deriveResponseSchema[T]                          // (fixes the agent's output type — see typed input and output in tools.md)
   .build
 ```
 

--- a/docs/agents/custom-backends.md
+++ b/docs/agents/custom-backends.md
@@ -62,7 +62,12 @@ object CatsEffectExample extends IOApp.Simple:
     val agent = OpenAIAgent.builder[IO](OpenAI.fromEnv, "gpt-4o-mini").maxIterations(5).tools(weatherTool).build
     HttpClientCatsBackend.resource[IO]().use { backend =>
       agent.run("What's the weather in London?")(backend)
-        .flatMap(r => IO.println(s"Answer: ${r.finalAnswer}"))
+        .flatMap { r =>
+          r.finalAnswer match {
+            case Right(answer) => IO.println(s"Answer: $answer")
+            case Left(failure) => IO.println(s"Agent did not finish cleanly: $failure")
+          }
+        }
     }
 ```
 
@@ -98,7 +103,10 @@ object ZIOExample extends ZIOAppDefault:
       for {
         backend <- HttpClientZioBackend.scoped()
         result <- agent.run("What's the weather in London?")(backend)
-        _ <- Console.printLine(s"Answer: ${result.finalAnswer}")
+        _ <- result.finalAnswer match {
+          case Right(answer) => Console.printLine(s"Answer: $answer")
+          case Left(failure) => Console.printLine(s"Agent did not finish cleanly: $failure")
+        }
       } yield ()
     }
 ```

--- a/docs/agents/mcp.md
+++ b/docs/agents/mcp.md
@@ -44,7 +44,10 @@ try
     .build
 
   val result = agent.run("Add 2 and 3 using the available tools")(backend)
-  println(result.finalAnswer)
+  result.finalAnswer match {
+    case Right(answer) => println(s"Answer: $answer")
+    case Left(failure) => println(s"Agent did not finish cleanly: $failure")
+  }
 finally
   backend.close()
   client.close()
@@ -81,7 +84,10 @@ try
     .build
 
   val result = agent.run("Add 2 and 3 using the available tools")(claudeBackend)
-  println(result.finalAnswer)
+  result.finalAnswer match {
+    case Right(answer) => println(s"Answer: $answer")
+    case Left(failure) => println(s"Agent did not finish cleanly: $failure")
+  }
 finally
   claudeBackend.close()
   claudeClient.close()

--- a/docs/agents/quickstart.md
+++ b/docs/agents/quickstart.md
@@ -43,7 +43,10 @@ object BasicExample extends App {
 
     val result = agent.run("What's the weather in Paris?")(backend)
 
-    println(s"Answer: ${result.finalAnswer}")
+    result.finalAnswer match {
+      case Right(answer) => println(s"Answer: $answer")
+      case Left(failure) => println(s"Agent did not finish cleanly: $failure")
+    }
     println(s"Iterations: ${result.iterations}")
   } finally backend.close()
 }

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -56,7 +56,7 @@ class CalculatorAgentSpec extends AnyFlatSpec with Matchers with AgentMatchers {
     result should haveCalledTool("calculator")
     result should haveCalledToolWith("calculator", """{"a": 1, "b": 2}""")
     result should haveFinishedWith(FinishReason.NaturalStop)
-    result.finalAnswer shouldBe "The answer is 3"
+    result.finalAnswer shouldBe Right("The answer is 3")
 
     // assert on what was sent to the "model"
     script should haveReceivedPrompt("What is 1 + 2?")

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -46,11 +46,14 @@ case class AgentResult[T](
 )
 ```
 
-`agent.run(prompt)(backend)` returns `AgentResult[String]`. For typed results, see `runAs[T]` below.
+`agent.run(prompt)(backend)` returns `AgentResult[Either[AgentFailure, String]]` by default. See below for typed input and output.
 
-## Typed responses with `runAs[T]`
+## Typed input and output
 
-Set `responseSchema` on `AgentConfig` and use `runAs[T]` to receive a parsed Scala value as the agent's final answer. The response schema, derived from `T`, is sent to the model to define the structured output of the agent's final answer. The answer is then parsed back into `T` via circe.
+A fresh builder starts at `Agent[F, String, String]`: plain-text prompt in, plain-text answer out. `deriveResponseSchema[T]`
+transitions the builder's `Out` type to `T`, so the built agent's `run` returns `AgentResult[Either[AgentFailure, T]]`
+instead. The response schema, derived from `T`, is sent to the model to define the structured output of the agent's
+final answer; the answer is then parsed back into `T` via circe.
 
 On failure the iteration trace is preserved: `finalAnswer` is a `Left(AgentFailure)` rather than a thrown exception. There are two failure cases:
 
@@ -84,7 +87,7 @@ object TypedAgentExample extends App {
       .tools(weatherTool)
       .deriveResponseSchema[TripSummary]
       .build
-    agent.runAs[TripSummary]("What's the weather in Paris?")(backend).finalAnswer match {
+    agent.run("What's the weather in Paris?")(backend).finalAnswer match {
       case Right(summary)                              => println(s"Weather: ${summary.weather}")
       case Left(AgentParseError(raw, cause))           => println(s"Parse failed: ${cause.getMessage}; raw=$raw")
       case Left(AgentIncomplete(raw, finishReason, _)) => println(s"Run incomplete ($finishReason); raw=$raw")
@@ -93,4 +96,46 @@ object TypedAgentExample extends App {
 }
 ```
 
-The same `runAs[T]` works against `ClaudeAgent.synchronous(...)`.
+The same `deriveResponseSchema[T]` works with `ClaudeAgent.synchronous(...)`.
+
+Input can be typed the same way. `input[In]` transitions the builder's `In` type, rendering the value into the first
+user message as compact JSON (via its circe `Encoder`) wrapped in a small fixed envelope; `inputRenderer[In]` takes
+an explicit `In => String` function when you want control over how the value is rendered.
+
+## Composing agents
+
+`andThen` chains two agents so the second starts a fresh conversation from the first's typed output: it only
+compiles when the first agent's `Out` matches the second's `In`, so a mismatched handoff is a compile error, not a
+runtime surprise.
+
+```scala mdoc:compile-only
+//> using dep com.softwaremill.sttp.ai::openai:@VERSION@
+
+import sttp.ai.openai.OpenAI
+import sttp.ai.openai.agent.OpenAIAgent
+import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
+import sttp.tapir.Schema
+
+val openai = OpenAI.fromEnv
+
+case class Location(city: String) derives io.circe.Codec.AsObject, Schema
+
+val planner = OpenAIAgent
+  .synchronous(openai, ChatCompletionModel.GPT4oMini)
+  .deriveResponseSchema[Location]
+  .build // Agent[Identity, String, Location]
+
+val guide = OpenAIAgent
+  .synchronous(openai, ChatCompletionModel.GPT4oMini)
+  .input[Location] // rendered into the first user message as JSON
+  .build // Agent[Identity, Location, String]
+
+val trip = planner.andThen(guide) // Agent[Identity, String, String] — compile-checked handoff
+```
+
+Each stage runs its own complete loop from scratch, seeded only with the previous stage's rendered output — no
+conversation history carries over. If a stage fails (`Left`), the chain short-circuits and later stages never run;
+on success, `iterations`, `toolCalls`, `usage`, and `llmCalls` aggregate across every stage that ran.
+
+When two agents are almost but not quite compatible, reach for `map` (adapt the output) or `contramap` (adapt the
+input) instead of rebuilding either agent.

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -135,7 +135,9 @@ val trip = planner.andThen(guide) // Agent[Identity, String, String] — compile
 
 Each stage runs its own complete loop from scratch, seeded only with the previous stage's rendered output — no
 conversation history carries over. If a stage fails (`Left`), the chain short-circuits and later stages never run;
-on success, `iterations`, `toolCalls`, `usage`, and `llmCalls` aggregate across every stage that ran.
+on success, `iterations`, `toolCalls`, `usage`, and `llmCalls` aggregate across every stage that ran. Interceptors
+are stage-local too: each agent keeps the interceptors it was built with, so a budget interceptor bounds its own
+stage's spend, not the whole chain's.
 
 When two agents are almost but not quite compatible, reach for `map` (adapt the output) or `contramap` (adapt the
 input) instead of rebuilding either agent.

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -42,7 +42,7 @@ case class AgentResult[T](
   finalAnswer: T,
   iterations: Int,
   toolCalls: Seq[ToolCallRecord],
-  finishReason: FinishReason  // MaxIterations | NaturalStop | TokenLimit | Error(message)
+  finishReason: FinishReason  // MaxIterations | NaturalStop | TokenLimit | ForcedStop (BudgetExceeded / Custom) | Error(message)
 )
 ```
 

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -58,9 +58,9 @@ final answer; the answer is then parsed back into `T` via circe.
 On failure the iteration trace is preserved: `finalAnswer` is a `Left(AgentFailure)` rather than a thrown exception. There are two failure cases:
 
 - `AgentParseError` - the loop stopped naturally but the answer couldn't be parsed as `T`.
-- `AgentIncomplete` - the loop was cut short (`FinishReason.MaxIterations` or `FinishReason.TokenLimit`). On `MaxIterations` a parse is still attempted (the final iteration forces a schema-guided answer without tools), and `parseError` carries the cause if it failed; on `TokenLimit` the answer is truncated, so no parse is attempted and `parseError` is `None`.
+- `AgentIncomplete` - the loop was cut short (`FinishReason.MaxIterations`, an interceptor-forced `FinishReason.ForcedStop` such as `BudgetExceeded`/`Custom`, or `FinishReason.TokenLimit`). On `MaxIterations` and on a forced stop, a parse is still attempted (the final iteration forces a schema-guided answer without tools), and `parseError` carries the cause if it failed; on `TokenLimit` the answer is truncated, so no parse is attempted and `parseError` is `None`.
 
-Note that because `MaxIterations` still parses, `finalAnswer` can be `Right(t)` even though the run hit the iteration cap - check `AgentResult.finishReason` if you need to distinguish a capped run from a natural stop.
+Note that because `MaxIterations` and forced stops still parse, `finalAnswer` can be `Right(t)` even though the run was capped or cut short by an interceptor — check `AgentResult.finishReason` if you need to distinguish that from a natural stop.
 
 ```scala mdoc:compile-only
 //> using dep com.softwaremill.sttp.ai::openai:@VERSION@

--- a/docs/gemini/tool-calling.md
+++ b/docs/gemini/tool-calling.md
@@ -168,7 +168,10 @@ object AgentExample:
 
       val result = agent.run("What's the weather in Paris?")(backend)
 
-      println(s"Answer: ${result.finalAnswer}")
+      result.finalAnswer match {
+        case Right(answer) => println(s"Answer: $answer")
+        case Left(failure) => println(s"Agent did not finish cleanly: $failure")
+      }
       println(s"Iterations: ${result.iterations}")
     } finally backend.close()
 ```

--- a/examples/src/main/scala/examples/TypedAgentLoopExample.scala
+++ b/examples/src/main/scala/examples/TypedAgentLoopExample.scala
@@ -44,16 +44,22 @@ object TypedAgentLoopExample extends App {
       .build
     val prompt = "What's the weather in Paris? Also, what is 15 multiplied by 23? Provide a complete answer."
 
-    agent.runAs[TripSummary](prompt)(backend).finalAnswer match {
-      case Right(summary) =>
-        println(s"weather:     ${summary.weatherSummary}")
-        println(s"calculation: ${summary.calculation}")
-        println(s"conclusion:  ${summary.conclusion}")
-      case Left(AgentParseError(rawAnswer, cause)) =>
-        println(s"Failed to parse structured answer: ${cause.getMessage}")
-        println(s"Raw answer was: $rawAnswer")
-      case Left(AgentIncomplete(rawAnswer, finishReason, _)) =>
-        println(s"Agent did not finish cleanly ($finishReason), raw answer was: $rawAnswer")
-    }
+    val result = agent.run(prompt)(backend)
+    println(s"Result: ${result.finalAnswer}")
+    println(s"Finish reason: ${result.finishReason}")
+
+    // TODO after 0.9.0 release: switch to the typed run result, e.g.:
+    // agent.run(prompt)(backend).finalAnswer match {
+    //   case Right(summary) =>
+    //     println(s"weather:     ${summary.weatherSummary}")
+    //     println(s"calculation: ${summary.calculation}")
+    //     println(s"conclusion:  ${summary.conclusion}")
+    //   case Left(AgentParseError(rawAnswer, cause)) =>
+    //     println(s"Failed to parse structured answer: ${cause.getMessage}")
+    //     println(s"Raw answer was: $rawAnswer")
+    //   case Left(AgentIncomplete(rawAnswer, finishReason, _)) =>
+    //     println(s"Agent did not finish cleanly ($finishReason), raw answer was: $rawAnswer")
+    // }
+    // Also bump the `//> using dep com.softwaremill.sttp.ai::openai:...` directive at the top of this file to 0.9.0+.
   } finally backend.close()
 }

--- a/gemini/src/main/scala/sttp/ai/gemini/agent/GeminiAgent.scala
+++ b/gemini/src/main/scala/sttp/ai/gemini/agent/GeminiAgent.scala
@@ -158,7 +158,9 @@ object GeminiAgent {
 
   final class BuilderPartiallyApplied[F[_]] private[GeminiAgent] () {
 
-    def apply[M <: GeminiModel](client: GeminiClient, model: M)(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, M] =
+    def apply[M <: GeminiModel](client: GeminiClient, model: M)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M, String, String] =
       apply(client, (_: IterationInfo) => model)
 
     /** Selects the model per loop iteration (e.g. a cheap model for tool iterations, a stronger one for the forced-final synthesis). `M`
@@ -166,45 +168,53 @@ object GeminiAgent {
       */
     def apply[M <: GeminiModel](client: GeminiClient, modelForIteration: IterationInfo => M)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, M] =
+    ): AgentBuilder[F, M, String, String] =
       AgentBuilder[F, M](config =>
         new GeminiAgentBackend[F](client, modelForIteration, config.userTools, config.systemPrompt, config.responseSchema)
       )
 
     def apply(client: GeminiClient, modelName: String)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, GeminiModel.CustomModel] =
+    ): AgentBuilder[F, GeminiModel.CustomModel, String, String] =
       apply(client, GeminiModel.CustomModel(modelName))
 
-    def apply[M <: GeminiModel](geminiConfig: GeminiConfig, model: M)(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, M] =
+    def apply[M <: GeminiModel](geminiConfig: GeminiConfig, model: M)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M, String, String] =
       apply(GeminiClient(geminiConfig), model)
 
     def apply[M <: GeminiModel](geminiConfig: GeminiConfig, modelForIteration: IterationInfo => M)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, M] =
+    ): AgentBuilder[F, M, String, String] =
       apply(GeminiClient(geminiConfig), modelForIteration)
 
     def apply(geminiConfig: GeminiConfig, modelName: String)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, GeminiModel.CustomModel] =
+    ): AgentBuilder[F, GeminiModel.CustomModel, String, String] =
       apply(GeminiClient(geminiConfig), modelName)
   }
 
-  def synchronous[M <: GeminiModel](client: GeminiClient, model: M): AgentBuilder[Identity, M] =
+  def synchronous[M <: GeminiModel](client: GeminiClient, model: M): AgentBuilder[Identity, M, String, String] =
     builder[Identity](client, model)(IdentityMonad)
 
-  def synchronous[M <: GeminiModel](client: GeminiClient, modelForIteration: IterationInfo => M): AgentBuilder[Identity, M] =
+  def synchronous[M <: GeminiModel](
+      client: GeminiClient,
+      modelForIteration: IterationInfo => M
+  ): AgentBuilder[Identity, M, String, String] =
     builder[Identity](client, modelForIteration)(IdentityMonad)
 
-  def synchronous(client: GeminiClient, modelName: String): AgentBuilder[Identity, GeminiModel.CustomModel] =
+  def synchronous(client: GeminiClient, modelName: String): AgentBuilder[Identity, GeminiModel.CustomModel, String, String] =
     builder[Identity](client, modelName)(IdentityMonad)
 
-  def synchronous[M <: GeminiModel](geminiConfig: GeminiConfig, model: M): AgentBuilder[Identity, M] =
+  def synchronous[M <: GeminiModel](geminiConfig: GeminiConfig, model: M): AgentBuilder[Identity, M, String, String] =
     builder[Identity](geminiConfig, model)(IdentityMonad)
 
-  def synchronous[M <: GeminiModel](geminiConfig: GeminiConfig, modelForIteration: IterationInfo => M): AgentBuilder[Identity, M] =
+  def synchronous[M <: GeminiModel](
+      geminiConfig: GeminiConfig,
+      modelForIteration: IterationInfo => M
+  ): AgentBuilder[Identity, M, String, String] =
     builder[Identity](geminiConfig, modelForIteration)(IdentityMonad)
 
-  def synchronous(geminiConfig: GeminiConfig, modelName: String): AgentBuilder[Identity, GeminiModel.CustomModel] =
+  def synchronous(geminiConfig: GeminiConfig, modelName: String): AgentBuilder[Identity, GeminiModel.CustomModel, String, String] =
     builder[Identity](geminiConfig, modelName)(IdentityMonad)
 }

--- a/gemini/src/test/scala/sttp/ai/gemini/integration/GeminiAgentIntegrationSpec.scala
+++ b/gemini/src/test/scala/sttp/ai/gemini/integration/GeminiAgentIntegrationSpec.scala
@@ -14,7 +14,7 @@ class GeminiAgentIntegrationSpec extends AgentIntegrationSpecBase {
   override def providerName: String = "Gemini"
   override def apiKeyEnvVar: String = "GEMINI_API_KEY"
 
-  override def createAgent(maxIterations: Int, tools: Seq[AgentTool[Identity, _]]): Agent[Identity] = {
+  override def createAgent(maxIterations: Int, tools: Seq[AgentTool[Identity, _]]): Agent[Identity, String, String] = {
     val config = GeminiConfig.fromEnv
     val client = GeminiClient(config)
     val agentConfig = AgentConfig[Identity](maxIterations = maxIterations, userTools = tools)
@@ -32,7 +32,7 @@ class GeminiAgentIntegrationSpec extends AgentIntegrationSpecBase {
       maxIterations: Int,
       tools: Seq[AgentTool[Identity, _]],
       responseSchema: ResponseSchema[T]
-  ): Agent[Identity] =
+  ): Agent[Identity, String, T] =
     GeminiAgent
       .synchronous(GeminiConfig.fromEnv, GeminiModel.Gemini35FlashLite)
       .maxIterations(maxIterations)

--- a/mcp/src/test/scala/sttp/ai/core/agent/mcp/integration/McpAgentIntegrationSpec.scala
+++ b/mcp/src/test/scala/sttp/ai/core/agent/mcp/integration/McpAgentIntegrationSpec.scala
@@ -12,7 +12,7 @@ import ox.supervised
 import sttp.ai.claude.agent.ClaudeAgent
 import sttp.ai.claude.config.ClaudeConfig
 import sttp.ai.core.agent.mcp.McpTools
-import sttp.ai.core.agent.{AgentBuilder, AgentResult, AgentTool}
+import sttp.ai.core.agent.{AgentBuilder, AgentFailure, AgentResult, AgentTool}
 import sttp.ai.core.model.AIModel
 import sttp.ai.openai.OpenAI
 import sttp.ai.openai.agent.OpenAIAgent
@@ -34,8 +34,8 @@ class McpAgentIntegrationSpec extends AnyFlatSpec with Matchers {
   case class Location(lat: Double, lng: Double) derives Codec, Schema
   case class CreateEventInput(title: String, location: Option[Location], priority: Option[String]) derives Codec, Schema
 
-  private def withMcpAgentRun[M <: AIModel](builderFor: Seq[AgentTool[Identity, ?]] => AgentBuilder[Identity, M])(
-      check: AgentResult[String] => Assertion
+  private def withMcpAgentRun[M <: AIModel](builderFor: Seq[AgentTool[Identity, ?]] => AgentBuilder[Identity, M, String, String])(
+      check: AgentResult[Either[AgentFailure, String]] => Assertion
   ): Assertion =
     supervised {
       val createEvent = tool("create-event")
@@ -65,7 +65,7 @@ class McpAgentIntegrationSpec extends AnyFlatSpec with Matchers {
       } finally binding.stop()
     }
 
-  private def assertToolExecuted(result: AgentResult[String]): Assertion = {
+  private def assertToolExecuted(result: AgentResult[Either[AgentFailure, String]]): Assertion = {
     result.toolCalls.map(_.toolName) should contain("create-event")
     val output = result.toolCalls.filter(_.toolName == "create-event").map(_.output).mkString("\n")
     output should include("Standup")

--- a/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
+++ b/openai/src/main/scala/sttp/ai/openai/agent/OpenAIAgent.scala
@@ -153,12 +153,14 @@ object OpenAIAgent {
 
   final class BuilderPartiallyApplied[F[_]] private[OpenAIAgent] () {
 
-    def apply[M <: ChatCompletionModel](openAI: OpenAI, model: M)(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, M] =
+    def apply[M <: ChatCompletionModel](openAI: OpenAI, model: M)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M, String, String] =
       apply(openAI, model, strictTools = true)
 
     def apply[M <: ChatCompletionModel](openAI: OpenAI, model: M, strictTools: Boolean)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, M] =
+    ): AgentBuilder[F, M, String, String] =
       apply(openAI, (_: IterationInfo) => model, strictTools)
 
     /** Selects the model per loop iteration (e.g. a cheap model for tool iterations, a stronger one for the forced-final synthesis). `M`
@@ -166,104 +168,118 @@ object OpenAIAgent {
       */
     def apply[M <: ChatCompletionModel](openAI: OpenAI, modelForIteration: IterationInfo => M)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, M] =
+    ): AgentBuilder[F, M, String, String] =
       apply(openAI, modelForIteration, strictTools = true)
 
     def apply[M <: ChatCompletionModel](openAI: OpenAI, modelForIteration: IterationInfo => M, strictTools: Boolean)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, M] =
+    ): AgentBuilder[F, M, String, String] =
       AgentBuilder[F, M](config =>
         new OpenAIAgentBackend[F](openAI, modelForIteration, config.userTools, config.systemPrompt, config.responseSchema, strictTools)
       )
 
     def apply(openAI: OpenAI, modelName: String)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
+    ): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel, String, String] =
       apply(openAI, ChatCompletionModel.CustomChatCompletionModel(modelName))
 
     def apply(openAI: OpenAI, modelName: String, strictTools: Boolean)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
+    ): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel, String, String] =
       apply(openAI, ChatCompletionModel.CustomChatCompletionModel(modelName), strictTools)
 
     def apply(apiKey: String, modelName: String)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
+    ): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel, String, String] =
       apply(new OpenAI(apiKey), modelName)
 
     def apply(apiKey: String, modelName: String, strictTools: Boolean)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel] =
+    ): AgentBuilder[F, ChatCompletionModel.CustomChatCompletionModel, String, String] =
       apply(new OpenAI(apiKey), modelName, strictTools)
 
-    def apply[M <: ChatCompletionModel](apiKey: String, model: M)(implicit monad: sttp.monad.MonadError[F]): AgentBuilder[F, M] =
+    def apply[M <: ChatCompletionModel](apiKey: String, model: M)(implicit
+        monad: sttp.monad.MonadError[F]
+    ): AgentBuilder[F, M, String, String] =
       apply(new OpenAI(apiKey), model)
 
     def apply[M <: ChatCompletionModel](apiKey: String, model: M, strictTools: Boolean)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, M] =
+    ): AgentBuilder[F, M, String, String] =
       apply(new OpenAI(apiKey), model, strictTools)
 
     def apply[M <: ChatCompletionModel](apiKey: String, modelForIteration: IterationInfo => M)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, M] =
+    ): AgentBuilder[F, M, String, String] =
       apply(new OpenAI(apiKey), modelForIteration)
 
     def apply[M <: ChatCompletionModel](apiKey: String, modelForIteration: IterationInfo => M, strictTools: Boolean)(implicit
         monad: sttp.monad.MonadError[F]
-    ): AgentBuilder[F, M] =
+    ): AgentBuilder[F, M, String, String] =
       apply(new OpenAI(apiKey), modelForIteration, strictTools)
   }
 
-  def synchronous[M <: ChatCompletionModel](openAI: OpenAI, model: M): AgentBuilder[Identity, M] =
+  def synchronous[M <: ChatCompletionModel](openAI: OpenAI, model: M): AgentBuilder[Identity, M, String, String] =
     builder[Identity](openAI, model)(IdentityMonad)
 
-  def synchronous[M <: ChatCompletionModel](openAI: OpenAI, model: M, strictTools: Boolean): AgentBuilder[Identity, M] =
+  def synchronous[M <: ChatCompletionModel](openAI: OpenAI, model: M, strictTools: Boolean): AgentBuilder[Identity, M, String, String] =
     builder[Identity](openAI, model, strictTools)(IdentityMonad)
 
-  def synchronous[M <: ChatCompletionModel](openAI: OpenAI, modelForIteration: IterationInfo => M): AgentBuilder[Identity, M] =
+  def synchronous[M <: ChatCompletionModel](
+      openAI: OpenAI,
+      modelForIteration: IterationInfo => M
+  ): AgentBuilder[Identity, M, String, String] =
     builder[Identity](openAI, modelForIteration)(IdentityMonad)
 
   def synchronous[M <: ChatCompletionModel](
       openAI: OpenAI,
       modelForIteration: IterationInfo => M,
       strictTools: Boolean
-  ): AgentBuilder[Identity, M] =
+  ): AgentBuilder[Identity, M, String, String] =
     builder[Identity](openAI, modelForIteration, strictTools)(IdentityMonad)
 
-  def synchronous(openAI: OpenAI, modelName: String): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel] =
+  def synchronous(
+      openAI: OpenAI,
+      modelName: String
+  ): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel, String, String] =
     builder[Identity](openAI, modelName)(IdentityMonad)
 
   def synchronous(
       openAI: OpenAI,
       modelName: String,
       strictTools: Boolean
-  ): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel] =
+  ): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel, String, String] =
     builder[Identity](openAI, modelName, strictTools)(IdentityMonad)
 
-  def synchronous(apiKey: String, modelName: String): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel] =
+  def synchronous(
+      apiKey: String,
+      modelName: String
+  ): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel, String, String] =
     builder[Identity](apiKey, modelName)(IdentityMonad)
 
   def synchronous(
       apiKey: String,
       modelName: String,
       strictTools: Boolean
-  ): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel] =
+  ): AgentBuilder[Identity, ChatCompletionModel.CustomChatCompletionModel, String, String] =
     builder[Identity](apiKey, modelName, strictTools)(IdentityMonad)
 
-  def synchronous[M <: ChatCompletionModel](apiKey: String, model: M): AgentBuilder[Identity, M] =
+  def synchronous[M <: ChatCompletionModel](apiKey: String, model: M): AgentBuilder[Identity, M, String, String] =
     builder[Identity](apiKey, model)(IdentityMonad)
 
-  def synchronous[M <: ChatCompletionModel](apiKey: String, model: M, strictTools: Boolean): AgentBuilder[Identity, M] =
+  def synchronous[M <: ChatCompletionModel](apiKey: String, model: M, strictTools: Boolean): AgentBuilder[Identity, M, String, String] =
     builder[Identity](apiKey, model, strictTools)(IdentityMonad)
 
-  def synchronous[M <: ChatCompletionModel](apiKey: String, modelForIteration: IterationInfo => M): AgentBuilder[Identity, M] =
+  def synchronous[M <: ChatCompletionModel](
+      apiKey: String,
+      modelForIteration: IterationInfo => M
+  ): AgentBuilder[Identity, M, String, String] =
     builder[Identity](apiKey, modelForIteration)(IdentityMonad)
 
   def synchronous[M <: ChatCompletionModel](
       apiKey: String,
       modelForIteration: IterationInfo => M,
       strictTools: Boolean
-  ): AgentBuilder[Identity, M] =
+  ): AgentBuilder[Identity, M, String, String] =
     builder[Identity](apiKey, modelForIteration, strictTools)(IdentityMonad)
 }

--- a/openai/src/test/scala/sttp/ai/openai/integration/OpenAIAgentIntegrationSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/integration/OpenAIAgentIntegrationSpec.scala
@@ -1,12 +1,16 @@
 package sttp.ai.openai.integration
 
+import io.circe.Codec
+import io.circe.generic.semiauto.deriveCodec
 import sttp.ai.core.agent.integration.AgentIntegrationSpecBase
 import sttp.ai.core.agent._
 import sttp.ai.openai.OpenAI
 import sttp.ai.openai.agent._
 import sttp.ai.openai.requests.completions.chat.ChatRequestBody.ChatCompletionModel
+import sttp.client4.DefaultSyncBackend
 import sttp.monad.IdentityMonad
 import sttp.shared.Identity
+import sttp.tapir.Schema
 
 class OpenAIAgentIntegrationSpec extends AgentIntegrationSpecBase {
 
@@ -39,5 +43,37 @@ class OpenAIAgentIntegrationSpec extends AgentIntegrationSpecBase {
       .tools(tools)
       .responseSchema(responseSchema)
       .build
+  }
+
+  case class CityReport(city: String, temperatureSummary: String)
+  object CityReport {
+    implicit val codec: Codec[CityReport] = deriveCodec
+    implicit val schema: Schema[CityReport] = Schema.derived
+  }
+
+  it should "hand off a typed result between two composed agents" in {
+    if (maybeApiKey.isEmpty) cancel(s"$apiKeyEnvVar not defined - skipping integration test")
+    val backend = DefaultSyncBackend()
+    try {
+      val openai = OpenAI.fromEnv
+      val reporter = OpenAIAgent
+        .synchronous(openai, "gpt-4o-mini")
+        .maxIterations(3)
+        .tools(weatherTool)
+        .deriveResponseSchema[CityReport]
+        .build
+      val summarizer = OpenAIAgent
+        .synchronous(openai, "gpt-4o-mini")
+        .maxIterations(2)
+        .inputRenderer[CityReport](r => s"In five words or fewer, restate: ${r.temperatureSummary}")
+        .build
+
+      val result = reporter
+        .andThen(summarizer)
+        .run("What's the weather in Paris? Reply with the city and a temperature summary.")(backend)
+
+      result.finalAnswer.isRight shouldBe true: Unit
+      result.llmCalls.size should be >= 2
+    } finally backend.close()
   }
 }

--- a/openai/src/test/scala/sttp/ai/openai/integration/OpenAIAgentIntegrationSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/integration/OpenAIAgentIntegrationSpec.scala
@@ -13,7 +13,7 @@ class OpenAIAgentIntegrationSpec extends AgentIntegrationSpecBase {
   override def providerName: String = "OpenAI"
   override def apiKeyEnvVar: String = "OPENAI_API_KEY"
 
-  override def createAgent(maxIterations: Int, tools: Seq[AgentTool[Identity, _]]): Agent[Identity] = {
+  override def createAgent(maxIterations: Int, tools: Seq[AgentTool[Identity, _]]): Agent[Identity, String, String] = {
     val openai = OpenAI.fromEnv
     val agentConfig = AgentConfig[Identity](maxIterations = maxIterations, userTools = tools)
     val agentBackend = new OpenAIAgentBackend[Identity](
@@ -31,7 +31,7 @@ class OpenAIAgentIntegrationSpec extends AgentIntegrationSpecBase {
       maxIterations: Int,
       tools: Seq[AgentTool[Identity, _]],
       responseSchema: ResponseSchema[T]
-  ): Agent[Identity] = {
+  ): Agent[Identity, String, T] = {
     val openai = OpenAI.fromEnv
     OpenAIAgent
       .synchronous(openai, "gpt-4o-mini")

--- a/openai/src/test/scala/sttp/ai/openai/integration/OpenAIAgentIntegrationSpec.scala
+++ b/openai/src/test/scala/sttp/ai/openai/integration/OpenAIAgentIntegrationSpec.scala
@@ -72,7 +72,7 @@ class OpenAIAgentIntegrationSpec extends AgentIntegrationSpecBase {
         .andThen(summarizer)
         .run("What's the weather in Paris? Reply with the city and a temperature summary.")(backend)
 
-      result.finalAnswer.isRight shouldBe true: Unit
+      result.finalAnswer.fold(f => fail(s"handoff failed: $f"), _ => succeed): Unit
       result.llmCalls.size should be >= 2
     } finally backend.close()
   }


### PR DESCRIPTION
## What

Replaces the stringly-typed `Agent[F]` with `Agent[F, In, Out]`:

- **Typed output.** `deriveResponseSchema[T]` / `responseSchema[T]` now fix the agent's output type at build time, and `run` returns `F[AgentResult[Either[AgentFailure, Out]]]`. The old schema-`A`-vs-`runAs[B]` mismatch is unrepresentable; `runAs` is removed.
- **Typed input.** `input[In]` renders the input as JSON into the initial user message via its circe `Encoder` (fixed envelope); `inputRenderer[In](render: In => String)` gives explicit control.
- **Composition.** `a.andThen(b)` compiles only when A's `Out` is B's `In` (compile-time-checked handoffs — vs. Embabel's runtime type matching). `map`/`contramap` adapt almost-matching types.
- Providers (OpenAI/Claude/Gemini), `agent-testkit`, MCP tests, and all mdoc docs migrated. New cost-minimal OpenAI integration test does a real two-agent handoff.

## Key design decisions

- **Fresh conversation per handoff.** In `a.andThen(b)`, agent B starts a new conversation from A's typed `Out` value, rendered by B's own input renderer — no history carryover. The contract between agents is the type, not ambient chat state: predictable token costs, no cross-agent prompt pollution, and B's system prompt/tools apply cleanly.
- **Metadata aggregation on composition.** When both stages run: `iterations` and `usage` are summed, `toolCalls`/`llmCalls` concatenated in stage order, `finishReason` taken from the last stage that ran. On a `Left` from stage A, B never runs and A's metadata is returned as-is. Interceptors (and budgets) stay stage-local. `ToolCallRecord.iteration` is stage-local (documented); a per-stage breakdown can come later if needed.

## ⚠️ Breaking changes (target 0.9.0)

- `Agent[F]` → `Agent[F, In, Out]` (trait); `AgentBuilder[F, M]` → `AgentBuilder[F, M, In, Out]`. A fresh builder is `AgentBuilder[F, M, String, String]`, so provider entry points are source-compatible at call sites.
- `runAs[T]` removed — build with `.deriveResponseSchema[T]` (usually already present) and call `run`.
- `run` result shape: `AgentResult[String]` → `AgentResult[Either[AgentFailure, Out]]`.
- Wildcard `responseSchema(schema: ResponseSchema[_])` removed in favor of the typed overload.
- **Runtime behavior change for untyped (string) agents:** a `TokenLimit`/`Error` finish now yields `Left(AgentIncomplete(rawAnswer, reason, parseError = None))` where 0.8.0 silently returned the truncated string. `MaxIterations` and interceptor-forced stops still parse-attempt (answer may be `Right` — check `finishReason`).

## Notes

- `examples/` are kept **dual-compatible**: they compile against the released 0.5.6 artifact (CI's scala-cli check) *and* the local new API (sbt build). `TypedAgentLoopExample`'s typed pattern-match demo is a commented TODO — swap in and bump `//> using dep` after 0.9.0 is published.
- `generated-docs/out` is regenerated by the release process; intentionally untouched.
- Verified: full cross-version compile (2.13.18 / 3.3.8), 1300 JVM tests green, `compileDocumentation`, scalafmt checks.